### PR TITLE
ec_deployment:Delete Enterprise Search session_key

### DIFF
--- a/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_expanders.go
+++ b/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_expanders.go
@@ -150,13 +150,6 @@ func expandConfig(raw interface{}) *models.EnterpriseSearchConfiguration {
 	var res = &models.EnterpriseSearchConfiguration{}
 	for _, rawCfg := range raw.([]interface{}) {
 		var cfg = rawCfg.(map[string]interface{})
-		if key, ok := cfg["secret_session_key"]; ok {
-			if res.SystemSettings == nil {
-				res.SystemSettings = &models.EnterpriseSearchSystemSettings{}
-			}
-			res.SystemSettings.SecretSessionKey = key.(string)
-		}
-
 		if settings, ok := cfg["user_settings_json"]; ok && settings != nil {
 			if s, ok := settings.(string); ok && s != "" {
 				res.UserSettingsJSON = settings

--- a/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_expanders_test.go
+++ b/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_expanders_test.go
@@ -81,9 +81,7 @@ func TestExpandResources(t *testing.T) {
 						"resource_id":                  mock.ValidClusterID,
 						"version":                      "7.7.0",
 						"region":                       "some-region",
-						"config": []interface{}{map[string]interface{}{
-							"secret_session_key": "somekey",
-						}},
+						"config":                       []interface{}{map[string]interface{}{}},
 						"topology": []interface{}{map[string]interface{}{
 							"config": []interface{}{map[string]interface{}{
 								"user_settings_yaml":          "some.setting: value",
@@ -160,9 +158,6 @@ func TestExpandResources(t *testing.T) {
 					Plan: &models.EnterpriseSearchPlan{
 						EnterpriseSearch: &models.EnterpriseSearchConfiguration{
 							Version: "7.7.0",
-							SystemSettings: &models.EnterpriseSearchSystemSettings{
-								SecretSessionKey: "somekey",
-							},
 						},
 						ClusterTopology: []*models.EnterpriseSearchTopologyElement{{
 							EnterpriseSearch: &models.EnterpriseSearchConfiguration{

--- a/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_flatteners.go
+++ b/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_flatteners.go
@@ -140,32 +140,11 @@ func flattenConfig(cfg *models.EnterpriseSearchConfiguration) []interface{} {
 		m["user_settings_override_json"] = cfg.UserSettingsOverrideJSON
 	}
 
-	for k, v := range flattenSystemConfig(cfg.SystemSettings) {
-		m[k] = v
-	}
-
 	if len(m) == 0 {
 		return nil
 	}
 
 	return []interface{}{m}
-}
-
-func flattenSystemConfig(cfg *models.EnterpriseSearchSystemSettings) map[string]interface{} {
-	var m = make(map[string]interface{})
-	if cfg == nil {
-		return nil
-	}
-
-	if cfg.SecretSessionKey != "" {
-		m["secret_session_key"] = cfg.SecretSessionKey
-	}
-
-	if len(m) == 0 {
-		return nil
-	}
-
-	return m
 }
 
 // IsCurrentPlanEmpty checks the enterprise search resource current plan is empty.

--- a/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_flatteners_test.go
+++ b/ec/ecresource/deploymentresource/enterprisesearchstate/enterprise_search_flatteners_test.go
@@ -83,11 +83,7 @@ func TestFlattenResource(t *testing.T) {
 										UserSettingsOverrideJSON: `{"some.setting": "some other override"}`,
 									},
 									ClusterTopology: []*models.EnterpriseSearchTopologyElement{{
-										EnterpriseSearch: &models.EnterpriseSearchConfiguration{
-											SystemSettings: &models.EnterpriseSearchSystemSettings{
-												SecretSessionKey: "somekey secret key",
-											},
-										},
+										EnterpriseSearch:        &models.EnterpriseSearchConfiguration{},
 										ZoneCount:               1,
 										InstanceConfigurationID: "aws.enterprisesearch.r4",
 										Size: &models.TopologySize{
@@ -127,9 +123,6 @@ func TestFlattenResource(t *testing.T) {
 						"zone_count":                int32(1),
 						"node_type_appserver":       true,
 						"node_type_worker":          false,
-						"config": []interface{}{map[string]interface{}{
-							"secret_session_key": "somekey secret key",
-						}},
 					}},
 				},
 			},

--- a/ec/ecresource/deploymentresource/schema_enteprise_search.go
+++ b/ec/ecresource/deploymentresource/schema_enteprise_search.go
@@ -121,12 +121,6 @@ func enterpriseSearchConfig() *schema.Schema {
 		Description:      `Optionally define the Enterprise Search configuration options for the Enterprise Search Server`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"secret_session_key": {
-					Type:        schema.TypeString,
-					Description: `Optionally override the secret session key within Enterprise Search - defaults to the previously existing secretSession`,
-					Computed:    true,
-				},
-
 				"user_settings_json": {
 					Type:        schema.TypeString,
 					Description: `An arbitrary JSON object allowing (non-admin) cluster owners to set their parameters (only one of this and 'user_settings_yaml' is allowed), provided they are on the whitelist ('user_settings_whitelist') and not on the blacklist ('user_settings_blacklist'). (This field together with 'user_settings_override*' and 'system_settings' defines the total set of resource settings)`,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Deletes `secret_session_key` from the `enterprise_search` schema and all
the flattening / expanding from / to state.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Delete setting which isn't useful.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
