### PR TITLE
test: Move NewResourceData function to utility package

### DIFF
--- a/ec/ecdatasource/deploymentdatasource/datasource_test.go
+++ b/ec/ecdatasource/deploymentdatasource/datasource_test.go
@@ -25,15 +25,18 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_modelToState(t *testing.T) {
 	deploymentSchemaArg := schema.TestResourceDataRaw(t, newSchema(), nil)
 	deploymentSchemaArg.SetId(mock.ValidClusterID)
 
-	wantDeployment := newResourceData(t, resDataParams{
+	wantDeployment := util.NewResourceData(t, util.ResDataParams{
 		ID:        mock.ValidClusterID,
 		Resources: newSampleDeployment(),
+		Schema:    newSchema(),
 	})
 
 	type args struct {
@@ -109,18 +112,6 @@ func Test_modelToState(t *testing.T) {
 			assert.Equal(t, tt.want.State().Attributes, tt.args.d.State().Attributes)
 		})
 	}
-}
-
-type resDataParams struct {
-	Resources map[string]interface{}
-	ID        string
-}
-
-func newResourceData(t *testing.T, params resDataParams) *schema.ResourceData {
-	raw := schema.TestResourceDataRaw(t, DataSource().Schema, params.Resources)
-	raw.SetId(params.ID)
-
-	return raw
 }
 
 func newSampleDeployment() map[string]interface{} {

--- a/ec/ecdatasource/deploymentsdatasource/datasource_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/datasource_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_modelToState(t *testing.T) {
@@ -33,9 +35,10 @@ func Test_modelToState(t *testing.T) {
 	_ = deploymentsSchemaArg.Set("healthy", "true")
 	_ = deploymentsSchemaArg.Set("deployment_template_id", "azure-compute-optimized")
 
-	wantDeployments := newResourceData(t, resDataParams{
+	wantDeployments := util.NewResourceData(t, util.ResDataParams{
 		ID:        "myID",
 		Resources: newSampleDeployments(),
+		Schema:    newSchema(),
 	})
 
 	type args struct {
@@ -112,18 +115,6 @@ func Test_modelToState(t *testing.T) {
 			assert.Equal(t, tt.want.State().Attributes, tt.args.d.State().Attributes)
 		})
 	}
-}
-
-type resDataParams struct {
-	Resources map[string]interface{}
-	ID        string
-}
-
-func newResourceData(t *testing.T, params resDataParams) *schema.ResourceData {
-	raw := schema.TestResourceDataRaw(t, DataSource().Schema, params.Resources)
-	raw.SetId(params.ID)
-
-	return raw
 }
 
 func newSampleDeployments() map[string]interface{} {

--- a/ec/ecdatasource/deploymentsdatasource/expanders_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders_test.go
@@ -25,16 +25,20 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_expandFilters(t *testing.T) {
-	deploymentsDS := newResourceData(t, resDataParams{
+	deploymentsDS := util.NewResourceData(t, util.ResDataParams{
 		ID:        "myID",
 		Resources: newSampleFilters(),
+		Schema:    newSchema(),
 	})
-	invalidDS := newResourceData(t, resDataParams{
+	invalidDS := util.NewResourceData(t, util.ResDataParams{
 		ID:        "myID",
 		Resources: newInvalidFilters(),
+		Schema:    newSchema(),
 	})
 	type args struct {
 		d *schema.ResourceData

--- a/ec/ecdatasource/stackdatasource/datasource_test.go
+++ b/ec/ecdatasource/stackdatasource/datasource_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_modelToState(t *testing.T) {
@@ -35,9 +37,10 @@ func Test_modelToState(t *testing.T) {
 	_ = deploymentSchemaArg.Set("region", "us-east-1")
 	_ = deploymentSchemaArg.Set("version_regex", "latest")
 
-	wantDeployment := newResourceData(t, resDataParams{
+	wantDeployment := util.NewResourceData(t, util.ResDataParams{
 		ID:        "someid",
 		Resources: newSampleStack(),
+		Schema:    newSchema(),
 	})
 
 	type args struct {
@@ -124,18 +127,6 @@ func Test_modelToState(t *testing.T) {
 			assert.Equal(t, tt.want.State().Attributes, tt.args.d.State().Attributes)
 		})
 	}
-}
-
-type resDataParams struct {
-	Resources map[string]interface{}
-	ID        string
-}
-
-func newResourceData(t *testing.T, params resDataParams) *schema.ResourceData {
-	raw := schema.TestResourceDataRaw(t, DataSource().Schema, params.Resources)
-	raw.SetId(params.ID)
-
-	return raw
 }
 
 func newSampleStack() map[string]interface{} {

--- a/ec/ecresource/deploymentresource/expanders_test.go
+++ b/ec/ecresource/deploymentresource/expanders_test.go
@@ -25,12 +25,15 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_createResourceToModel(t *testing.T) {
-	deploymentRD := newResourceData(t, resDataParams{
+	deploymentRD := util.NewResourceData(t, util.ResDataParams{
 		ID:        mock.ValidClusterID,
 		Resources: newSampleDeployment(),
+		Schema:    newSchema(),
 	})
 	type args struct {
 		d *schema.ResourceData
@@ -189,9 +192,10 @@ func Test_createResourceToModel(t *testing.T) {
 }
 
 func Test_updateResourceToModel(t *testing.T) {
-	deploymentRD := newResourceData(t, resDataParams{
+	deploymentRD := util.NewResourceData(t, util.ResDataParams{
 		ID:        mock.ValidClusterID,
 		Resources: newSampleDeployment(),
+		Schema:    newSchema(),
 	})
 	type args struct {
 		d *schema.ResourceData

--- a/ec/ecresource/deploymentresource/flatteners_test.go
+++ b/ec/ecresource/deploymentresource/flatteners_test.go
@@ -26,15 +26,18 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_modelToState(t *testing.T) {
 	deploymentSchemaArg := schema.TestResourceDataRaw(t, newSchema(), nil)
 	deploymentSchemaArg.SetId(mock.ValidClusterID)
 
-	wantDeployment := newResourceData(t, resDataParams{
+	wantDeployment := util.NewResourceData(t, util.ResDataParams{
 		ID:        mock.ValidClusterID,
 		Resources: newSampleDeployment(),
+		Schema:    newSchema(),
 	})
 
 	type args struct {
@@ -334,9 +337,10 @@ func Test_getDeploymentTemplateID(t *testing.T) {
 }
 
 func Test_parseCredentials(t *testing.T) {
-	deploymentRD := newResourceData(t, resDataParams{
+	deploymentRD := util.NewResourceData(t, util.ResDataParams{
 		ID:        mock.ValidClusterID,
 		Resources: newSampleDeployment(),
+		Schema:    newSchema(),
 	})
 
 	rawData := newSampleDeployment()
@@ -344,9 +348,10 @@ func Test_parseCredentials(t *testing.T) {
 	rawData["elasticsearch_password"] = "my-password"
 	rawData["apm_secret_token"] = "some-secret-token"
 
-	wantDeploymentRD := newResourceData(t, resDataParams{
+	wantDeploymentRD := util.NewResourceData(t, util.ResDataParams{
 		ID:        mock.ValidClusterID,
 		Resources: rawData,
+		Schema:    newSchema(),
 	})
 
 	type args struct {
@@ -376,9 +381,10 @@ func Test_parseCredentials(t *testing.T) {
 		{
 			name: "when no credentials are passed, it doesn't overwrite them",
 			args: args{
-				d: newResourceData(t, resDataParams{
+				d: util.NewResourceData(t, util.ResDataParams{
 					ID:        mock.ValidClusterID,
 					Resources: rawData,
+					Schema:    newSchema(),
 				}),
 				resources: []*models.DeploymentResource{
 					{},

--- a/ec/ecresource/deploymentresource/testutils.go
+++ b/ec/ecresource/deploymentresource/testutils.go
@@ -18,23 +18,8 @@
 package deploymentresource
 
 import (
-	"testing"
-
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-type resDataParams struct {
-	Resources map[string]interface{}
-	ID        string
-}
-
-func newResourceData(t *testing.T, params resDataParams) *schema.ResourceData {
-	raw := schema.TestResourceDataRaw(t, Resource().Schema, params.Resources)
-	raw.SetId(params.ID)
-
-	return raw
-}
 
 func newSampleDeployment() map[string]interface{} {
 	return map[string]interface{}{

--- a/ec/ecresource/deploymentresource/update_test.go
+++ b/ec/ecresource/deploymentresource/update_test.go
@@ -23,28 +23,34 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_hasDeploymentChange(t *testing.T) {
-	unchanged := Resource().Data(newResourceData(t, resDataParams{
+	unchanged := Resource().Data(util.NewResourceData(t, util.ResDataParams{
 		ID:        mock.ValidClusterID,
+		Schema:    newSchema(),
 		Resources: newSampleDeployment(),
 	}).State())
 
-	changesToTrafficFilter := newResourceData(t, resDataParams{
-		ID: mock.ValidClusterID,
+	changesToTrafficFilter := util.NewResourceData(t, util.ResDataParams{
+		ID:     mock.ValidClusterID,
+		Schema: newSchema(),
 		Resources: map[string]interface{}{
 			"traffic_filter": []interface{}{"1.1.1.1"},
 		},
 	})
 
-	changesToName := newResourceData(t, resDataParams{
+	changesToName := util.NewResourceData(t, util.ResDataParams{
 		ID:        mock.ValidClusterID,
+		Schema:    newSchema(),
 		Resources: map[string]interface{}{"name": "some name"},
 	})
 
-	changesToRegion := newResourceData(t, resDataParams{
-		ID: mock.ValidClusterID,
+	changesToRegion := util.NewResourceData(t, util.ResDataParams{
+		ID:     mock.ValidClusterID,
+		Schema: newSchema(),
 		Resources: map[string]interface{}{
 			"name":   "some name",
 			"region": "some-region",

--- a/ec/ecresource/trafficfilterassocresource/expanders_test.go
+++ b/ec/ecresource/trafficfilterassocresource/expanders_test.go
@@ -24,12 +24,15 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_expand(t *testing.T) {
-	rd := newResourceData(t, resDataParams{
+	rd := util.NewResourceData(t, util.ResDataParams{
 		Resources: newSampleTrafficFilterAssociation(),
 		ID:        "123451",
+		Schema:    newSchema(),
 	})
 	type args struct {
 		d *schema.ResourceData

--- a/ec/ecresource/trafficfilterassocresource/flatteners_test.go
+++ b/ec/ecresource/trafficfilterassocresource/flatteners_test.go
@@ -25,17 +25,21 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_flatten(t *testing.T) {
-	rd := newResourceData(t, resDataParams{
+	rd := util.NewResourceData(t, util.ResDataParams{
 		Resources: newSampleTrafficFilterAssociation(),
 		ID:        "123451",
+		Schema:    newSchema(),
 	})
 
-	wantNotFoundRd := newResourceData(t, resDataParams{
+	wantNotFoundRd := util.NewResourceData(t, util.ResDataParams{
 		Resources: newSampleTrafficFilterAssociation(),
 		ID:        "123451",
+		Schema:    newSchema(),
 	})
 
 	_ = wantNotFoundRd.Set("deployment_id", "")

--- a/ec/ecresource/trafficfilterresource/expanders_test.go
+++ b/ec/ecresource/trafficfilterresource/expanders_test.go
@@ -24,12 +24,15 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_expandModel(t *testing.T) {
-	trafficFilterRD := newResourceData(t, resDataParams{
+	trafficFilterRD := util.NewResourceData(t, util.ResDataParams{
 		ID:        "some-random-id",
 		Resources: newSampleTrafficFilter(),
+		Schema:    newSchema(),
 	})
 	type args struct {
 		d *schema.ResourceData

--- a/ec/ecresource/trafficfilterresource/flatteners_test.go
+++ b/ec/ecresource/trafficfilterresource/flatteners_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func Test_modelToState(t *testing.T) {
@@ -42,9 +44,10 @@ func Test_modelToState(t *testing.T) {
 		},
 	}
 
-	wantTrafficFilter := newResourceData(t, resDataParams{
+	wantTrafficFilter := util.NewResourceData(t, util.ResDataParams{
 		ID:        "some-random-id",
 		Resources: newSampleTrafficFilter(),
+		Schema:    newSchema(),
 	})
 	type args struct {
 		d   *schema.ResourceData

--- a/ec/ecresource/trafficfilterresource/testutils.go
+++ b/ec/ecresource/trafficfilterresource/testutils.go
@@ -17,24 +17,6 @@
 
 package trafficfilterresource
 
-import (
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-)
-
-type resDataParams struct {
-	Resources map[string]interface{}
-	ID        string
-}
-
-func newResourceData(t *testing.T, params resDataParams) *schema.ResourceData {
-	raw := schema.TestResourceDataRaw(t, newSchema(), params.Resources)
-	raw.SetId(params.ID)
-
-	return raw
-}
-
 func newSampleTrafficFilter() map[string]interface{} {
 	return map[string]interface{}{
 		"name":               "my traffic filter",

--- a/ec/internal/util/testutils.go
+++ b/ec/internal/util/testutils.go
@@ -15,17 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package trafficfilterassocresource
+package util
 
 import (
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var mockTrafficFilterID = "420b7b540dfc967a7a649c18e2fce4e4"
+// ResDataParams holds the raw configuration for NewResourceData to consume
+type ResDataParams struct {
+	ID        string
+	Resources map[string]interface{}
+	Schema    map[string]*schema.Schema
+}
 
-func newSampleTrafficFilterAssociation() map[string]interface{} {
-	return map[string]interface{}{
-		"deployment_id":     mock.ValidClusterID,
-		"traffic_filter_id": mockTrafficFilterID,
-	}
+// NewResourceData creates a ResourceData from a raw configuration map and schema.
+func NewResourceData(t *testing.T, params ResDataParams) *schema.ResourceData {
+	rd := schema.TestResourceDataRaw(t, params.Schema, params.Resources)
+	rd.SetId(params.ID)
+
+	return rd
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
The `NewResourceData` function and its corresponding `ResDataParams`
struct were being copy pasted to every package. This has won the function
it's place in the `util` package to be reused in all tests.

## How Has This Been Tested?
`make unit`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] All new and existing tests passed
