### PR TITLE
terraform: Bump to 0.13.x and strip install suffix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: "0.12.29"
+        terraform_version: "0.13.x"
 
     - name: Cache Go Modules
       uses: actions/cache@v1

--- a/build/Makefile.build
+++ b/build/Makefile.build
@@ -1,6 +1,8 @@
 BINARY_LOCATION ?= bin/$(BINARY)
 PLUGIN_LOCATION ?= ~/.terraform.d/plugins/
-PLUGIN_0.13 ?= registry.terraform.io/elastic/ec/$(VERSION)/$(shell uname -s|tr '[:upper:]' '[:lower:]')_amd64/terraform-provider-ec_v$(VERSION)
+# Removes any of "-suffix" the version might have
+STRIPPED_V = $(shell echo $${VERSION%%-*})
+PLUGIN_0.13 = registry.terraform.io/elastic/ec/$(STRIPPED_V)/$(shell uname -s|tr '[:upper:]' '[:lower:]')_amd64/terraform-provider-ec_v$(STRIPPED_V)
 
 ### Build targets
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This PR updates both the terraform version to the latest `0.13.x` and
also removes the `-<prefix>` that the VERSION variable might contain.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
testing no longer cumbersome with `0.13.x`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
