### PR TITLE
config: Reduce timeout to 40s

### DIFF
--- a/ec/provider.go
+++ b/ec/provider.go
@@ -19,6 +19,7 @@ package ec
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -49,6 +50,11 @@ var (
 	passwordDesc = fmt.Sprint("Password to use for API authentication. ", eceOnlyText, ".")
 
 	validURLSchemes = []string{"http", "https"}
+
+	// defaultTimeout used for all outgoing HTTP requests, keeping it low-ish
+	// since any requests which timeout due to network factors are retried
+	// automatically by the SDK 2 times.
+	defaultTimeout = 40 * time.Second
 )
 
 // Provider returns a schema.Provider.
@@ -122,7 +128,7 @@ func newSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			DefaultFunc: schema.MultiEnvDefaultFunc(
-				[]string{"EC_TIMEOUT"}, "1m",
+				[]string{"EC_TIMEOUT"}, defaultTimeout.String(),
 			),
 		},
 		"verbose": {

--- a/ec/provider_config_test.go
+++ b/ec/provider_config_test.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/auth"
@@ -103,6 +102,19 @@ func Test_verboseSettings(t *testing.T) {
 }
 
 func Test_newAPIConfig(t *testing.T) {
+	// This is necessary to avoid any EC_API_KEY which might be set to cause
+	// test flakyness.
+	if k := os.Getenv("EC_API_KEY"); k != "" {
+		if err := os.Unsetenv("EC_API_KEY"); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := os.Setenv("EC_API_KEY", k); err != nil {
+				t.Fatal(err)
+			}
+		}()
+	}
+
 	defaultCfg := util.NewResourceData(t, util.ResDataParams{
 		ID:        "whocares",
 		Schema:    newSchema(),
@@ -229,7 +241,7 @@ func Test_newAPIConfig(t *testing.T) {
 				Host:        api.ESSEndpoint,
 				AuthWriter:  &apiKeyObj,
 				Client:      &http.Client{},
-				Timeout:     time.Minute,
+				Timeout:     defaultTimeout,
 				Retries:     2,
 			},
 		},
@@ -242,7 +254,7 @@ func Test_newAPIConfig(t *testing.T) {
 				Host:        api.ESSEndpoint,
 				AuthWriter:  &userPassObj,
 				Client:      &http.Client{},
-				Timeout:     time.Minute,
+				Timeout:     defaultTimeout,
 				Retries:     2,
 			},
 		},
@@ -255,7 +267,7 @@ func Test_newAPIConfig(t *testing.T) {
 				Host:          api.ESSEndpoint,
 				AuthWriter:    &apiKeyObj,
 				Client:        &http.Client{},
-				Timeout:       time.Minute,
+				Timeout:       defaultTimeout,
 				Retries:       2,
 				SkipTLSVerify: true,
 			},
@@ -269,7 +281,7 @@ func Test_newAPIConfig(t *testing.T) {
 				Host:          api.ESSEndpoint,
 				AuthWriter:    &apiKeyObj,
 				Client:        &http.Client{},
-				Timeout:       time.Minute,
+				Timeout:       defaultTimeout,
 				Retries:       2,
 				SkipTLSVerify: true,
 			},
@@ -283,7 +295,7 @@ func Test_newAPIConfig(t *testing.T) {
 				Host:        api.ESSEndpoint,
 				AuthWriter:  &apiKeyObj,
 				Client:      &http.Client{},
-				Timeout:     time.Minute,
+				Timeout:     defaultTimeout,
 				Retries:     2,
 				VerboseSettings: api.VerboseSettings{
 					Verbose:    true,
@@ -301,7 +313,7 @@ func Test_newAPIConfig(t *testing.T) {
 				Host:        api.ESSEndpoint,
 				AuthWriter:  &apiKeyObj,
 				Client:      &http.Client{},
-				Timeout:     time.Minute,
+				Timeout:     defaultTimeout,
 				Retries:     2,
 				VerboseSettings: api.VerboseSettings{
 					Verbose:    true,
@@ -319,7 +331,7 @@ func Test_newAPIConfig(t *testing.T) {
 				Host:        api.ESSEndpoint,
 				AuthWriter:  &apiKeyObj,
 				Client:      &http.Client{},
-				Timeout:     time.Minute,
+				Timeout:     defaultTimeout,
 				Retries:     2,
 				VerboseSettings: api.VerboseSettings{
 					Verbose:    true,

--- a/ec/provider_config_test.go
+++ b/ec/provider_config_test.go
@@ -102,18 +102,7 @@ func Test_verboseSettings(t *testing.T) {
 }
 
 func Test_newAPIConfig(t *testing.T) {
-	// This is necessary to avoid any EC_API_KEY which might be set to cause
-	// test flakyness.
-	if k := os.Getenv("EC_API_KEY"); k != "" {
-		if err := os.Unsetenv("EC_API_KEY"); err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			if err := os.Setenv("EC_API_KEY", k); err != nil {
-				t.Fatal(err)
-			}
-		}()
-	}
+	defer unsetECAPIKey(t)()
 
 	defaultCfg := util.NewResourceData(t, util.ResDataParams{
 		ID:        "whocares",
@@ -369,4 +358,21 @@ func Test_newAPIConfig(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func unsetECAPIKey(t *testing.T) func() {
+	t.Helper()
+	// This is necessary to avoid any EC_API_KEY which might be set to cause
+	// test flakyness.
+	if k := os.Getenv("EC_API_KEY"); k != "" {
+		if err := os.Unsetenv("EC_API_KEY"); err != nil {
+			t.Fatal(err)
+		}
+		return func() {
+			if err := os.Setenv("EC_API_KEY", k); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	return func() {}
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Reduce the timeout to `40s` from `1m` since any potential client network
instability needn't take 1m to resolve and is likely that a retry might
make the request succeed when retried.

Still `40s` is a reasonable timeout time for most requests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Retries should take care of timed out requests and `1m` timeout seems excessive for the the timeouts that are most likely to be cause by client network issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
running `make testacc`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [X] Refactoring (improves code quality but has no user-facing effect)
