### PR TITLE
acceptance: Improve ec_deployments datasource query test

### DIFF
--- a/ec/acc/datasource_deployment_basic_test.go
+++ b/ec/acc/datasource_deployment_basic_test.go
@@ -33,6 +33,7 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	depCfg := "testdata/datasource_deployment_basic.tf"
 	cfg := testAccDeploymentDatasourceBasic(t, depCfg, randomName, region, deploymentVersion)
+	var namePrefix = randomName[:22]
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -109,7 +110,7 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 				Config:             cfg,
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(depsDatasourceName, "name_prefix", "terraform_acc_"),
+					resource.TestCheckResourceAttr(depsDatasourceName, "name_prefix", namePrefix),
 					resource.TestCheckResourceAttr(depsDatasourceName, "deployment_template_id", "aws-compute-optimized-v2"),
 
 					// Deployment resources

--- a/ec/acc/testdata/datasource_deployment_basic.tf
+++ b/ec/acc/testdata/datasource_deployment_basic.tf
@@ -54,7 +54,7 @@ data "ec_deployment" "success" {
 }
 
 data "ec_deployments" "query" {
-  name_prefix            = "terraform_acc_"
+  name_prefix            = substr(ec_deployment.basic_datasource.name, 0, 22) 
   deployment_template_id = "aws-compute-optimized-v2"
 
   elasticsearch {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
`name_prefix` is now unique enough, so that if there happen to be any 
dangling resources the tests will consistently pass.

## Related Issues
Closes: https://github.com/elastic/terraform-provider-ec/issues/116

## How Has This Been Tested?
By running the tests while another deployment with the `test_acc_`
prefix existed.

```console
$ make testacc TEST_NAME=TestAccDatasourceDeployment_basic
-> Running terraform acceptance tests...
=== RUN   TestAccDatasourceDeployment_basic
=== PAUSE TestAccDatasourceDeployment_basic
=== CONT  TestAccDatasourceDeployment_basic
--- PASS: TestAccDatasourceDeployment_basic (391.60s)
PASS
ok  	github.com/elastic/terraform-provider-ec/ec/acc	392.717s
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
