### PR TITLE
ci: Add terraform fmt to lint and format targets

### DIFF
--- a/build/Makefile.format
+++ b/build/Makefile.format
@@ -7,6 +7,7 @@ format: deps tools
 	@ $(GOBIN)/tfproviderlint -fix ./...
 	@ echo "-> Formatting Terraform documentation blocks..."
 	@ find ./docs -type f -name "*.md" -exec $(GOBIN)/terrafmt fmt -f {} \;
+	@ terraform fmt -write=true -recursive
 	@ echo "-> Done."
 
 .PHONY: license-header

--- a/build/Makefile.lint
+++ b/build/Makefile.lint
@@ -1,6 +1,6 @@
 ## Lints all of the source files
 .PHONY: lint
-lint: golint golangci-lint check-license tfproviderlint tfproviderdocs terrafmt
+lint: golint golangci-lint check-license tfproviderlint tfproviderdocs terrafmt fmt
 
 .PHONY: tfproviderlint
 tfproviderlint: tools
@@ -35,3 +35,8 @@ terrafmt:
 ## Validates all the terraform example files found in examples/
 validate-examples:
 	@ ./scripts/validate_examples.sh
+
+## Formats all the terraform ".tf" files in the repository
+fmt:
+	@ echo "-> Checking that the terraform .tf files are formatted..."
+	@ terraform fmt -write=false -recursive

--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -25,7 +25,7 @@ tests: unit
 
 .PHONY: testacc
 ## Runs the Terraform acceptance tests. Use TEST, TESTARGS and TEST_COUNT to control execution
-testacc: format
+testacc:
 	@ echo "-> Running terraform acceptance tests..."
 	@ TF_ACC=1 go test $(TEST_ACC) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m -run $(TEST_NAME)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds `terraform fmt` to both `lint` and `format` makefile targets.
`format`: will rewrite the files, while `lint` will return with an error
when the files aren't formatted according to `terraform fmt`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Have `terraform fmt` run the checks in the CI.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
