### PR TITLE
docs: Add note on importing legacy deployments

### DIFF
--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -225,7 +225,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-~> **Note on legacy (pre-slider) deployments** If your deployment was created prior to the addition of Sliders in both ECE or ESS, and has not been migrated over to use Sliders, importing it is not supported and will result in erroneous behavior.
+~> **Note on legacy (pre-slider) deployments** If your deployment was created prior to the addition of sliders in both ECE or ESS, and has not been migrated to use sliders, importing it is not supported and will result in erroneous behavior.
 
 Deployments can be imported using the `id`, e.g.
 

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -225,6 +225,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
+~> **Note on legacy (pre-slider) deployments** If your deployment was created prior to the addition of Sliders in both ECE or ESS, and has not been migrated over to use Sliders, importing it is not supported and will result in erroneous behavior.
+
 Deployments can be imported using the `id`, e.g.
 
 ```


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a warning note on the `ec_deployment` resource about importing pre-
Slider deployments.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Part of #10
Action item from #125 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Doesn't make them work, but at least there's a note about it

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation
