### PR TITLE
acceptance: Update ec_deployment datasource test to include traffic filter

### DIFF
--- a/ec/acc/datasource_deployment_basic_test.go
+++ b/ec/acc/datasource_deployment_basic_test.go
@@ -45,6 +45,7 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "region", resourceName, "region"),
 					resource.TestCheckResourceAttrPair(datasourceName, "deployment_template_id", resourceName, "deployment_template_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "traffic_filter.#", resourceName, "traffic_filter.#"),
 
 					// Elasticsearch
 					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.ref_id", resourceName, "elasticsearch.0.ref_id"),
@@ -132,6 +133,6 @@ func testAccDeploymentDatasourceBasic(t *testing.T, fileName, name, region, vers
 		t.Fatal(err)
 	}
 	return fmt.Sprintf(string(b),
-		name, region, version, version, version, version, version,
+		name, region, version, name, region, version, version, version, version,
 	)
 }

--- a/ec/acc/testdata/datasource_deployment_basic.tf
+++ b/ec/acc/testdata/datasource_deployment_basic.tf
@@ -33,6 +33,20 @@ resource "ec_deployment" "basic_datasource" {
       instance_configuration_id = "aws.enterprisesearch.m5d"
     }
   }
+
+  traffic_filter = [
+    ec_deployment_traffic_filter.default.id,
+  ]
+}
+
+resource "ec_deployment_traffic_filter" "default" {
+  name   = "%s"
+  region = "%s"
+  type   = "ip"
+
+  rule {
+    source = "0.0.0.0/0"
+  }
 }
 
 data "ec_deployment" "success" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Follow up PR for https://github.com/elastic/terraform-provider-ec/pull/91 which adds acceptance tests.

## How Has This Been Tested?
```console
-> Running terraform acceptance tests...
=== RUN   TestAccDatasourceDeployment_basic
=== PAUSE TestAccDatasourceDeployment_basic
=== CONT  TestAccDatasourceDeployment_basic
--- PASS: TestAccDatasourceDeployment_basic (443.13s)
PASS
ok  	github.com/elastic/terraform-provider-ec/ec/acc	444.707s
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
