### PR TITLE
misc: Documentation ownership for cloud writers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # These owners will be the default owners for everything in
 # the repository.
 *       @elastic/cloud-delivery
+docs/   @alaudazzi @nrichers @elastic/cloud-delivery


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Changes `CODEOWNERS` file to include cloud writers as co-owners of
the `docs/` directory.
