### PR TITLE
ci: Fix broken acceptance build pipeline

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -18,4 +18,4 @@ clean: ## Delete credentials
 	@ rm -f .apikey
 
 .apikey:
-	@ VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -field=apikey secret/cloud-team/production/delivery-clients > .apikey
+	@ VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -field=apikey secret/devops-ci/terraform-provider-ec > .apikey

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -18,4 +18,4 @@ clean: ## Delete credentials
 	@ rm -f .apikey
 
 .apikey:
-	@ $(vault) read -field=apikey secret/cloud-team/production/delivery-clients > .apikey
+	@ VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -field=apikey secret/cloud-team/production/delivery-clients > .apikey

--- a/.ci/jobs/elastic+terraform-provider-ec+pull-request.yml
+++ b/.ci/jobs/elastic+terraform-provider-ec+pull-request.yml
@@ -12,7 +12,7 @@
                 - elastic
             allow-whitelist-orgs-as-admins: true
             cancel-builds-on-update: true
-            status-context: acceptance
+            status-context: "Terraform Acceptance"
     pipeline-scm:
         scm:
             - git:

--- a/.ci/jobs/elastic+terraform-provider-ec+pull-request.yml
+++ b/.ci/jobs/elastic+terraform-provider-ec+pull-request.yml
@@ -12,7 +12,7 @@
                 - elastic
             allow-whitelist-orgs-as-admins: true
             cancel-builds-on-update: true
-            status-context: "Terraform Acceptance"
+            status-context: acceptance
     pipeline-scm:
         scm:
             - git:

--- a/.ci/pipelines/acceptance.Jenkinsfile
+++ b/.ci/pipelines/acceptance.Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 node('docker') {
-    String DOCKER_IMAGE = "golang:1.15-buster"
+    String DOCKER_IMAGE = "golang:1.15"
     String APP_PATH = "/go/src/github.com/elastic/terraform-provider-ec"
 
     stage('Checkout from GitHub') {

--- a/.ci/pipelines/acceptance.Jenkinsfile
+++ b/.ci/pipelines/acceptance.Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 node('docker') {
-    String DOCKER_IMAGE = "golang:1.15-stretch"
+    String DOCKER_IMAGE = "golang:1.15-buster"
     String APP_PATH = "/go/src/github.com/elastic/terraform-provider-ec"
 
     stage('Checkout from GitHub') {

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,6 +1,9 @@
 name: Go
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   # Acceptance tests run.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes a few issues with the committed pipeline and build configurations.

First, The path used for the secret wasn't readable by the vault role
configured in the `devops-ci`, furthermore that key contained more
credentials in the secret path. Instead of using the initial path, a new
secret has been created in the Vault server with only the apikey
credentials, in a path accessible by the vault role.

Second, fixes the docker `golang` docker image to  use the tag  `1.15`.

Last, it changes the `acceptance.yml` github action to only run on the
push operation in the master branch. This is temporary and until the
master build in Jenkins is fixed (Currently not triggered).

## Related issues

Part of #58 