### PR TITLE
deploymentresource: Add support for EnterpriseSearch resource type

### DIFF
--- a/ec/acc/deployment_test.go
+++ b/ec/acc/deployment_test.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	deploymentVersion = "7.6.2"
-	region            = "us-east-1"
+	deploymentVersion          = "7.8.1"
+	deploymentVersionAppsearch = "7.6.2"
+	region                     = "us-east-1"
 )
 
 func TestAccDeployment_basic(t *testing.T) {
@@ -83,7 +84,7 @@ func TestAccDeployment_basic(t *testing.T) {
 func TestAccDeployment_appsearch(t *testing.T) {
 	resName := "ec_deployment.appsearch"
 	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	cfg := testAccDeploymentResourceAppsearch(t, randomName, region, deploymentVersion)
+	cfg := testAccDeploymentResourceAppsearch(t, randomName, region, deploymentVersionAppsearch)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -97,11 +98,57 @@ func TestAccDeployment_appsearch(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "name", randomName),
 					resource.TestCheckResourceAttr(resName, "region", region),
 					resource.TestCheckResourceAttr(resName, "appsearch.#", "1"),
-					resource.TestCheckResourceAttr(resName, "appsearch.0.version", deploymentVersion),
+					resource.TestCheckResourceAttr(resName, "appsearch.0.version", deploymentVersionAppsearch),
 					resource.TestCheckResourceAttr(resName, "appsearch.0.region", region),
 					resource.TestCheckResourceAttr(resName, "appsearch.0.topology.0.memory_per_node", "2g"),
 					resource.TestCheckResourceAttrSet(resName, "appsearch.0.http_endpoint"),
 					resource.TestCheckResourceAttrSet(resName, "appsearch.0.https_endpoint"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.version", deploymentVersionAppsearch),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.region", region),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.memory_per_node", "1g"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.http_endpoint"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.https_endpoint"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "1"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.version", deploymentVersionAppsearch),
+					resource.TestCheckResourceAttr(resName, "kibana.0.region", region),
+					resource.TestCheckResourceAttr(resName, "kibana.0.topology.0.memory_per_node", "1g"),
+					resource.TestCheckResourceAttrSet(resName, "kibana.0.http_endpoint"),
+					resource.TestCheckResourceAttrSet(resName, "kibana.0.https_endpoint"),
+				),
+			},
+			// Ensure that no diff is generated.
+			{
+				Config:   cfg,
+				PlanOnly: true,
+			},
+			// TODO: Import case when import is ready.
+		},
+	})
+}
+
+func TestAccDeployment_enterpriseSearch(t *testing.T) {
+	resName := "ec_deployment.enterprise_search"
+	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	cfg := testAccDeploymentResourceEnterpriseSearch(t, randomName, region, deploymentVersion)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDeploymentExists(resName),
+					resource.TestCheckResourceAttr(resName, "name", randomName),
+					resource.TestCheckResourceAttr(resName, "region", region),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "1"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.0.version", deploymentVersion),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.0.region", region),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.0.topology.0.memory_per_node", "2g"),
+					resource.TestCheckResourceAttrSet(resName, "enterprise_search.0.http_endpoint"),
+					resource.TestCheckResourceAttrSet(resName, "enterprise_search.0.https_endpoint"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.version", deploymentVersion),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.region", region),
@@ -138,6 +185,16 @@ func testAccDeploymentResourceBasic(t *testing.T, name, region, version string) 
 
 func testAccDeploymentResourceAppsearch(t *testing.T, name, region, version string) string {
 	b, err := ioutil.ReadFile("testdata/deployment_appsearch.tf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf(string(b),
+		name, region, version,
+	)
+}
+
+func testAccDeploymentResourceEnterpriseSearch(t *testing.T, name, region, version string) string {
+	b, err := ioutil.ReadFile("testdata/deployment_enterprise_search.tf")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/testdata/deployment_enterprise_search.tf
+++ b/ec/acc/testdata/deployment_enterprise_search.tf
@@ -1,0 +1,27 @@
+resource "ec_deployment" "enterprise_search" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = "%s"
+  
+  # TODO: Make this template ID dependent on the region.
+  deployment_template_id = "aws-enterprise-search-dedicated-v2"
+
+  elasticsearch {
+    topology {
+      instance_configuration_id = "aws.data.highcpu.m5d"
+      memory_per_node = "1g"
+    }
+  }
+
+  kibana {
+    topology {
+      instance_configuration_id = "aws.kibana.r5d"
+    }
+  }
+
+  enterprise_search {
+    topology {
+      instance_configuration_id = "aws.enterprisesearch.m5d"
+    }
+  }
+}

--- a/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_expanders.go
+++ b/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_expanders.go
@@ -1,0 +1,132 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package enterprisesearchstate
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/deploymentstate"
+)
+
+// ExpandResources expands appsearch resources into their models.
+func ExpandResources(apss []interface{}) ([]*models.EnterpriseSearchPayload, error) {
+	if len(apss) == 0 {
+		return nil, nil
+	}
+
+	result := make([]*models.EnterpriseSearchPayload, 0, len(apss))
+	for _, raw := range apss {
+		resResource, err := expandResource(raw)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, resResource)
+	}
+
+	return result, nil
+}
+
+func expandResource(raw interface{}) (*models.EnterpriseSearchPayload, error) {
+	var es = raw.(map[string]interface{})
+	var res = models.EnterpriseSearchPayload{
+		Plan: &models.EnterpriseSearchPlan{
+			EnterpriseSearch: &models.EnterpriseSearchConfiguration{},
+		},
+		Settings: &models.EnterpriseSearchSettings{},
+	}
+
+	if esRefID, ok := es["elasticsearch_cluster_ref_id"]; ok {
+		res.ElasticsearchClusterRefID = ec.String(esRefID.(string))
+	}
+
+	if name, ok := es["display_name"]; ok {
+		res.DisplayName = name.(string)
+	}
+
+	if refID, ok := es["ref_id"]; ok {
+		res.RefID = ec.String(refID.(string))
+	}
+
+	if version, ok := es["version"]; ok {
+		res.Plan.EnterpriseSearch.Version = version.(string)
+	}
+
+	if region, ok := es["region"]; ok {
+		if r := region.(string); r != "" {
+			res.Region = ec.String(r)
+		}
+	}
+
+	if rawTopology, ok := es["topology"]; ok {
+		topology, err := expandTopology(rawTopology)
+		if err != nil {
+			return nil, err
+		}
+		res.Plan.ClusterTopology = topology
+	}
+
+	return &res, nil
+}
+
+func expandTopology(raw interface{}) ([]*models.EnterpriseSearchTopologyElement, error) {
+	var rawTopologies = raw.([]interface{})
+	var res = make([]*models.EnterpriseSearchTopologyElement, 0, len(rawTopologies))
+	for _, rawTop := range rawTopologies {
+		var topology = rawTop.(map[string]interface{})
+		var nodeType = parseNodeType(topology)
+
+		size, err := deploymentstate.ParseTopologySize(topology)
+		if err != nil {
+			return nil, err
+		}
+
+		var elem = models.EnterpriseSearchTopologyElement{
+			Size:     &size,
+			NodeType: &nodeType,
+		}
+
+		if id, ok := topology["instance_configuration_id"]; ok {
+			elem.InstanceConfigurationID = id.(string)
+		}
+
+		if zones, ok := topology["zone_count"]; ok {
+			elem.ZoneCount = int32(zones.(int))
+		}
+
+		res = append(res, &elem)
+	}
+
+	return res, nil
+}
+
+func parseNodeType(topology map[string]interface{}) models.EnterpriseSearchNodeTypes {
+	var result models.EnterpriseSearchNodeTypes
+	if val, ok := topology["node_type_appserver"]; ok {
+		result.Appserver = ec.Bool(val.(bool))
+	}
+
+	if val, ok := topology["node_type_connector"]; ok {
+		result.Connector = ec.Bool(val.(bool))
+	}
+
+	if val, ok := topology["node_type_worker"]; ok {
+		result.Worker = ec.Bool(val.(bool))
+	}
+
+	return result
+}

--- a/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_expanders_test.go
+++ b/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_expanders_test.go
@@ -1,0 +1,149 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package enterprisesearchstate
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandResources(t *testing.T) {
+	type args struct {
+		ess []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*models.EnterpriseSearchPayload
+		err  error
+	}{
+		{
+			name: "returns nil when there's no resources",
+		},
+		{
+			name: "parses multiple resources",
+			args: args{
+				ess: []interface{}{
+					map[string]interface{}{
+						"ref_id":                       "main-enterprise_search",
+						"resource_id":                  mock.ValidClusterID,
+						"version":                      "7.7.0",
+						"region":                       "some-region",
+						"elasticsearch_cluster_ref_id": "somerefid",
+						"topology": []interface{}{
+							map[string]interface{}{
+								"instance_configuration_id": "aws.enterprisesearch.m5",
+								"memory_per_node":           "2g",
+								"zone_count":                1,
+								"node_type_appserver":       true,
+								"node_type_connector":       true,
+								"node_type_worker":          false,
+							},
+						},
+					},
+					map[string]interface{}{
+						"display_name":                 "somename",
+						"ref_id":                       "secondary-enterprise_search",
+						"elasticsearch_cluster_ref_id": "somerefid",
+						"resource_id":                  mock.ValidClusterID,
+						"version":                      "7.6.0",
+						"region":                       "some-region",
+						"topology": []interface{}{
+							map[string]interface{}{
+								"instance_configuration_id": "aws.enterprisesearch.m5",
+								"memory_per_node":           "4g",
+								"zone_count":                1,
+								"node_type_appserver":       false,
+								"node_type_connector":       true,
+								"node_type_worker":          true,
+							}},
+					},
+				},
+			},
+			want: []*models.EnterpriseSearchPayload{
+				{
+					ElasticsearchClusterRefID: ec.String("somerefid"),
+					Region:                    ec.String("some-region"),
+					RefID:                     ec.String("main-enterprise_search"),
+					Settings:                  &models.EnterpriseSearchSettings{},
+					Plan: &models.EnterpriseSearchPlan{
+						EnterpriseSearch: &models.EnterpriseSearchConfiguration{
+							Version: "7.7.0",
+						},
+						ClusterTopology: []*models.EnterpriseSearchTopologyElement{
+							{
+								ZoneCount:               1,
+								InstanceConfigurationID: "aws.enterprisesearch.m5",
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(2048),
+								},
+								NodeType: &models.EnterpriseSearchNodeTypes{
+									Appserver: ec.Bool(true),
+									Connector: ec.Bool(true),
+									Worker:    ec.Bool(false),
+								},
+							},
+						},
+					},
+				},
+				{
+					ElasticsearchClusterRefID: ec.String("somerefid"),
+					DisplayName:               "somename",
+					Region:                    ec.String("some-region"),
+					RefID:                     ec.String("secondary-enterprise_search"),
+					Settings:                  &models.EnterpriseSearchSettings{},
+					Plan: &models.EnterpriseSearchPlan{
+						EnterpriseSearch: &models.EnterpriseSearchConfiguration{
+							Version: "7.6.0",
+						},
+						ClusterTopology: []*models.EnterpriseSearchTopologyElement{
+							{
+								ZoneCount:               1,
+								InstanceConfigurationID: "aws.enterprisesearch.m5",
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(4096),
+								},
+								NodeType: &models.EnterpriseSearchNodeTypes{
+									Appserver: ec.Bool(false),
+									Connector: ec.Bool(true),
+									Worker:    ec.Bool(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpandResources(tt.args.ess)
+			if tt.err != nil {
+				assert.EqualError(t, err, tt.err.Error())
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_flatteners.go
+++ b/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_flatteners.go
@@ -1,0 +1,116 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package enterprisesearchstate
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/deploymentstate"
+)
+
+// FlattenResources flattens Enterprise Search resources into its flattened structure.
+func FlattenResources(in []*models.EnterpriseSearchResourceInfo, name string) []interface{} {
+	var result = make([]interface{}, 0, len(in))
+	for _, res := range in {
+		var m = make(map[string]interface{})
+		if isCurrentPlanEmpty(res) {
+			continue
+		}
+
+		if res.Info.Name != nil && *res.Info.Name != name && *res.Info.Name != "" {
+			m["display_name"] = *res.Info.Name
+		}
+
+		if res.RefID != nil && *res.RefID != "" {
+			m["ref_id"] = *res.RefID
+		}
+
+		if res.Info.ID != nil && *res.Info.ID != "" {
+			m["resource_id"] = *res.Info.ID
+		}
+
+		var plan = res.Info.PlanInfo.Current.Plan
+		if plan.EnterpriseSearch != nil {
+			m["version"] = plan.EnterpriseSearch.Version
+		}
+
+		if res.Region != nil {
+			m["region"] = *res.Region
+		}
+
+		if topology := flattenTopology(plan); len(topology) > 0 {
+			m["topology"] = topology
+		}
+
+		if res.ElasticsearchClusterRefID != nil {
+			m["elasticsearch_cluster_ref_id"] = *res.ElasticsearchClusterRefID
+		}
+
+		if urls := deploymentstate.FlattenClusterEndpoint(res.Info.Metadata); len(urls) > 0 {
+			for k, v := range urls {
+				m[k] = v
+			}
+		}
+
+		result = append(result, m)
+	}
+
+	return result
+}
+
+func flattenTopology(plan *models.EnterpriseSearchPlan) []interface{} {
+	var result = make([]interface{}, 0, len(plan.ClusterTopology))
+	for _, topology := range plan.ClusterTopology {
+		var m = make(map[string]interface{})
+		if topology.Size == nil || topology.Size.Value == nil || *topology.Size.Value == 0 {
+			continue
+		}
+
+		if topology.InstanceConfigurationID != "" {
+			m["instance_configuration_id"] = topology.InstanceConfigurationID
+		}
+
+		if *topology.Size.Resource == "memory" {
+			m["memory_per_node"] = deploymentstate.MemoryToState(*topology.Size.Value)
+		}
+
+		if nt := topology.NodeType; nt != nil {
+			if nt.Appserver != nil {
+				m["node_type_appserver"] = *nt.Appserver
+			}
+
+			if nt.Connector != nil {
+				m["node_type_connector"] = *nt.Connector
+			}
+
+			if nt.Worker != nil {
+				m["node_type_worker"] = *nt.Worker
+			}
+		}
+
+		m["zone_count"] = topology.ZoneCount
+
+		result = append(result, m)
+	}
+
+	return result
+}
+
+func isCurrentPlanEmpty(res *models.EnterpriseSearchResourceInfo) bool {
+	var emptyPlanInfo = res.Info == nil || res.Info.PlanInfo == nil || res.Info.PlanInfo.Current == nil
+	return emptyPlanInfo || res.Info.PlanInfo.Current.Plan == nil
+}

--- a/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_flatteners_test.go
+++ b/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_flatteners_test.go
@@ -1,0 +1,130 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package enterprisesearchstate
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenResource(t *testing.T) {
+	type args struct {
+		in   []*models.EnterpriseSearchResourceInfo
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []interface{}
+	}{
+		{
+			name: "empty resource list returns empty list",
+			args: args{in: []*models.EnterpriseSearchResourceInfo{}},
+			want: []interface{}{},
+		},
+		{
+			name: "empty current plan returns empty list",
+			args: args{in: []*models.EnterpriseSearchResourceInfo{
+				{
+					Info: &models.EnterpriseSearchInfo{
+						PlanInfo: &models.EnterpriseSearchPlansInfo{
+							Pending: &models.EnterpriseSearchPlanInfo{},
+						},
+					},
+				},
+			}},
+			want: []interface{}{},
+		},
+		{
+			name: "parses the enterprisesearch resource",
+			args: args{in: []*models.EnterpriseSearchResourceInfo{
+				{
+					Region:                    ec.String("some-region"),
+					RefID:                     ec.String("main-enterprise_search"),
+					ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+					Info: &models.EnterpriseSearchInfo{
+						ID:     &mock.ValidClusterID,
+						Name:   ec.String("some-enterprisesearch-name"),
+						Region: "some-region",
+						Metadata: &models.ClusterMetadataInfo{
+							Endpoint: "enterprisesearchresource.cloud.elastic.co",
+							Ports: &models.ClusterMetadataPortInfo{
+								HTTP:  ec.Int32(9200),
+								HTTPS: ec.Int32(9243),
+							},
+						},
+						PlanInfo: &models.EnterpriseSearchPlansInfo{
+							Current: &models.EnterpriseSearchPlanInfo{
+								Plan: &models.EnterpriseSearchPlan{
+									EnterpriseSearch: &models.EnterpriseSearchConfiguration{
+										Version: "7.7.0",
+									},
+									ClusterTopology: []*models.EnterpriseSearchTopologyElement{
+										{
+											ZoneCount:               1,
+											InstanceConfigurationID: "aws.enterprisesearch.r4",
+											Size: &models.TopologySize{
+												Resource: ec.String("memory"),
+												Value:    ec.Int32(1024),
+											},
+											NodeType: &models.EnterpriseSearchNodeTypes{
+												Appserver: ec.Bool(true),
+												Worker:    ec.Bool(false),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+			want: []interface{}{
+				map[string]interface{}{
+					"elasticsearch_cluster_ref_id": "main-elasticsearch",
+					"display_name":                 "some-enterprisesearch-name",
+					"ref_id":                       "main-enterprise_search",
+					"resource_id":                  mock.ValidClusterID,
+					"version":                      "7.7.0",
+					"region":                       "some-region",
+					"http_endpoint":                "http://enterprisesearchresource.cloud.elastic.co:9200",
+					"https_endpoint":               "https://enterprisesearchresource.cloud.elastic.co:9243",
+					"topology": []interface{}{
+						map[string]interface{}{
+							"instance_configuration_id": "aws.enterprisesearch.r4",
+							"memory_per_node":           "1g",
+							"zone_count":                int32(1),
+							"node_type_appserver":       true,
+							"node_type_worker":          false,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FlattenResources(tt.args.in, tt.args.name)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ec/ecresource/deploymentresource/expanders.go
+++ b/ec/ecresource/deploymentresource/expanders.go
@@ -24,12 +24,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/apmstate"
 	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/appsearchstate"
 	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/elasticsearchstate"
+	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/enterprisesearchstate"
 	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/kibanastate"
 )
 
-// TODO: EnterpriseSearch
-// TODO: AppSearch ? EnterpriseSearch superseeds AppSearch, might not be worth spending time
-// on it.
 func createResourceToModel(d *schema.ResourceData) (*models.DeploymentCreateRequest, error) {
 	var result = models.DeploymentCreateRequest{
 		Name: d.Get("name").(string),
@@ -69,12 +67,15 @@ func createResourceToModel(d *schema.ResourceData) (*models.DeploymentCreateRequ
 	}
 	result.Resources.Appsearch = append(result.Resources.Appsearch, appsearchRes...)
 
+	enterpriseSearchRes, err := enterprisesearchstate.ExpandResources(d.Get("enterprise_search").([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+	result.Resources.EnterpriseSearch = append(result.Resources.EnterpriseSearch, enterpriseSearchRes...)
+
 	return &result, nil
 }
 
-// TODO: EnterpriseSearch
-// TODO: AppSearch ? EnterpriseSearch superseeds AppSearch, might not be worth spending time
-// on it.
 func updateResourceToModel(d *schema.ResourceData) (*models.DeploymentUpdateRequest, error) {
 	var result = models.DeploymentUpdateRequest{
 		Name: d.Get("name").(string),
@@ -117,6 +118,12 @@ func updateResourceToModel(d *schema.ResourceData) (*models.DeploymentUpdateRequ
 		return nil, err
 	}
 	result.Resources.Appsearch = append(result.Resources.Appsearch, appsearchRes...)
+
+	enterpriseSearchRes, err := enterprisesearchstate.ExpandResources(d.Get("enterprise_search").([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+	result.Resources.EnterpriseSearch = append(result.Resources.EnterpriseSearch, enterpriseSearchRes...)
 
 	return &result, nil
 }

--- a/ec/ecresource/deploymentresource/expanders_test.go
+++ b/ec/ecresource/deploymentresource/expanders_test.go
@@ -47,7 +47,6 @@ func Test_createResourceToModel(t *testing.T) {
 			want: &models.DeploymentCreateRequest{
 				Name: "my_deployment_name",
 				Resources: &models.DeploymentCreateResources{
-					EnterpriseSearch: make([]*models.EnterpriseSearchPayload, 0),
 					Elasticsearch: []*models.ElasticsearchPayload{
 						{
 							DisplayName: "some-name",
@@ -160,6 +159,35 @@ func Test_createResourceToModel(t *testing.T) {
 							},
 						},
 					},
+					EnterpriseSearch: []*models.EnterpriseSearchPayload{
+						{
+							DisplayName:               "some-enterprise_search-name",
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+							Region:                    ec.String("some-region"),
+							RefID:                     ec.String("main-enterprise_search"),
+							Settings:                  &models.EnterpriseSearchSettings{},
+							Plan: &models.EnterpriseSearchPlan{
+								EnterpriseSearch: &models.EnterpriseSearchConfiguration{
+									Version: "7.7.0",
+								},
+								ClusterTopology: []*models.EnterpriseSearchTopologyElement{
+									{
+										ZoneCount:               1,
+										InstanceConfigurationID: "aws.enterprisesearch.m5",
+										Size: &models.TopologySize{
+											Resource: ec.String("memory"),
+											Value:    ec.Int32(2048),
+										},
+										NodeType: &models.EnterpriseSearchNodeTypes{
+											Appserver: ec.Bool(true),
+											Connector: ec.Bool(true),
+											Worker:    ec.Bool(true),
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -198,7 +226,6 @@ func Test_updateResourceToModel(t *testing.T) {
 				Name:         "my_deployment_name",
 				PruneOrphans: ec.Bool(false),
 				Resources: &models.DeploymentUpdateResources{
-					EnterpriseSearch: make([]*models.EnterpriseSearchPayload, 0),
 					Elasticsearch: []*models.ElasticsearchPayload{
 						{
 							DisplayName: "some-name",
@@ -304,6 +331,35 @@ func Test_updateResourceToModel(t *testing.T) {
 										},
 										NodeType: &models.AppSearchNodeTypes{
 											Appserver: ec.Bool(true),
+											Worker:    ec.Bool(true),
+										},
+									},
+								},
+							},
+						},
+					},
+					EnterpriseSearch: []*models.EnterpriseSearchPayload{
+						{
+							DisplayName:               "some-enterprise_search-name",
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+							Region:                    ec.String("some-region"),
+							RefID:                     ec.String("main-enterprise_search"),
+							Settings:                  &models.EnterpriseSearchSettings{},
+							Plan: &models.EnterpriseSearchPlan{
+								EnterpriseSearch: &models.EnterpriseSearchConfiguration{
+									Version: "7.7.0",
+								},
+								ClusterTopology: []*models.EnterpriseSearchTopologyElement{
+									{
+										ZoneCount:               1,
+										InstanceConfigurationID: "aws.enterprisesearch.m5",
+										Size: &models.TopologySize{
+											Resource: ec.String("memory"),
+											Value:    ec.Int32(2048),
+										},
+										NodeType: &models.EnterpriseSearchNodeTypes{
+											Appserver: ec.Bool(true),
+											Connector: ec.Bool(true),
 											Worker:    ec.Bool(true),
 										},
 									},

--- a/ec/ecresource/deploymentresource/flatteners.go
+++ b/ec/ecresource/deploymentresource/flatteners.go
@@ -28,6 +28,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/apmstate"
 	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/appsearchstate"
 	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/elasticsearchstate"
+	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/enterprisesearchstate"
 	"github.com/terraform-providers/terraform-provider-ec/ec/ecresource/deploymentresource/kibanastate"
 )
 
@@ -63,6 +64,11 @@ func modelToState(d *schema.ResourceData, res *models.DeploymentGetResponse) err
 
 		appsearchFlattened := appsearchstate.FlattenResources(res.Resources.Appsearch, *res.Name)
 		if err := d.Set("appsearch", appsearchFlattened); err != nil {
+			return err
+		}
+
+		enterpriseSearchFlattened := enterprisesearchstate.FlattenResources(res.Resources.EnterpriseSearch, *res.Name)
+		if err := d.Set("enterprise_search", enterpriseSearchFlattened); err != nil {
 			return err
 		}
 	}

--- a/ec/ecresource/deploymentresource/flatteners_test.go
+++ b/ec/ecresource/deploymentresource/flatteners_test.go
@@ -194,6 +194,42 @@ func Test_modelToState(t *testing.T) {
 								},
 							},
 						},
+						EnterpriseSearch: []*models.EnterpriseSearchResourceInfo{
+							{
+								Region:                    ec.String("some-region"),
+								RefID:                     ec.String("main-enterprise_search"),
+								ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+								Info: &models.EnterpriseSearchInfo{
+									ID:     &mock.ValidClusterID,
+									Name:   ec.String("some-enterprise_search-name"),
+									Region: "some-region",
+									PlanInfo: &models.EnterpriseSearchPlansInfo{
+										Current: &models.EnterpriseSearchPlanInfo{
+											Plan: &models.EnterpriseSearchPlan{
+												EnterpriseSearch: &models.EnterpriseSearchConfiguration{
+													Version: "7.7.0",
+												},
+												ClusterTopology: []*models.EnterpriseSearchTopologyElement{
+													{
+														ZoneCount:               1,
+														InstanceConfigurationID: "aws.enterprisesearch.m5",
+														Size: &models.TopologySize{
+															Resource: ec.String("memory"),
+															Value:    ec.Int32(2048),
+														},
+														NodeType: &models.EnterpriseSearchNodeTypes{
+															Appserver: ec.Bool(true),
+															Connector: ec.Bool(true),
+															Worker:    ec.Bool(true),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/ec/ecresource/deploymentresource/schema.go
+++ b/ec/ecresource/deploymentresource/schema.go
@@ -255,6 +255,53 @@ func NewSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"enterprise_search": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"elasticsearch_cluster_ref_id": {
+						Type:     schema.TypeString,
+						Default:  "main-elasticsearch",
+						Optional: true,
+					},
+					"display_name": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"ref_id": {
+						Type:     schema.TypeString,
+						Default:  "main-enterprises_search",
+						Optional: true,
+					},
+					"resource_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"version": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"region": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"http_endpoint": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"https_endpoint": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"topology": enterpriseSearchTopologySchema(),
+
+					// TODO: Implement settings field.
+					// "settings": interface{}
+				},
+			},
+		},
 	}
 }
 
@@ -433,6 +480,49 @@ func appsearchTopologySchema() *schema.Schema {
 				// Node types
 
 				"node_type_appserver": {
+					Type:     schema.TypeBool,
+					Default:  true,
+					Optional: true,
+				},
+				"node_type_worker": {
+					Type:     schema.TypeBool,
+					Default:  true,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func enterpriseSearchTopologySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"instance_configuration_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"memory_per_node": {
+					Type:     schema.TypeString,
+					Default:  "2g",
+					Optional: true,
+				},
+				"zone_count": {
+					Type:     schema.TypeInt,
+					Default:  1,
+					Optional: true,
+				},
+
+				// Node types
+
+				"node_type_appserver": {
+					Type:     schema.TypeBool,
+					Default:  true,
+					Optional: true,
+				},
+				"node_type_connector": {
 					Type:     schema.TypeBool,
 					Default:  true,
 					Optional: true,

--- a/ec/ecresource/deploymentresource/testutils.go
+++ b/ec/ecresource/deploymentresource/testutils.go
@@ -44,6 +44,7 @@ func newSampleDeployment() map[string]interface{} {
 		"kibana":                 []interface{}{newKibanaSample()},
 		"apm":                    []interface{}{newApmSample()},
 		"appsearch":              []interface{}{newAppsearchSample()},
+		"enterprise_search":      []interface{}{newEnterpriseSearchSample()},
 	}
 }
 
@@ -121,6 +122,27 @@ func newAppsearchSample() map[string]interface{} {
 				"memory_per_node":           "2g",
 				"zone_count":                1,
 				"node_type_appserver":       true,
+				"node_type_worker":          true,
+			},
+		},
+	}
+}
+
+func newEnterpriseSearchSample() map[string]interface{} {
+	return map[string]interface{}{
+		"elasticsearch_cluster_ref_id": "main-elasticsearch",
+		"display_name":                 "some-enterprise_search-name",
+		"ref_id":                       "main-enterprise_search",
+		"resource_id":                  mock.ValidClusterID,
+		"version":                      "7.7.0",
+		"region":                       "some-region",
+		"topology": []interface{}{
+			map[string]interface{}{
+				"instance_configuration_id": "aws.enterprisesearch.m5",
+				"memory_per_node":           "2g",
+				"zone_count":                1,
+				"node_type_appserver":       true,
+				"node_type_connector":       true,
 				"node_type_worker":          true,
 			},
 		},

--- a/examples/deployment_enterprise_search/README.md
+++ b/examples/deployment_enterprise_search/README.md
@@ -1,7 +1,7 @@
 # Deployment Example
 
 This example shows how to deploy an Elastic Cloud Appsearch deployment using Terraform only.
-The created resources are a single-node Elasticsearch cluster with a Kibana and AppSearch instances.
+The created resources are a single-node Elasticsearch cluster with a Kibana and Enterprise Search instances.
 
 ## Running the example
 

--- a/examples/deployment_enterprise_search/README.md
+++ b/examples/deployment_enterprise_search/README.md
@@ -1,0 +1,8 @@
+# Deployment Example
+
+This example shows how to deploy an Elastic Cloud Appsearch deployment using Terraform only.
+The created resources are a single-node Elasticsearch cluster with a Kibana and AppSearch instances.
+
+## Running the example
+
+run `terraform apply` to see it work.

--- a/examples/deployment_enterprise_search/deployment.tf
+++ b/examples/deployment_enterprise_search/deployment.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "ec" {
+}
+
+# Create an Elastic Cloud deployment
+resource "ec_deployment" "example_minimal" {
+  # Optional name.
+  name = "my_example_deployment"
+
+  # Mandatory fields
+  region                 = "us-east-1"
+  version                = "7.8.1"
+  deployment_template_id = "aws-enterprise-search-dedicated-v2"
+
+  elasticsearch {
+    topology {
+      instance_configuration_id = "aws.data.highcpu.m5d"
+      memory_per_node = "1g"
+    }
+  }
+
+  kibana {
+    topology {
+      instance_configuration_id = "aws.kibana.r5d"
+    }
+  }
+
+  enterprise_search {
+    topology {
+      instance_configuration_id = "aws.enterprisesearch.m5d"
+    }
+  }
+}

--- a/go.sum
+++ b/go.sum
@@ -438,6 +438,7 @@ github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Adds EnterpriseSearch as a manageable resource type.

## Related Issues
Closes: #13 

## How Has This Been Tested?
- By running acceptance tests:

```console
$ make testacc
-> Formatting Go files...
-> Formatting Terraform documentation blocks...
-> Done.
-> Running terraform acceptance tests...
=== RUN   TestAccDeployment_basic
=== PAUSE TestAccDeployment_basic
=== RUN   TestAccDeployment_appsearch
=== PAUSE TestAccDeployment_appsearch
=== RUN   TestAccDeployment_enterpriseSearch
=== PAUSE TestAccDeployment_enterpriseSearch
=== CONT  TestAccDeployment_basic
=== CONT  TestAccDeployment_enterpriseSearch
=== CONT  TestAccDeployment_appsearch
--- PASS: TestAccDeployment_appsearch (251.77s)
--- PASS: TestAccDeployment_enterpriseSearch (380.84s)
--- PASS: TestAccDeployment_basic (444.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ec/ec/acc	444.629s
```
- Manually by running `terraform apply` within the `examples/deployment_enterprise_search` directory.

```console
Terraform will perform the following actions:

  # ec_deployment.example_minimal will be created
  + resource "ec_deployment" "example_minimal" {
      + deployment_template_id = "aws-enterprise-search-dedicated-v2"
<...>
      + version                = "7.8.1"

      + enterprise_search {
<...>
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
