### PR TITLE
ec_deployment: Support terraform import

### DIFF
--- a/ec/acc/deployment_basic_test.go
+++ b/ec/acc/deployment_basic_test.go
@@ -129,7 +129,11 @@ func TestAccDeployment_basic(t *testing.T) {
 			},
 			// Ensure that no diff is generated.
 			{Config: cfg, PlanOnly: true},
-			// TODO: Import case when import is ready.
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/ec/ecresource/deploymentresource/resource.go
+++ b/ec/ecresource/deploymentresource/resource.go
@@ -33,9 +33,13 @@ func Resource() *schema.Resource {
 
 		Schema: NewSchema(),
 
-		// TODO: write importer function.
-		Importer:    nil,
-		Description: "",
+		Description: "Elastic Cloud Deployment resource",
+		Importer: &schema.ResourceImporter{
+			// It might be desired to provide the ability to import a deployment
+			// specifying key:value pairs of secrets to populate as part of the
+			// import with an implementation of schema.StateContextFunc.
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Default: schema.DefaultTimeout(40 * time.Minute),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This change adds the basic ID passthrough importer which allows users to
import existing deployments.
Providing the ability to import deployments but secret fields will be
missing:

    * `elasticsearch_username`
    * `elasticsearch_password`

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #9 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Importing an existing deployment and adding the `import` test case.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

