### PR TITLE
config: Add verbose_ credentials and file setting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -111,3 +111,9 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 * `verbose` - (Optional) When set to true, it'll write a "requests.json" file in the folder
   where terraform is executed with all outgoing HTTP requests and responses. Defaults to "false".
+
+* `verbose_credentials` - (Optional) When set with `verbose`, the contents of the Authorization
+header will not be redacted. Defaults to `"false"`.
+
+* `verbose_file` - (Optional) Sets the file where the verbose request / response http flow will
+be written to. Defaults to `"request.log"`.

--- a/ec/provider.go
+++ b/ec/provider.go
@@ -82,20 +82,18 @@ func newSchema() map[string]*schema.Schema {
 			),
 		},
 		"apikey": {
-			Description:   apikeyDesc,
-			Type:          schema.TypeString,
-			Optional:      true,
-			Sensitive:     true,
-			ConflictsWith: []string{"username", "password"},
+			Description: apikeyDesc,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
 			DefaultFunc: schema.MultiEnvDefaultFunc(
 				[]string{"EC_API_KEY"}, "",
 			),
 		},
 		"username": {
-			Description:   usernameDesc,
-			Type:          schema.TypeString,
-			Optional:      true,
-			ConflictsWith: []string{"apikey"},
+			Description: usernameDesc,
+			Type:        schema.TypeString,
+			Optional:    true,
 			DefaultFunc: schema.MultiEnvDefaultFunc(
 				[]string{"EC_USER", "EC_USERNAME"}, "",
 			),

--- a/ec/provider_config_test.go
+++ b/ec/provider_config_test.go
@@ -1,0 +1,360 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ec
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/auth"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+)
+
+func Test_verboseSettings(t *testing.T) {
+	f, err := ioutil.TempFile("", "request")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	type args struct {
+		name       string
+		verbose    bool
+		redactAuth bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want api.VerboseSettings
+		err  error
+	}{
+		{
+			name: "creates verbose settings when verbose = true",
+			args: args{
+				name:       f.Name(),
+				verbose:    true,
+				redactAuth: true,
+			},
+			want: api.VerboseSettings{
+				Verbose:    true,
+				RedactAuth: true,
+			},
+		},
+		{
+			name: "creates verbose settings when verbose = true, but without redacting auth",
+			args: args{
+				name:    f.Name(),
+				verbose: true,
+			},
+			want: api.VerboseSettings{
+				Verbose: true,
+			},
+		},
+		{
+			name: "skips creating verboose settings when verbose = false",
+			args: args{
+				name:       f.Name(),
+				verbose:    false,
+				redactAuth: true,
+			},
+			want: api.VerboseSettings{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := verboseSettings(tt.args.name, tt.args.verbose, tt.args.redactAuth)
+			assert.Equal(t, tt.err, err)
+			if tt.args.verbose {
+				assert.NotNil(t, got.Device)
+				got.Device = nil
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_newAPIConfig(t *testing.T) {
+	defaultCfg := util.NewResourceData(t, util.ResDataParams{
+		ID:        "whocares",
+		Schema:    newSchema(),
+		Resources: map[string]interface{}{},
+	})
+	invalidTimeoutCfg := util.NewResourceData(t, util.ResDataParams{
+		ID:     "whocares",
+		Schema: newSchema(),
+		Resources: map[string]interface{}{
+			"timeout": "invalid",
+		},
+	})
+
+	apiKeyCfg := util.NewResourceData(t, util.ResDataParams{
+		ID:     "whocares",
+		Schema: newSchema(),
+		Resources: map[string]interface{}{
+			"apikey": "blih",
+		},
+	})
+	apiKeyObj := auth.APIKey("blih")
+
+	userPassCfg := util.NewResourceData(t, util.ResDataParams{
+		ID:     "whocares",
+		Schema: newSchema(),
+		Resources: map[string]interface{}{
+			"username": "my-user",
+			"password": "my-pass",
+		},
+	})
+	userPassObj := auth.UserLogin{
+		Username: "my-user",
+		Password: "my-pass",
+		Holder:   new(auth.GenericHolder),
+	}
+
+	insecureCfg := util.NewResourceData(t, util.ResDataParams{
+		ID:     "whocares",
+		Schema: newSchema(),
+		Resources: map[string]interface{}{
+			"apikey":   "blih",
+			"insecure": true,
+		},
+	})
+
+	verboseCfg := util.NewResourceData(t, util.ResDataParams{
+		ID:     "whocares",
+		Schema: newSchema(),
+		Resources: map[string]interface{}{
+			"apikey":  "blih",
+			"verbose": true,
+		},
+	})
+	defer func() {
+		os.Remove("request.log")
+	}()
+
+	customFile, err := ioutil.TempFile("", "request-custom-verbose")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		customFile.Close()
+		os.Remove(customFile.Name())
+	}()
+	verboseCustomFileCfg := util.NewResourceData(t, util.ResDataParams{
+		ID:     "whocares",
+		Schema: newSchema(),
+		Resources: map[string]interface{}{
+			"apikey":       "blih",
+			"verbose":      true,
+			"verbose_file": customFile.Name(),
+		},
+	})
+	verboseAndCredsCustomFileCfg := util.NewResourceData(t, util.ResDataParams{
+		ID:     "whocares",
+		Schema: newSchema(),
+		Resources: map[string]interface{}{
+			"apikey":              "blih",
+			"verbose":             true,
+			"verbose_file":        customFile.Name(),
+			"verbose_credentials": true,
+		},
+	})
+	invalidPath := filepath.Join("a", "b", "c", "d", "e", "f", "g", "h", "invalid!")
+	verboseInvalidFileCfg := util.NewResourceData(t, util.ResDataParams{
+		ID:     "whocares",
+		Schema: newSchema(),
+		Resources: map[string]interface{}{
+			"apikey":              "blih",
+			"verbose":             true,
+			"verbose_file":        invalidPath,
+			"verbose_credentials": true,
+		},
+	})
+	type args struct {
+		d *schema.ResourceData
+	}
+	tests := []struct {
+		name         string
+		args         args
+		want         api.Config
+		wantFileName string
+		err          error
+	}{
+		{
+			name: "default config returns with authwriter error",
+			args: args{d: defaultCfg},
+			err: multierror.NewPrefixed("authwriter",
+				errors.New("one of apikey or username and password must be specified"),
+			),
+		},
+		{
+			name: "default config with  invalid timeout returns with authwriter error",
+			args: args{d: invalidTimeoutCfg},
+			err:  errors.New(`time: invalid duration "invalid"`),
+		},
+		{
+			name: "custom config with apikey auth succeeds",
+			args: args{d: apiKeyCfg},
+			want: api.Config{
+				UserAgent:   fmt.Sprintf(providerUserAgentFmt, Version, api.DefaultUserAgent),
+				ErrorDevice: os.Stdout,
+				Host:        api.ESSEndpoint,
+				AuthWriter:  &apiKeyObj,
+				Client:      &http.Client{},
+				Timeout:     time.Minute,
+				Retries:     2,
+			},
+		},
+		{
+			name: "custom config with username/password auth succeeds",
+			args: args{d: userPassCfg},
+			want: api.Config{
+				UserAgent:   fmt.Sprintf(providerUserAgentFmt, Version, api.DefaultUserAgent),
+				ErrorDevice: os.Stdout,
+				Host:        api.ESSEndpoint,
+				AuthWriter:  &userPassObj,
+				Client:      &http.Client{},
+				Timeout:     time.Minute,
+				Retries:     2,
+			},
+		},
+		{
+			name: "custom config with insecure succeeds",
+			args: args{d: insecureCfg},
+			want: api.Config{
+				UserAgent:     fmt.Sprintf(providerUserAgentFmt, Version, api.DefaultUserAgent),
+				ErrorDevice:   os.Stdout,
+				Host:          api.ESSEndpoint,
+				AuthWriter:    &apiKeyObj,
+				Client:        &http.Client{},
+				Timeout:       time.Minute,
+				Retries:       2,
+				SkipTLSVerify: true,
+			},
+		},
+		{
+			name: "custom config with insecure succeeds",
+			args: args{d: insecureCfg},
+			want: api.Config{
+				UserAgent:     fmt.Sprintf(providerUserAgentFmt, Version, api.DefaultUserAgent),
+				ErrorDevice:   os.Stdout,
+				Host:          api.ESSEndpoint,
+				AuthWriter:    &apiKeyObj,
+				Client:        &http.Client{},
+				Timeout:       time.Minute,
+				Retries:       2,
+				SkipTLSVerify: true,
+			},
+		},
+		{
+			name: "custom config with verbose (default file) succeeds",
+			args: args{d: verboseCfg},
+			want: api.Config{
+				UserAgent:   fmt.Sprintf(providerUserAgentFmt, Version, api.DefaultUserAgent),
+				ErrorDevice: os.Stdout,
+				Host:        api.ESSEndpoint,
+				AuthWriter:  &apiKeyObj,
+				Client:      &http.Client{},
+				Timeout:     time.Minute,
+				Retries:     2,
+				VerboseSettings: api.VerboseSettings{
+					Verbose:    true,
+					RedactAuth: true,
+				},
+			},
+			wantFileName: "request.log",
+		},
+		{
+			name: "custom config with verbose (custom file) succeeds",
+			args: args{d: verboseCustomFileCfg},
+			want: api.Config{
+				UserAgent:   fmt.Sprintf(providerUserAgentFmt, Version, api.DefaultUserAgent),
+				ErrorDevice: os.Stdout,
+				Host:        api.ESSEndpoint,
+				AuthWriter:  &apiKeyObj,
+				Client:      &http.Client{},
+				Timeout:     time.Minute,
+				Retries:     2,
+				VerboseSettings: api.VerboseSettings{
+					Verbose:    true,
+					RedactAuth: true,
+				},
+			},
+			wantFileName: filepath.Base(customFile.Name()),
+		},
+		{
+			name: "custom config with verbose and verbose_credentials (custom file) succeeds",
+			args: args{d: verboseAndCredsCustomFileCfg},
+			want: api.Config{
+				UserAgent:   fmt.Sprintf(providerUserAgentFmt, Version, api.DefaultUserAgent),
+				ErrorDevice: os.Stdout,
+				Host:        api.ESSEndpoint,
+				AuthWriter:  &apiKeyObj,
+				Client:      &http.Client{},
+				Timeout:     time.Minute,
+				Retries:     2,
+				VerboseSettings: api.VerboseSettings{
+					Verbose:    true,
+					RedactAuth: false,
+				},
+			},
+			wantFileName: filepath.Base(customFile.Name()),
+		},
+		{
+			name: "custom config with verbose and verbose_credentials (invalid file) fails ",
+			args: args{d: verboseInvalidFileCfg},
+			err: fmt.Errorf(`failed creating verbose file "%s": %w`,
+				invalidPath,
+				&os.PathError{
+					Op:   "open",
+					Path: invalidPath,
+					Err:  syscall.ENOENT,
+				},
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newAPIConfig(tt.args.d)
+			assert.Equal(t, tt.err, err)
+
+			if got.Verbose && err == nil {
+				assert.NotNil(t, got.Device)
+				if f, ok := got.Device.(*os.File); ok {
+					assert.Equal(t, tt.wantFileName, filepath.Base(f.Name()))
+				}
+				got.Device = nil
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch has two kinds of changes, user facing and a small refactoring
to allow the creation flow of `api.Config` to be unit tested.

User facing:

- By default, the Authorization header contents will now be redacted.
- Adds a new `verbose_credentials` boolean which allows users to dump
  the raw Authorization header in the log file.
- Adds a new `verbose_file` string which allows users to control the
  file where the request log is written to (defaults to `request.log`).
- Fixes a bug where the default timeout wasn't properly set to `1m`.
- Updates the `index.md` file.

Refactoring:

- Moves the provider schema to its own function to make easy to create
  *schema.ResourceData instances from it.
- `verboseSettings` wasn't returning an error on `os.Create` which just
  failed silently, this wasn't ideal since if users want debug to be
  enabled but the file path is incorrect, an error should be returned.
- Adds unit tests covering all code paths.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #110 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit & manually through the examples.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
