### PR TITLE
Add outputs to "examples/deployment"

### DIFF
--- a/examples/deployment/outputs.tf
+++ b/examples/deployment/outputs.tf
@@ -1,0 +1,23 @@
+output "deployment_id" {
+  value = ec_deployment.example_minimal.id
+}
+
+output "elasticsearch_version" {
+  value = ec_deployment.example_minimal.elasticsearch[0].version
+}
+
+output "elasticsearch_cloud_id" {
+  value = ec_deployment.example_minimal.elasticsearch[0].cloud_id
+}
+
+output "elasticsearch_https_endpoint" {
+  value = ec_deployment.example_minimal.elasticsearch[0].https_endpoint
+}
+
+output "elasticsearch_username" {
+  value = ec_deployment.example_minimal.elasticsearch_username
+}
+
+output "elasticsearch_password" {
+  value = ec_deployment.example_minimal.elasticsearch_password
+}


### PR DESCRIPTION
This patch adds an example `outputs.tf` file to the examples,
which returns the credentials for connecting to the cluster.
