### PR TITLE
ci: Do not cancel builds on commit push

### DIFF
--- a/.ci/jobs/elastic+terraform-provider-ec+pull-request.yml
+++ b/.ci/jobs/elastic+terraform-provider-ec+pull-request.yml
@@ -11,7 +11,7 @@
             org-list:
                 - elastic
             allow-whitelist-orgs-as-admins: true
-            cancel-builds-on-update: true
+            cancel-builds-on-update: false
             status-context: acceptance
     pipeline-scm:
         scm:


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Sets `cancel-builds-on-update` to `false` on the job definition to avoid
leaving dangling resources when builds are cancelled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoid leaving costly dangling resources.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
