### PR TITLE
acceptance: Remove acceptance build tag

### DIFF
--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -27,7 +27,7 @@ tests: unit
 ## Runs the Terraform acceptance tests. Use TEST_NAME, TESTARGS and TEST_COUNT to control execution
 testacc:
 	@ echo "-> Running terraform acceptance tests..."
-	@ TF_ACC=1 go test $(TEST_ACC) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m -run $(TEST_NAME) -tags=acceptance
+	@ TF_ACC=1 go test $(TEST_ACC) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m -run $(TEST_NAME)
 
 .PHONY: sweep
 ## Destroys any dangling infrastructure created by the acceptance tests (terraform_acc_ prefix).

--- a/ec/acc/acc_prereq.go
+++ b/ec/acc/acc_prereq.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (
@@ -65,5 +63,11 @@ func testAccPreCheck(t *testing.T) {
 
 	if apikey != "" && (username != "" || password != "") {
 		t.Fatal("Only one of API Key or Username / Password can be specified to execute acceptance tests")
+	}
+}
+
+func requiresAPIConn(t *testing.T) {
+	if os.Getenv("TF_ACC") != "1" {
+		t.Skip()
 	}
 }

--- a/ec/acc/acc_prereq.go
+++ b/ec/acc/acc_prereq.go
@@ -66,6 +66,9 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+// requiresAPIConn should be called in functions which would be executed by the
+// Go testing framework and require external HTTP access, said functions should
+// call this one to avoid the tests errorring because of failing prequisites.
 func requiresAPIConn(t *testing.T) {
 	if os.Getenv("TF_ACC") != "1" {
 		t.Skip()

--- a/ec/acc/datasource_deployment_basic_test.go
+++ b/ec/acc/datasource_deployment_basic_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (
@@ -135,6 +133,8 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 }
 
 func fixtureAccDeploymentDatasourceBasic(t *testing.T, fileName, name, region, depTpl string) string {
+	t.Helper()
+
 	deploymentTpl := setDefaultTemplate(region, depTpl)
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {

--- a/ec/acc/datasource_stack_test.go
+++ b/ec/acc/datasource_stack_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (
@@ -71,6 +69,8 @@ func TestAccDatasourceStack_regex(t *testing.T) {
 }
 
 func fixtureAccStackDataSource(t *testing.T, fileName, region string) string {
+	t.Helper()
+
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)

--- a/ec/acc/deployment_basic_defaults_test.go
+++ b/ec/acc/deployment_basic_defaults_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (
@@ -170,8 +168,9 @@ func TestAccDeployment_basic_defaults(t *testing.T) {
 }
 
 func fixtureAccDeploymentResourceBasicDefaults(t *testing.T, fileName, name, region, depTpl string) string {
-	deploymentTpl := setDefaultTemplate(region, depTpl)
+	t.Helper()
 
+	deploymentTpl := setDefaultTemplate(region, depTpl)
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)

--- a/ec/acc/deployment_basic_test.go
+++ b/ec/acc/deployment_basic_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (
@@ -63,24 +61,18 @@ func TestAccDeployment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "0"),
 				),
 			},
-			// Ensure that no diff is generated.
-			{Config: cfg, PlanOnly: true},
 			{
 				Config: cfgWithTrafficFilter,
 				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "1"),
 				),
 			},
-			// Ensure that no diff is generated.
-			{Config: cfgWithTrafficFilter, PlanOnly: true},
 			{
 				Config: cfgWithTrafficFilterUpdate,
 				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "1"),
 				),
 			},
-			// Ensure that no diff is generated.
-			{Config: cfgWithTrafficFilterUpdate, PlanOnly: true},
 			// Remove traffic filter.
 			{
 				Config: cfg,
@@ -92,7 +84,6 @@ func TestAccDeployment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "apm.0.topology.0.config.0.debug_enabled", "false"),
 				),
 			},
-			{Config: cfg, PlanOnly: true},
 			{
 				Config: topologyConfigCfg,
 				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
@@ -109,8 +100,6 @@ func TestAccDeployment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "enterprise_search.0.topology.0.config.0.user_settings_yaml", "ent_search.login_assistance_message: somemessage"),
 				),
 			},
-			// Ensure that no diff is generated.
-			{Config: topologyConfigCfg, PlanOnly: true},
 			{
 				Config: topConfigCfg,
 				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
@@ -127,8 +116,6 @@ func TestAccDeployment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "enterprise_search.0.topology.0.config.#", "0"),
 				),
 			},
-			// Ensure that no diff is generated.
-			{Config: topConfigCfg, PlanOnly: true},
 			{
 				Config: cfg,
 				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
@@ -143,8 +130,7 @@ func TestAccDeployment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "enterprise_search.0.topology.0.config.#", "0"),
 				),
 			},
-			// Ensure that no diff is generated.
-			{Config: cfg, PlanOnly: true},
+			// Import resource without complex ID
 			{
 				ResourceName:            resName,
 				ImportState:             true,
@@ -156,8 +142,10 @@ func TestAccDeployment_basic(t *testing.T) {
 }
 
 func fixtureAccDeploymentResourceBasic(t *testing.T, fileName, name, region, depTpl string) string {
-	deploymentTpl := setDefaultTemplate(region, depTpl)
+	t.Helper()
+	requiresAPIConn(t)
 
+	deploymentTpl := setDefaultTemplate(region, depTpl)
 	esIC, kibanaIC, apmIC, essIC, err := setInstanceConfigurations(deploymentTpl)
 	if err != nil {
 		t.Fatal(err)
@@ -173,8 +161,9 @@ func fixtureAccDeploymentResourceBasic(t *testing.T, fileName, name, region, dep
 }
 
 func fixtureAccDeploymentResourceBasicWithTF(t *testing.T, fileName, name, region, depTpl string) string {
-	deploymentTpl := setDefaultTemplate(region, depTpl)
+	t.Helper()
 
+	deploymentTpl := setDefaultTemplate(region, depTpl)
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)

--- a/ec/acc/deployment_ccs_test.go
+++ b/ec/acc/deployment_ccs_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (

--- a/ec/acc/deployment_checks_test.go
+++ b/ec/acc/deployment_checks_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (
@@ -39,6 +37,7 @@ func testAccCheckDeploymentExists(name string) resource.TestCheckFunc {
 		if saved.Primary.ID == "" {
 			return fmt.Errorf("no deployment id is set")
 		}
+
 		client, err := newAPI()
 		if err != nil {
 			return err

--- a/ec/acc/deployment_config_test.go
+++ b/ec/acc/deployment_config_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (

--- a/ec/acc/deployment_destroy_test.go
+++ b/ec/acc/deployment_destroy_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (

--- a/ec/acc/deployment_hotwarm_test.go
+++ b/ec/acc/deployment_hotwarm_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (
@@ -107,8 +105,10 @@ func TestAccDeployment_hotwarm(t *testing.T) {
 }
 
 func fixtureAccDeploymentResourceBasicHW(t *testing.T, fileName, name, region, depTpl string) string {
-	deploymentTpl := setDefaultTemplate(region, depTpl)
+	t.Helper()
+	requiresAPIConn(t)
 
+	deploymentTpl := setDefaultTemplate(region, depTpl)
 	esIC, esIC2, err := setInstanceConfigurationsHW(deploymentTpl)
 	if err != nil {
 		t.Fatal(err)

--- a/ec/acc/deployment_sweep_test.go
+++ b/ec/acc/deployment_sweep_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (

--- a/ec/acc/deployment_traffic_filter_association_test.go
+++ b/ec/acc/deployment_traffic_filter_association_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (
@@ -75,8 +73,9 @@ func TestAccDeploymentTrafficFilterAssociation_basic(t *testing.T) {
 }
 
 func fixtureAccDeploymentTrafficFilterResourceAssociationBasic(t *testing.T, fileName, name, region, depTpl string) string {
-	deploymentTpl := setDefaultTemplate(region, depTpl)
+	t.Helper()
 
+	deploymentTpl := setDefaultTemplate(region, depTpl)
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)

--- a/ec/acc/deployment_traffic_filter_checks_test.go
+++ b/ec/acc/deployment_traffic_filter_checks_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (

--- a/ec/acc/deployment_traffic_filter_destroy_test.go
+++ b/ec/acc/deployment_traffic_filter_destroy_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (

--- a/ec/acc/deployment_traffic_filter_sweep_test.go
+++ b/ec/acc/deployment_traffic_filter_sweep_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (

--- a/ec/acc/deployment_traffic_filter_test.go
+++ b/ec/acc/deployment_traffic_filter_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (
@@ -75,6 +73,7 @@ func TestAccDeploymentTrafficFilter_basic(t *testing.T) {
 }
 
 func fixtureAccDeploymentTrafficFilterResourceBasic(t *testing.T, fileName, name, region string) string {
+	t.Helper()
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)

--- a/ec/acc/sweep_test.go
+++ b/ec/acc/sweep_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build acceptance
-
 package acc
 
 import (

--- a/ec/ecresource/deploymentresource/resource.go
+++ b/ec/ecresource/deploymentresource/resource.go
@@ -35,7 +35,10 @@ func Resource() *schema.Resource {
 
 		Description: "Elastic Cloud Deployment resource",
 		Importer: &schema.ResourceImporter{
-			StateContext: importFunc,
+			// It might be desired to provide the ability to import a deployment
+			// specifying key:value pairs of secrets to populate as part of the
+			// import with an implementation of schema.StateContextFunc.
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/ec/ecresource/deploymentresource/resource.go
+++ b/ec/ecresource/deploymentresource/resource.go
@@ -35,10 +35,7 @@ func Resource() *schema.Resource {
 
 		Description: "Elastic Cloud Deployment resource",
 		Importer: &schema.ResourceImporter{
-			// It might be desired to provide the ability to import a deployment
-			// specifying key:value pairs of secrets to populate as part of the
-			// import with an implementation of schema.StateContextFunc.
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: importFunc,
 		},
 
 		Timeouts: &schema.ResourceTimeout{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Removes the acceptance build tag and instead adds a new function which
calls `t.Skip()` when a function with a `*testing.T` as the first arg
requires external HTTP access, in which case it is skipped, to trigger
this behavior any tests which fall into that category should call
`requiresAPIConn` at the beginning of the function to ensure that we're
not incurring any errors when calling `newAPI()`.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
`acceptance` build tag introduced in #121

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This was bothering me since writing tests was becoming quite cumbersome
due to the go build avoidance on the `+build acceptance` tag.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
