### PR TITLE
ec_stack: Add Data Source

### DIFF
--- a/docs/datasources/ec_stack.md
+++ b/docs/datasources/ec_stack.md
@@ -1,0 +1,61 @@
+---
+page_title: "Elastic Cloud: ec_stack"
+description: |-
+  Retrieves information of an Elastic Cloud stack.
+---
+
+# Data Source: ec_deployment
+
+Use this data source to retrieve information about an existing Elastic Cloud stack.
+
+## Example Usage
+
+```hcl
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "us-east-1"
+  lock          = true
+}
+```
+
+## Argument Reference
+s
+* `version_regex` (Required) - Regex to filter the available stacks. Can be any valid regex expression, when multiple stacks are matched through a regex, the latest version is returned.
+* `region` (Required) - Region where the stack pack is, `"ece-region` needs to be used for ece.
+* `lock` (Optional) - Lock the `"latest"` `version_regex` obtained so that when there's a new stack release, the new release doesn't cascade the changes down to the deployments, can be changed at any time.
+
+## Attributes Reference
+
+~> **NOTE:** Depending on the stack version, some values may not be set. These will not be available for interpolation.
+
+* `version` - The stack version.
+* `accessible` - Whether or not this version is accessible by the calling user. This is only relevant in EC (SaaS) and is not sent in ECE.
+* `min_upgradable_from` - The minimum version recommended to upgrade to this version.
+* `upgradable_to` - The Stack versions that this version can upgrade to.
+* `allowlisted` - Whether or not this version is in the allowlist. This is only relevant in EC (SaaS) and is not sent in ECE.
+* `apm` - Information for APM workloads on this Stack version.
+  * `apm.#.denylist` - List of configuration options that cannot be overridden by user settings.
+  * `apm.#.capacity_constraints_min` - Minimum size of the instances.
+  * `apm.#.capacity_constraints_max` - Maximum size of the instances.
+  * `apm.#.compatible_node_types` - List of node types compatible with this one.
+  * `apm.#.docker_image` - Docker image to use for the APM instance.
+* `elasticsearch` - Information for Elasticsearch workloads on this Stack version.
+  * `elasticsearch.#.denylist` - List of configuration options that cannot be overridden by user settings.
+  * `elasticsearch.#.capacity_constraints_min` - Minimum size of the instances.
+  * `elasticsearch.#.capacity_constraints_max` - Maximum size of the instances.
+  * `elasticsearch.#.compatible_node_types` - List of node types compatible with this one.
+  * `elasticsearch.#.default_plugins` - List of default plugins which are included in all Elasticsearch cluster instances.
+  * `elasticsearch.#.docker_image` - Docker image to use for the Elasticsearch cluster instances.
+  * `elasticsearch.#.plugins` - List of available plugins to be specified by users in Elasticsearch cluster instances.
+* `enterprise_search` - Information for Enterprise Search workloads on this Stack version.
+  * `enterprise_search.#.denylist` - List of configuration options that cannot be overridden by user settings.
+  * `enterprise_search.#.capacity_constraints_min` - Minimum size of the instances.
+  * `enterprise_search.#.capacity_constraints_max` - Maximum size of the instances.
+  * `enterprise_search.#.compatible_node_types` - List of node types compatible with this one.
+  * `enterprise_search.#.docker_image` - Docker image to use for the Enterprise Search instance.
+* `kibana` - Information for Kibana workloads on this Stack version.
+  * `kibana.#.denylist` - List of configuration options that cannot be overridden by user settings.
+  * `kibana.#.capacity_constraints_min` - Minimum size of the instances.
+  * `kibana.#.capacity_constraints_max` - Maximum size of the instances.
+  * `kibana.#.compatible_node_types` - List of node types compatible with this one.
+  * `kibana.#.docker_image` - Docker image to use for the Kibana instance.

--- a/docs/datasources/ec_stack.md
+++ b/docs/datasources/ec_stack.md
@@ -16,11 +16,16 @@ data "ec_stack" "latest" {
   region        = "us-east-1"
   lock          = true
 }
+
+data "ec_stack" "latest_patch" {
+  version_regex = "7.9.?"
+  region        = "us-east-1"
+}
 ```
 
 ## Argument Reference
 s
-* `version_regex` (Required) - Regex to filter the available stacks. Can be any valid regex expression, when multiple stacks are matched through a regex, the latest version is returned.
+* `version_regex` (Required) - Regex to filter the available stacks. Can be any valid regex expression, when multiple stacks are matched through a regex, the latest version is returned. `"latest"` is also accepted to obtain the latest available Stack version.
 * `region` (Required) - Region where the stack pack is, `"ece-region` needs to be used for ece.
 * `lock` (Optional) - Lock the `"latest"` `version_regex` obtained so that when there's a new stack release, the new release doesn't cascade the changes down to the deployments, can be changed at any time.
 

--- a/ec/acc/datasource_stack_test.go
+++ b/ec/acc/datasource_stack_test.go
@@ -1,0 +1,110 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDatasourceStack_latest(t *testing.T) {
+	datasourceName := "data.ec_stack.latest"
+	depCfg := "testdata/datasource_stack_latest.tf"
+	cfg := testAccStackDataSource(t, depCfg, region)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:             cfg,
+				PreventDiskCleanup: true,
+				Check: checkDataSourceStack(datasourceName,
+					resource.TestCheckResourceAttr(datasourceName, "version_regex", "latest"),
+					resource.TestCheckResourceAttr(datasourceName, "lock", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "region", region),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceStack_regex(t *testing.T) {
+	datasourceName := "data.ec_stack.regex"
+	depCfg := "testdata/datasource_stack_regex.tf"
+	cfg := testAccStackDataSource(t, depCfg, region)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:             cfg,
+				PreventDiskCleanup: true,
+				Check: checkDataSourceStack(datasourceName,
+					resource.TestCheckResourceAttr(datasourceName, "version_regex", "7.0.?"),
+					resource.TestCheckResourceAttr(datasourceName, "region", region),
+				),
+			},
+		},
+	})
+}
+
+func testAccStackDataSource(t *testing.T, fileName, region string) string {
+	b, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf(string(b), region)
+}
+
+func checkDataSourceStack(resName string, checks ...resource.TestCheckFunc) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(append([]resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resName, "version"),
+		resource.TestCheckResourceAttrSet(resName, "accessible"),
+		resource.TestCheckResourceAttrSet(resName, "min_upgradable_from"),
+		resource.TestCheckResourceAttrSet(resName, "allowlisted"),
+
+		// Elasticsearch
+		resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.denylist.#"),
+		resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.capacity_constraints_max"),
+		resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.capacity_constraints_min"),
+		resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.docker_image"),
+		resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.plugins.#"),
+		resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.default_plugins.#"),
+
+		// Kibana
+		resource.TestCheckResourceAttrSet(resName, "kibana.0.denylist.#"),
+		resource.TestCheckResourceAttrSet(resName, "kibana.0.capacity_constraints_max"),
+		resource.TestCheckResourceAttrSet(resName, "kibana.0.capacity_constraints_min"),
+		resource.TestCheckResourceAttrSet(resName, "kibana.0.docker_image"),
+
+		// APM
+		resource.TestCheckResourceAttrSet(resName, "apm.0.capacity_constraints_max"),
+		resource.TestCheckResourceAttrSet(resName, "apm.0.capacity_constraints_min"),
+		resource.TestCheckResourceAttrSet(resName, "apm.0.docker_image"),
+
+		// Enterprise Search
+		resource.TestCheckResourceAttrSet(resName, "enterprise_search.0.capacity_constraints_max"),
+		resource.TestCheckResourceAttrSet(resName, "enterprise_search.0.capacity_constraints_min"),
+		resource.TestCheckResourceAttrSet(resName, "enterprise_search.0.docker_image"),
+	}, checks...)...)
+}

--- a/ec/acc/testdata/datasource_stack_latest.tf
+++ b/ec/acc/testdata/datasource_stack_latest.tf
@@ -1,0 +1,5 @@
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  lock          = true
+  region        = "%s"
+}

--- a/ec/acc/testdata/datasource_stack_regex.tf
+++ b/ec/acc/testdata/datasource_stack_regex.tf
@@ -1,0 +1,4 @@
+data "ec_stack" "regex" {
+  version_regex = "7.0.?"
+  region        = "%s"
+}

--- a/ec/ecdatasource/stackdatasource/datasource.go
+++ b/ec/ecdatasource/stackdatasource/datasource.go
@@ -1,0 +1,156 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package stackdatasource
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/stackapi"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/elastic/terraform-provider-ec/ec/ecdatasource/stackdatasource/state"
+)
+
+// DataSource returns the ec_deployment data source schema.
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: read,
+
+		Schema: newSchema(),
+
+		Timeouts: &schema.ResourceTimeout{
+			Default: schema.DefaultTimeout(5 * time.Minute),
+		},
+	}
+}
+
+func read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*api.API)
+	region := d.Get("region").(string)
+
+	res, err := stackapi.List(stackapi.ListParams{
+		API:    client,
+		Region: region,
+	})
+	if err != nil {
+		return diag.FromErr(
+			multierror.NewPrefixed("failed retrieving the specified stack version", err),
+		)
+	}
+
+	versionExpr := d.Get("version_regex").(string)
+	version := d.Get("version").(string)
+	lock := d.Get("lock").(bool)
+	stack, err := stackFromFilters(versionExpr, version, lock, res.Stacks)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.Id() == "" {
+		d.SetId(strconv.Itoa(schema.HashString(version)))
+	}
+
+	if err := modelToState(d, stack); err != nil {
+		diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func stackFromFilters(expr, version string, locked bool, stacks []*models.StackVersionConfig) (*models.StackVersionConfig, error) {
+	if expr == "latest" && locked && version != "" {
+		expr = version
+	}
+
+	if expr == "latest" {
+		return stacks[0], nil
+	}
+
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile the version_regex: %w", err)
+	}
+
+	for _, stack := range stacks {
+		if re.MatchString(stack.Version) {
+			return stack, nil
+		}
+	}
+
+	return nil, fmt.Errorf(`failed to obtain a stack version matching "%s": `+
+		`please specify a valid version_regex`, expr,
+	)
+}
+
+func modelToState(d *schema.ResourceData, stack *models.StackVersionConfig) error {
+	if stack == nil {
+		return nil
+	}
+
+	if err := d.Set("version", stack.Version); err != nil {
+		return err
+	}
+
+	if stack.Accessible != nil {
+		if err := d.Set("accessible", *stack.Accessible); err != nil {
+			return err
+		}
+	}
+
+	if err := d.Set("min_upgradable_from", stack.MinUpgradableFrom); err != nil {
+		return err
+	}
+
+	if len(stack.UpgradableTo) > 0 {
+		if err := d.Set("upgradable_to", stack.UpgradableTo); err != nil {
+			return err
+		}
+	}
+
+	if stack.Whitelisted != nil {
+		if err := d.Set("allowlisted", *stack.Whitelisted); err != nil {
+			return err
+		}
+	}
+
+	if err := d.Set("apm", state.FlattenApmResources(stack.Apm)); err != nil {
+		return err
+	}
+
+	if err := d.Set("elasticsearch", state.FlattenElasticsearchResources(stack.Elasticsearch)); err != nil {
+		return err
+	}
+
+	if err := d.Set("enterprise_search", state.FlattenEnterpriseSearchResources(stack.EnterpriseSearch)); err != nil {
+		return err
+	}
+
+	if err := d.Set("kibana", state.FlattenKibanaResources(stack.Kibana)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/ec/ecdatasource/stackdatasource/datasource_test.go
+++ b/ec/ecdatasource/stackdatasource/datasource_test.go
@@ -1,0 +1,265 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package stackdatasource
+
+import (
+	"errors"
+	"fmt"
+	"regexp/syntax"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_modelToState(t *testing.T) {
+	deploymentSchemaArg := schema.TestResourceDataRaw(t, newSchema(), nil)
+	deploymentSchemaArg.SetId("someid")
+	_ = deploymentSchemaArg.Set("region", "us-east-1")
+	_ = deploymentSchemaArg.Set("version_regex", "latest")
+
+	wantDeployment := newResourceData(t, resDataParams{
+		ID:        "someid",
+		Resources: newSampleStack(),
+	})
+
+	type args struct {
+		d   *schema.ResourceData
+		res *models.StackVersionConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want *schema.ResourceData
+		err  error
+	}{
+		{
+			name: "flattens deployment resources",
+			want: wantDeployment,
+			args: args{
+				d: deploymentSchemaArg,
+				res: &models.StackVersionConfig{
+					Version:           "7.9.1",
+					Accessible:        ec.Bool(true),
+					Whitelisted:       ec.Bool(true),
+					MinUpgradableFrom: "6.8.0",
+					Apm: &models.StackVersionApmConfig{
+						Blacklist: []string{"some"},
+						CapacityConstraints: &models.StackVersionInstanceCapacityConstraint{
+							Max: ec.Int32(8192),
+							Min: ec.Int32(512),
+						},
+						DockerImage: ec.String("docker.elastic.co/cloud-assets/apm:7.9.1-0"),
+					},
+					Kibana: &models.StackVersionKibanaConfig{
+						Blacklist: []string{"some"},
+						CapacityConstraints: &models.StackVersionInstanceCapacityConstraint{
+							Max: ec.Int32(8192),
+							Min: ec.Int32(512),
+						},
+						DockerImage: ec.String("docker.elastic.co/cloud-assets/kibana:7.9.1-0"),
+					},
+					Elasticsearch: &models.StackVersionElasticsearchConfig{
+						Blacklist: []string{"some"},
+						CapacityConstraints: &models.StackVersionInstanceCapacityConstraint{
+							Max: ec.Int32(8192),
+							Min: ec.Int32(512),
+						},
+						DockerImage:    ec.String("docker.elastic.co/cloud-assets/elasticsearch:7.9.1-0"),
+						DefaultPlugins: []string{"repository-s3"},
+						Plugins: []string{
+							"analysis-icu",
+							"analysis-kuromoji",
+							"analysis-nori",
+							"analysis-phonetic",
+							"analysis-smartcn",
+							"analysis-stempel",
+							"analysis-ukrainian",
+							"ingest-attachment",
+							"mapper-annotated-text",
+							"mapper-murmur3",
+							"mapper-size",
+							"repository-azure",
+							"repository-gcs",
+						},
+					},
+					EnterpriseSearch: &models.StackVersionEnterpriseSearchConfig{
+						Blacklist: []string{"some"},
+						CapacityConstraints: &models.StackVersionInstanceCapacityConstraint{
+							Max: ec.Int32(8192),
+							Min: ec.Int32(512),
+						},
+						DockerImage: ec.String("docker.elastic.co/cloud-assets/enterprise_search:7.9.1-0"),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := modelToState(tt.args.d, tt.args.res)
+			if tt.err != nil {
+				assert.EqualError(t, err, tt.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want.State().Attributes, tt.args.d.State().Attributes)
+		})
+	}
+}
+
+type resDataParams struct {
+	Resources map[string]interface{}
+	ID        string
+}
+
+func newResourceData(t *testing.T, params resDataParams) *schema.ResourceData {
+	raw := schema.TestResourceDataRaw(t, DataSource().Schema, params.Resources)
+	raw.SetId(params.ID)
+
+	return raw
+}
+
+func newSampleStack() map[string]interface{} {
+	return map[string]interface{}{
+		"id":            "someid",
+		"region":        "us-east-1",
+		"version_regex": "latest",
+
+		"version":             "7.9.1",
+		"accessible":          true,
+		"allowlisted":         true,
+		"min_upgradable_from": "6.8.0",
+		"elasticsearch": []interface{}{map[string]interface{}{
+			"denylist":                 []interface{}{"some"},
+			"capacity_constraints_max": 8192,
+			"capacity_constraints_min": 512,
+			"default_plugins":          []interface{}{"repository-s3"},
+			"docker_image":             "docker.elastic.co/cloud-assets/elasticsearch:7.9.1-0",
+			"plugins": []interface{}{
+				"analysis-icu",
+				"analysis-kuromoji",
+				"analysis-nori",
+				"analysis-phonetic",
+				"analysis-smartcn",
+				"analysis-stempel",
+				"analysis-ukrainian",
+				"ingest-attachment",
+				"mapper-annotated-text",
+				"mapper-murmur3",
+				"mapper-size",
+				"repository-azure",
+				"repository-gcs",
+			},
+		}},
+		"kibana": []interface{}{map[string]interface{}{
+			"denylist":                 []interface{}{"some"},
+			"capacity_constraints_max": 8192,
+			"capacity_constraints_min": 512,
+			"docker_image":             "docker.elastic.co/cloud-assets/kibana:7.9.1-0",
+		}},
+		"apm": []interface{}{map[string]interface{}{
+			"denylist":                 []interface{}{"some"},
+			"capacity_constraints_max": 8192,
+			"capacity_constraints_min": 512,
+			"docker_image":             "docker.elastic.co/cloud-assets/apm:7.9.1-0",
+		}},
+		"enterprise_search": []interface{}{map[string]interface{}{
+			"denylist":                 []interface{}{"some"},
+			"capacity_constraints_max": 8192,
+			"capacity_constraints_min": 512,
+			"docker_image":             "docker.elastic.co/cloud-assets/enterprise_search:7.9.1-0",
+		}},
+	}
+}
+
+func Test_stackFromFilters(t *testing.T) {
+	var stackPacks = []*models.StackVersionConfig{
+		{Version: "7.9.1"},
+		{Version: "7.9.0"},
+		{Version: "7.8.1"},
+		{Version: "7.8.0"},
+	}
+	type args struct {
+		expr    string
+		version string
+		locked  bool
+		stacks  []*models.StackVersionConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.StackVersionConfig
+		err  error
+	}{
+		{
+			name: "returns the stack pack with exact matching",
+			args: args{expr: "7.9.0", stacks: stackPacks},
+			want: &models.StackVersionConfig{Version: "7.9.0"},
+		},
+		{
+			name: "returns the stack pack with patch regex",
+			args: args{expr: "7.8.?", stacks: stackPacks},
+			want: &models.StackVersionConfig{Version: "7.8.1"},
+		},
+		{
+			name: "returns the latest stackpack",
+			args: args{expr: "latest", stacks: stackPacks},
+			want: &models.StackVersionConfig{Version: "7.9.1"},
+		},
+		{
+			name: "returns the latest stackpack with a locked version",
+			args: args{
+				expr:    "latest",
+				stacks:  stackPacks,
+				locked:  true,
+				version: "7.8.1",
+			},
+			want: &models.StackVersionConfig{Version: "7.8.1"},
+		},
+		{
+			name: "returns an error when the expression doesn't match the stackpack",
+			args: args{expr: "7.9.1", stacks: []*models.StackVersionConfig{
+				{Version: "7.8.0"},
+			}},
+			err: errors.New(`failed to obtain a stack version matching "7.9.1": please specify a valid version_regex`),
+		},
+		{
+			name: "returns an error when the regex can't be compiled",
+			args: args{expr: `(?!`, stacks: []*models.StackVersionConfig{
+				{Version: "7.8.0"},
+			}},
+			err: fmt.Errorf("failed to compile the version_regex: %w", &syntax.Error{
+				Expr: `(?!`,
+				Code: syntax.ErrInvalidPerlOp,
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := stackFromFilters(tt.args.expr, tt.args.version, tt.args.locked, tt.args.stacks)
+			if !assert.Equal(t, tt.err, err) {
+				fmt.Println(err, "!= want ", tt.err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ec/ecdatasource/stackdatasource/schema.go
+++ b/ec/ecdatasource/stackdatasource/schema.go
@@ -1,0 +1,120 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package stackdatasource
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func newSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"version_regex": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"region": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"lock": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+
+		// Exported attributes
+		"version": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"accessible": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"min_upgradable_from": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"upgradable_to": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"allowlisted": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+
+		"apm":               newKindResourceSchema(),
+		"enterprise_search": newKindResourceSchema(),
+		"elasticsearch":     newKindResourceSchema(),
+		"kibana":            newKindResourceSchema(),
+	}
+}
+
+func newKindResourceSchema() *schema.Schema {
+	return &schema.Schema{
+		Computed: true,
+		Type:     schema.TypeList,
+		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+			"denylist": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"capacity_constraints_max": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"capacity_constraints_min": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"compatible_node_types": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"docker_image": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"plugins": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"default_plugins": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			// node_types not added. It is highly unlikely they will be used
+			// for anything, and if they're needed in the future, then we can
+			// invest on adding them.
+		}},
+	}
+}

--- a/ec/ecdatasource/stackdatasource/state/flatteners_apm.go
+++ b/ec/ecdatasource/stackdatasource/state/flatteners_apm.go
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package state
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/terraform-provider-ec/ec/util"
+)
+
+// FlattenApmResources takes in Apm resource models and returns its
+// flattened form.
+func FlattenApmResources(res *models.StackVersionApmConfig) []interface{} {
+	var m = make(map[string]interface{})
+
+	if res == nil {
+		return nil
+	}
+
+	if len(res.Blacklist) > 0 {
+		m["denylist"] = util.StringToItems(res.Blacklist...)
+	}
+
+	if res.CapacityConstraints != nil {
+		m["capacity_constraints_max"] = int(*res.CapacityConstraints.Max)
+		m["capacity_constraints_min"] = int(*res.CapacityConstraints.Min)
+	}
+
+	if len(res.CompatibleNodeTypes) > 0 {
+		m["compatible_node_types"] = res.CompatibleNodeTypes
+	}
+
+	if res.DockerImage != nil && *res.DockerImage != "" {
+		m["docker_image"] = *res.DockerImage
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	return []interface{}{m}
+}

--- a/ec/ecdatasource/stackdatasource/state/flatteners_apm_test.go
+++ b/ec/ecdatasource/stackdatasource/state/flatteners_apm_test.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenApmResource(t *testing.T) {
+	type args struct {
+		res *models.StackVersionApmConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want []interface{}
+	}{
+		{
+			name: "empty resource list returns empty list",
+			args: args{},
+			want: nil,
+		},
+		{
+			name: "empty resource list returns empty list",
+			args: args{res: &models.StackVersionApmConfig{}},
+			want: nil,
+		},
+		{
+			name: "parses the apm resource",
+			args: args{res: &models.StackVersionApmConfig{
+				Blacklist: []string{"some"},
+				CapacityConstraints: &models.StackVersionInstanceCapacityConstraint{
+					Max: ec.Int32(8192),
+					Min: ec.Int32(512),
+				},
+				DockerImage: ec.String("docker.elastic.co/cloud-assets/apm:7.9.1-0"),
+			}},
+			want: []interface{}{map[string]interface{}{
+				"denylist":                 []interface{}{"some"},
+				"capacity_constraints_max": 8192,
+				"capacity_constraints_min": 512,
+				"docker_image":             "docker.elastic.co/cloud-assets/apm:7.9.1-0",
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FlattenApmResources(tt.args.res)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ec/ecdatasource/stackdatasource/state/flatteners_elasticsearch.go
+++ b/ec/ecdatasource/stackdatasource/state/flatteners_elasticsearch.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package state
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/terraform-provider-ec/ec/util"
+)
+
+// FlattenElasticsearchResources takes in Elasticsearch resource models and returns its
+// flattened form.
+func FlattenElasticsearchResources(res *models.StackVersionElasticsearchConfig) []interface{} {
+	var m = make(map[string]interface{})
+
+	if res == nil {
+		return nil
+	}
+
+	if len(res.Blacklist) > 0 {
+		m["denylist"] = util.StringToItems(res.Blacklist...)
+	}
+
+	if res.CapacityConstraints != nil {
+		m["capacity_constraints_max"] = int(*res.CapacityConstraints.Max)
+		m["capacity_constraints_min"] = int(*res.CapacityConstraints.Min)
+	}
+
+	if len(res.CompatibleNodeTypes) > 0 {
+		m["compatible_node_types"] = util.StringToItems(res.CompatibleNodeTypes...)
+	}
+
+	if res.DockerImage != nil && *res.DockerImage != "" {
+		m["docker_image"] = *res.DockerImage
+	}
+
+	if len(res.Plugins) > 0 {
+		m["plugins"] = util.StringToItems(res.Plugins...)
+	}
+
+	if len(res.DefaultPlugins) > 0 {
+		m["default_plugins"] = util.StringToItems(res.DefaultPlugins...)
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	return []interface{}{m}
+}

--- a/ec/ecdatasource/stackdatasource/state/flatteners_elasticsearch_test.go
+++ b/ec/ecdatasource/stackdatasource/state/flatteners_elasticsearch_test.go
@@ -1,0 +1,103 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenElasticsearchResources(t *testing.T) {
+	type args struct {
+		res *models.StackVersionElasticsearchConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want []interface{}
+	}{
+		{
+			name: "empty resource list returns empty list",
+			args: args{},
+			want: nil,
+		},
+		{
+			name: "empty resource list returns empty list",
+			args: args{res: &models.StackVersionElasticsearchConfig{}},
+			want: nil,
+		},
+		{
+			name: "parses the apm resource",
+			args: args{res: &models.StackVersionElasticsearchConfig{
+				Blacklist: []string{"some"},
+				CapacityConstraints: &models.StackVersionInstanceCapacityConstraint{
+					Max: ec.Int32(8192),
+					Min: ec.Int32(512),
+				},
+				DockerImage:    ec.String("docker.elastic.co/cloud-assets/elasticsearch:7.9.1-0"),
+				DefaultPlugins: []string{"repository-s3"},
+				Plugins: []string{
+					"analysis-icu",
+					"analysis-kuromoji",
+					"analysis-nori",
+					"analysis-phonetic",
+					"analysis-smartcn",
+					"analysis-stempel",
+					"analysis-ukrainian",
+					"ingest-attachment",
+					"mapper-annotated-text",
+					"mapper-murmur3",
+					"mapper-size",
+					"repository-azure",
+					"repository-gcs",
+				},
+			}},
+			want: []interface{}{map[string]interface{}{
+				"denylist":                 []interface{}{"some"},
+				"capacity_constraints_max": 8192,
+				"capacity_constraints_min": 512,
+				"default_plugins":          []interface{}{"repository-s3"},
+				"docker_image":             "docker.elastic.co/cloud-assets/elasticsearch:7.9.1-0",
+				"plugins": []interface{}{
+					"analysis-icu",
+					"analysis-kuromoji",
+					"analysis-nori",
+					"analysis-phonetic",
+					"analysis-smartcn",
+					"analysis-stempel",
+					"analysis-ukrainian",
+					"ingest-attachment",
+					"mapper-annotated-text",
+					"mapper-murmur3",
+					"mapper-size",
+					"repository-azure",
+					"repository-gcs",
+				},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FlattenElasticsearchResources(tt.args.res)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ec/ecdatasource/stackdatasource/state/flatteners_enterprise_search.go
+++ b/ec/ecdatasource/stackdatasource/state/flatteners_enterprise_search.go
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package state
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/terraform-provider-ec/ec/util"
+)
+
+// FlattenEnterpriseSearchResources takes in EnterpriseSearch resource models and returns its
+// flattened form.
+func FlattenEnterpriseSearchResources(res *models.StackVersionEnterpriseSearchConfig) []interface{} {
+	var m = make(map[string]interface{})
+
+	if res == nil {
+		return nil
+	}
+
+	if len(res.Blacklist) > 0 {
+		m["denylist"] = util.StringToItems(res.Blacklist...)
+	}
+
+	if res.CapacityConstraints != nil {
+		m["capacity_constraints_max"] = int(*res.CapacityConstraints.Max)
+		m["capacity_constraints_min"] = int(*res.CapacityConstraints.Min)
+	}
+
+	if len(res.CompatibleNodeTypes) > 0 {
+		m["compatible_node_types"] = res.CompatibleNodeTypes
+	}
+
+	if res.DockerImage != nil && *res.DockerImage != "" {
+		m["docker_image"] = *res.DockerImage
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	return []interface{}{m}
+}

--- a/ec/ecdatasource/stackdatasource/state/flatteners_enterprise_search_test.go
+++ b/ec/ecdatasource/stackdatasource/state/flatteners_enterprise_search_test.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenEnterpriseSearchResources(t *testing.T) {
+	type args struct {
+		res *models.StackVersionEnterpriseSearchConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want []interface{}
+	}{
+		{
+			name: "empty resource list returns empty list",
+			args: args{},
+			want: nil,
+		},
+		{
+			name: "empty resource list returns empty list",
+			args: args{res: &models.StackVersionEnterpriseSearchConfig{}},
+			want: nil,
+		},
+		{
+			name: "parses the apm resource",
+			args: args{res: &models.StackVersionEnterpriseSearchConfig{
+				Blacklist: []string{"some"},
+				CapacityConstraints: &models.StackVersionInstanceCapacityConstraint{
+					Max: ec.Int32(8192),
+					Min: ec.Int32(512),
+				},
+				DockerImage: ec.String("docker.elastic.co/cloud-assets/enterprise_search:7.9.1-0"),
+			}},
+			want: []interface{}{map[string]interface{}{
+				"denylist":                 []interface{}{"some"},
+				"capacity_constraints_max": 8192,
+				"capacity_constraints_min": 512,
+				"docker_image":             "docker.elastic.co/cloud-assets/enterprise_search:7.9.1-0",
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FlattenEnterpriseSearchResources(tt.args.res)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ec/ecdatasource/stackdatasource/state/flatteners_kibana.go
+++ b/ec/ecdatasource/stackdatasource/state/flatteners_kibana.go
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package state
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/terraform-provider-ec/ec/util"
+)
+
+// FlattenKibanaResources takes in Kibana resource models and returns its
+// flattened form.
+func FlattenKibanaResources(res *models.StackVersionKibanaConfig) []interface{} {
+	var m = make(map[string]interface{})
+
+	if res == nil {
+		return nil
+	}
+
+	if len(res.Blacklist) > 0 {
+		m["denylist"] = util.StringToItems(res.Blacklist...)
+	}
+
+	if res.CapacityConstraints != nil {
+		m["capacity_constraints_max"] = int(*res.CapacityConstraints.Max)
+		m["capacity_constraints_min"] = int(*res.CapacityConstraints.Min)
+	}
+
+	if len(res.CompatibleNodeTypes) > 0 {
+		m["compatible_node_types"] = util.StringToItems(res.CompatibleNodeTypes...)
+	}
+
+	if res.DockerImage != nil && *res.DockerImage != "" {
+		m["docker_image"] = *res.DockerImage
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	return []interface{}{m}
+}

--- a/ec/ecdatasource/stackdatasource/state/flatteners_kibana_test.go
+++ b/ec/ecdatasource/stackdatasource/state/flatteners_kibana_test.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenKibanaResources(t *testing.T) {
+	type args struct {
+		res *models.StackVersionKibanaConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want []interface{}
+	}{
+		{
+			name: "empty resource list returns empty list",
+			args: args{},
+			want: nil,
+		},
+		{
+			name: "empty resource list returns empty list",
+			args: args{res: &models.StackVersionKibanaConfig{}},
+			want: nil,
+		},
+		{
+			name: "parses the apm resource",
+			args: args{res: &models.StackVersionKibanaConfig{
+				Blacklist: []string{"some"},
+				CapacityConstraints: &models.StackVersionInstanceCapacityConstraint{
+					Max: ec.Int32(8192),
+					Min: ec.Int32(512),
+				},
+				DockerImage: ec.String("docker.elastic.co/cloud-assets/kibana:7.9.1-0"),
+			}},
+			want: []interface{}{map[string]interface{}{
+				"denylist":                 []interface{}{"some"},
+				"capacity_constraints_max": 8192,
+				"capacity_constraints_min": 512,
+				"docker_image":             "docker.elastic.co/cloud-assets/kibana:7.9.1-0",
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FlattenKibanaResources(tt.args.res)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ec/provider.go
+++ b/ec/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/elastic/terraform-provider-ec/ec/ecdatasource/deploymentdatasource"
+	"github.com/elastic/terraform-provider-ec/ec/ecdatasource/stackdatasource"
 	"github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource"
 	"github.com/elastic/terraform-provider-ec/ec/ecresource/trafficfilterassocresource"
 	"github.com/elastic/terraform-provider-ec/ec/ecresource/trafficfilterresource"
@@ -124,6 +125,7 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ec_deployment": deploymentdatasource.DataSource(),
+			"ec_stack":      stackdatasource.DataSource(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"ec_deployment":                            deploymentresource.Resource(),

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new data source which allows the terraform provider users to get
information about a specific stack version by using a `version_regex`.
The `version_regex` field also accepts a `"latest"` string as a value
which will cause the data source to obtain the latest available stack
version and return it, best used with `lock`.

There's quite a lot of fields contained in the Stack models and this PR
implements most of the fields which might not even be useful in the long
run, but can be useful to browse around what capabilities are in a stack
version.

### Using the "latest" string

```hcl
data "ec_stack" "latest" {
  version_regex = "latest"
  region        = "us-east-1"
  lock          = true
}
```

### Obtaining the latest patch version of a major

```hcl
data "ec_stack" "latest" {
  version_regex = "7.9.?"
  region        = "us-east-1"
}
```

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Fixes #66 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```console
$ make testacc TEST_NAME=TestAccDatasourceStack
-> Running terraform acceptance tests...
=== RUN   TestAccDatasourceStack_latest
=== PAUSE TestAccDatasourceStack_latest
=== RUN   TestAccDatasourceStack_regex
=== PAUSE TestAccDatasourceStack_regex
=== CONT  TestAccDatasourceStack_latest
=== CONT  TestAccDatasourceStack_regex
--- PASS: TestAccDatasourceStack_latest (4.68s)
--- PASS: TestAccDatasourceStack_regex (4.68s)
PASS
ok  	github.com/elastic/terraform-provider-ec/ec/acc	5.315s
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
