### PR TITLE
ci: Add Acceptance tests to GitHub action workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,11 +1,11 @@
 name: Go
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
-  # Unit test run
-  unit:
-    name: Unit
+  # Acceptance tests run.
+  acceptance:
+    name: Acceptance
     runs-on: ubuntu-latest
     steps:
 
@@ -30,10 +30,8 @@ jobs:
       run: make vendor
       id: modules
 
-    - name: Linters
-      run: make lint
-      id: lint
-    
-    - name: Run unit tests
-      run: make unit
-      id: unit
+    - name: Run Acceptance tests
+      run: make testacc
+      id: testacc
+      env:
+        EC_API_KEY: ${{ secrets.EC_API_KEY }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,9 +3,9 @@ name: Go
 on: [push, pull_request]
 
 jobs:
-
-  build:
-    name: Build
+  # Unit test run
+  unit:
+    name: Unit
     runs-on: ubuntu-latest
     steps:
 
@@ -37,3 +37,36 @@ jobs:
     - name: Run unit tests
       run: make unit
       id: unit
+
+  # Acceptance tests run.
+  acceptance:
+    name: Acceptance
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Cache Go Modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Get dependencies
+      run: make vendor
+      id: modules
+
+    - name: Run Acceptance tests
+      run: make testacc
+      id: testacc
+      env:
+        EC_API_KEY: ${{ secrets.EC_API_KEY }}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the acceptance tests `make testacc` run to the workflow run in all
the commits and branches, but omitting the pull_request trigger due to
the GitHub Actions limitations on forks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Run the acceptance tests in tests in GH Actions.
