### PR TITLE
ec_deployment: Remove snapshot_settings attribute

### DIFF
--- a/ec/ecdatasource/deploymentdatasource/schema_elasticsearch.go
+++ b/ec/ecdatasource/deploymentdatasource/schema_elasticsearch.go
@@ -57,8 +57,6 @@ func newElasticsearchResourceInfo() *schema.Resource {
 				Computed: true,
 			},
 			"topology": elasticsearchTopologySchema(),
-
-			// TODO: Snapshot settings once they have been implemented in the resource
 		},
 	}
 }

--- a/ec/ecresource/deploymentresource/elasticsearchstate/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearchstate/elasticsearch_expanders.go
@@ -110,31 +110,6 @@ func expandResource(raw interface{}, dt string) (*models.ElasticsearchPayload, e
 		// }
 	}
 
-	// TODO: Verify that this works.
-	if rawSettings, ok := es["snapshot_settings"]; ok {
-		if settings := rawSettings.([]interface{}); len(settings) > 0 {
-			res.Settings.Snapshot = &models.ClusterSnapshotSettings{}
-			var ss = settings[0].((map[string]interface{}))
-			res.Settings.Snapshot.Retention = &models.ClusterSnapshotRetention{}
-
-			if enabled, ok := ss["enabled"].(bool); ok {
-				res.Settings.Snapshot.Enabled = ec.Bool(enabled)
-			}
-
-			if interval, ok := ss["interval"].(string); ok {
-				res.Settings.Snapshot.Interval = interval
-			}
-
-			if maxAge, ok := ss["retention_max_age"].(string); ok {
-				res.Settings.Snapshot.Retention.MaxAge = maxAge
-			}
-
-			if snapshotRetention, ok := ss["retention_snapshots"].(int); ok {
-				res.Settings.Snapshot.Retention.Snapshots = int32(snapshotRetention)
-			}
-		}
-	}
-
 	return &res, nil
 }
 

--- a/ec/ecresource/deploymentresource/schema_elasticsearch.go
+++ b/ec/ecresource/deploymentresource/schema_elasticsearch.go
@@ -74,9 +74,6 @@ func newElasticsearchResource() *schema.Resource {
 
 			"config": elasticsearchConfig(),
 
-			// This setting hasn't been implemented.
-			"snapshot_settings": elasticsearchSnapshotSchema(),
-
 			// This doesn't work properly. Deleting a monitoring setting doesn't work.
 			"monitoring_settings": elasticsearchMonitoringSchema(),
 		},
@@ -140,35 +137,6 @@ func elasticsearchTopologySchema() *schema.Schema {
 				},
 
 				"config": elasticsearchConfig(),
-			},
-		},
-	}
-}
-
-// TODO: This schema is missing quite a lot of properties compared to the API model.
-func elasticsearchSnapshotSchema() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"enabled": {
-					Type:     schema.TypeBool,
-					Required: true,
-				},
-				"interval": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-				"retention_max_age": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-				"retention_snapshots": {
-					Type:     schema.TypeInt,
-					Required: true,
-				},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Removes the unimplemented `snapshot_settings` attribute from the source
code since Snapshot settings shouldn't be managed in `ec_deployment`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove unused code and attributes which aren't usable.
