### PR TITLE
ec_resource: Fix overwritten elasticsearch config

### DIFF
--- a/ec/acc/deployment_hotwarm_test.go
+++ b/ec/acc/deployment_hotwarm_test.go
@@ -1,0 +1,99 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// This test case takes that on a hot/warm "ec_deployment", a select number of
+// topology settings can be changed without affecting the underlying Deployment
+// Template.
+func TestAccDeployment_hotwarm(t *testing.T) {
+	resName := "ec_deployment.hotwarm"
+	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	startCfg := "testdata/deployment_hotwarm_1.tf"
+	secondCfg := "testdata/deployment_hotwarm_2.tf"
+	cfg := testAccDeploymentResourceBasic(t, startCfg, randomName, region, deploymentVersion)
+	secondConfigCfg := testAccDeploymentResourceBasic(t, secondCfg, randomName, region, deploymentVersion)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create a Hot / Warm deployment with the default settings.
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "2"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.1.instance_configuration_id"),
+					// Hot Warm defaults to 4g.
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.memory_per_node", "4g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.memory_per_node", "4g"),
+
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", "false"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "2"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.node_type_data", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.node_type_ingest", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.node_type_master", "false"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.node_type_ml", "false"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.zone_count", "2"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "0"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+				),
+			},
+			{
+				// Change the Elasticsearch toplogy size and node count.
+				Config: secondConfigCfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Changes.
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.memory_per_node", "1g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.memory_per_node", "2g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.zone_count", "1"),
+
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "2"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.1.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", "false"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.node_type_data", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.node_type_ingest", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.node_type_master", "false"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.1.node_type_ml", "false"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "0"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/ec/acc/testdata/deployment_hotwarm_1.tf
+++ b/ec/acc/testdata/deployment_hotwarm_1.tf
@@ -1,0 +1,10 @@
+resource "ec_deployment" "hotwarm" {
+  name    = "%s"
+  region  = "%s"
+  version = "%s"
+
+  # TODO: Make this template ID dependent on the region.
+  deployment_template_id = "aws-hot-warm-v2"
+
+  elasticsearch {}
+}

--- a/ec/acc/testdata/deployment_hotwarm_2.tf
+++ b/ec/acc/testdata/deployment_hotwarm_2.tf
@@ -1,0 +1,21 @@
+resource "ec_deployment" "hotwarm" {
+  name    = "%s"
+  region  = "%s"
+  version = "%s"
+
+  # TODO: Make this template ID dependent on the region.
+  deployment_template_id = "aws-hot-warm-v2"
+
+  elasticsearch {
+    topology {
+      instance_configuration_id = "aws.data.highio.i3"
+      zone_count                = 1
+      memory_per_node           = "1g"
+    }
+    topology {
+      instance_configuration_id = "aws.data.highstorage.d2"
+      zone_count                = 1
+      memory_per_node           = "2g"
+    }
+  }
+}


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
This patch fixes a bug where the topology.ElasticsearchConfig setting
was being overridden when some topology settings were being set, since
there was a reassignment back to `elem.Elasticsearch`.

The change now takes in the existing ElasticsearchConfig and sets what
needs to be overwritten instead of creating a new object and reassigning
the result back to the property, which was creating this issue.

It is unlikely that the same situation occurs in the other deployment
resources, but it might be good to change the other resources functions
use the same signature.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #111 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, and added an acceptance test case too.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
