### PR TITLE
acceptance: Refactor traffic filter tests to use trafficfilterapi

### DIFF
--- a/ec/acc/deployment_traffic_filter_checks_test.go
+++ b/ec/acc/deployment_traffic_filter_checks_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -41,10 +41,11 @@ func testAccCheckDeploymentTrafficFilterExists(name string) resource.TestCheckFu
 			return err
 		}
 
-		return api.ReturnErrOnly(client.V1API.DeploymentsTrafficFilter.GetTrafficFilterRuleset(
-			deployments_traffic_filter.NewGetTrafficFilterRulesetParams().
-				WithRulesetID(saved.Primary.ID),
-			client.AuthWriter,
+		return api.ReturnErrOnly(trafficfilterapi.Get(
+			trafficfilterapi.GetParams{
+				API: client,
+				ID:  saved.Primary.ID,
+			},
 		))
 	}
 }

--- a/ec/acc/deployment_traffic_filter_destroy_test.go
+++ b/ec/acc/deployment_traffic_filter_destroy_test.go
@@ -20,7 +20,7 @@ package acc
 import (
 	"fmt"
 
-	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -37,11 +37,10 @@ func testAccDeploymentTrafficFilterDestroy(s *terraform.State) error {
 			continue
 		}
 
-		res, err := client.V1API.DeploymentsTrafficFilter.GetTrafficFilterRuleset(
-			deployments_traffic_filter.NewGetTrafficFilterRulesetParams().
-				WithRulesetID(rs.Primary.ID),
-			client.AuthWriter,
-		)
+		res, err := trafficfilterapi.Get(trafficfilterapi.GetParams{
+			API: client,
+			ID:  rs.Primary.ID,
+		})
 
 		// The resource will only exist if it can be obtained via the API and
 		// the metadata status is not set to hidden. Currently ESS clients


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This patch refactors traffic filter tests to use trafficfilterapi instead
of the APIs from the generated swagger code.

## How Has This Been Tested?
```console
-> Running terraform acceptance tests...
=== RUN   TestAccDeploymentTrafficFilterAssociation_basic
=== PAUSE TestAccDeploymentTrafficFilterAssociation_basic
=== RUN   TestAccDeploymentTrafficFilter_basic
=== PAUSE TestAccDeploymentTrafficFilter_basic
=== CONT  TestAccDeploymentTrafficFilterAssociation_basic
=== CONT  TestAccDeploymentTrafficFilter_basic
--- PASS: TestAccDeploymentTrafficFilter_basic (66.97s)
--- PASS: TestAccDeploymentTrafficFilterAssociation_basic (210.40s)
PASS
ok  	github.com/elastic/terraform-provider-ec/ec/acc	211.955s
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
