### PR TITLE
misc: Only accept EC_API_KEY as the API key environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To generate an API key, follow these steps:
 After you've generated your API Key, you can make it available to the Terraform provider by exporting it as an environment variable:
 
 ```sh
-$ export EC_APIKEY="<apikey value>"
+$ export EC_API_KEY="<apikey value>"
 ```
 
 After doing so, you can navigate to any of our examples in `./examples` and try one.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ public version control system.
 
 API Keys are the recommended authentication method. They can be used when authenticating against the Elasticsearch Service (ESS) or Elastic Cloud Enterprise (ECE).
 
-They can either be harcoded in the provider `.tf` provider configuration (NOT RECOMMENDED). Or specified via environment variables: `EC_APIKEY` or `EC_API_KEY`.
+They can either be harcoded in the provider `.tf` provider configuration (NOT RECOMMENDED). Or specified via environment variables: `EC_API_KEY`.
 
 ```hcl
 provider "ec" {
@@ -91,8 +91,8 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 * `apikey` - (Optional) This is the EC API Key. Required when targetting the Elasticsearch
   Service (ESS) offering, but also valid when targetting an ECE installation. It must be
-  provided, but it can also be sourced from the `EC_APIKEY` or `EC_API_KEY` environment
-  variables. Conflicts with `username` and `password` authentication options.
+  provided, but it can also be sourced from the `EC_API_KEY` environment variable.
+  Conflicts with `username` and `password` authentication options.
 
 * `username` - (Optional) This is the EC username. It must be provided, but it can also
   be sourced from the `EC_USER` or `EC_USERNAME` environment variables. Conflicts with

--- a/ec/acc/acc_prereq.go
+++ b/ec/acc/acc_prereq.go
@@ -39,9 +39,6 @@ func providerFactory() (*schema.Provider, error) {
 
 func testAccPreCheck(t *testing.T) {
 	var apikey, username, password string
-	if k := os.Getenv("EC_APIKEY"); k != "" {
-		apikey = k
-	}
 	if k := os.Getenv("EC_API_KEY"); k != "" {
 		apikey = k
 	}

--- a/ec/acc/sweep_test.go
+++ b/ec/acc/sweep_test.go
@@ -41,9 +41,6 @@ func NewAPI() (*api.API, error) {
 	}
 
 	var apikey string
-	if k := os.Getenv("EC_APIKEY"); k != "" {
-		apikey = k
-	}
 	if k := os.Getenv("EC_API_KEY"); k != "" {
 		apikey = k
 	}

--- a/ec/provider.go
+++ b/ec/provider.go
@@ -70,7 +70,7 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Sensitive:   true,
 				DefaultFunc: schema.MultiEnvDefaultFunc(
-					[]string{"EC_APIKEY", "EC_API_KEY"}, "",
+					[]string{"EC_API_KEY"}, "",
 				),
 			},
 			"username": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
`ECE_API_KEY` is the only recommended format in the Elastic Cloud [documentation](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html).
It makes sense to only accept that format in order to avoid confusions with our users.

## Motivation and Context
UX

## How Has This Been Tested?
By running both unit and acceptance tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
