### PR TITLE
renovate: Set configuration options

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "automerge": true,
+  "automergeType": "pr",
+  "major": {
+    "automerge": false
+  }
 }


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Changes the `renovate.json` to always run `go mod tidy`, automerge all
PRs when status checks pass for all versions except a major version.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better renovate
