### PR TITLE
ec_deployment: Add observability settings to datasource

### DIFF
--- a/docs/data-sources/ec_deployment.md
+++ b/docs/data-sources/ec_deployment.md
@@ -31,6 +31,11 @@ These will not be available for interpolation.
 * `region` - Region where the deployment can be found.
 * `deployment_template_id` - Deployment Template identifier from where the deployment is created.
 * `traffic_filter` - Traffic Filter block, which contains a list of traffic filter rule identifiers.
+* `observability` Observability settings. Information about logs and metrics shipped to a dedicated deployment.
+  * `observability.#.deployment_id` - Destination deployment ID for the shipped logs and monitoring metrics.
+  * `observability.#.ref_id` - Elasticsearch resource kind ref_id of the destination deployment.
+  * `observability.#.logs` - Defines whether logs are enabled or disabled.
+  * `observability.#.metrics` - Defines whether metrics are enabled or disabled.
 * `elasticsearch` - Instance configuration of the Elasticsearch resource kind.
   * `elasticsearch.#.healthy` - Resource kind health status.
   * `elasticsearch.#.cloud_id` - The encoded Elasticsearch credentials to use in Beats or Logstash, [more information](https://www.elastic.co/guide/en/cloud/current/ec-cloud-id.html).

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -293,6 +293,7 @@ In addition to all arguments above, the following attributes are exported:
 * `enterprise_search.#.topology.#.node_type_connector` - Node type (Connector) for the Enterprise Search Topology element.
 * `enterprise_search.#.topology.#.node_type_worker` - Node type (worker) for the Enterprise Search Topology element.
 * `observability.#.deployment_id` - Destination deployment ID for the shipped logs and monitoring metrics.
+* `observability.#.ref_id` - (Optional) Elasticsearch resource kind ref_id of the destination deployment.
 * `observability.#.logs` - Enables or disables shipping logs (defaults to true).
 * `observability.#.metrics` - Enables or disables shipping metrics (defaults to true).
 

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -47,7 +47,7 @@ resource "ec_deployment" "example_observability" {
   deployment_template_id = "aws-io-optimized-v2"
 
   elasticsearch {}
-  
+
   kibana {}
 
   # Optional observability settings

--- a/ec/acc/datasource_deployment_basic_test.go
+++ b/ec/acc/datasource_deployment_basic_test.go
@@ -31,9 +31,10 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 	datasourceName := "data.ec_deployment.success"
 	depsDatasourceName := "data.ec_deployments.query"
 	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	secondRandomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	depCfg := "testdata/datasource_deployment_basic.tf"
-	cfg := fixtureAccDeploymentDatasourceBasic(t, depCfg, randomName, getRegion(), computeOpTemplate)
-	var namePrefix = randomName[:22]
+	cfg := fixtureAccDeploymentDatasourceBasic(t, depCfg, randomName, secondRandomName, getRegion(), computeOpTemplate)
+	var namePrefix = secondRandomName[:22]
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -132,7 +133,7 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 	})
 }
 
-func fixtureAccDeploymentDatasourceBasic(t *testing.T, fileName, name, region, depTpl string) string {
+func fixtureAccDeploymentDatasourceBasic(t *testing.T, fileName, name, secondName, region, depTpl string) string {
 	t.Helper()
 
 	deploymentTpl := setDefaultTemplate(region, depTpl)
@@ -141,6 +142,6 @@ func fixtureAccDeploymentDatasourceBasic(t *testing.T, fileName, name, region, d
 		t.Fatal(err)
 	}
 	return fmt.Sprintf(string(b),
-		region, name, region, deploymentTpl, name, region, deploymentTpl,
+		region, name, region, deploymentTpl, secondName, region, deploymentTpl, secondName, region, deploymentTpl,
 	)
 }

--- a/ec/acc/testdata/datasource_deployment_basic.tf
+++ b/ec/acc/testdata/datasource_deployment_basic.tf
@@ -3,6 +3,20 @@ data "ec_stack" "latest" {
   region        = "%s"
 }
 
+resource "ec_deployment" "basic_observability" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
+
+  elasticsearch {
+    topology {
+      size = "1g"
+      zone_count = 1
+    }
+  }
+}
+
 resource "ec_deployment" "basic_datasource" {
   name                   = "%s"
   region                 = "%s"
@@ -20,6 +34,10 @@ resource "ec_deployment" "basic_datasource" {
   apm {}
 
   enterprise_search {}
+
+  observability {
+    deployment_id = ec_deployment.basic_observability.id
+  }
 
   traffic_filter = [
     ec_deployment_traffic_filter.default.id,

--- a/ec/acc/testdata/datasource_deployment_basic.tf
+++ b/ec/acc/testdata/datasource_deployment_basic.tf
@@ -11,7 +11,7 @@ resource "ec_deployment" "basic_observability" {
 
   elasticsearch {
     topology {
-      size = "1g"
+      size       = "1g"
       zone_count = 1
     }
   }

--- a/ec/ecdatasource/deploymentdatasource/datasource.go
+++ b/ec/ecdatasource/deploymentdatasource/datasource.go
@@ -104,6 +104,12 @@ func modelToState(d *schema.ResourceData, res *models.DeploymentGetResponse) err
 		}
 	}
 
+	if observability := flattenObservability(res.Settings); observability != nil {
+		if err := d.Set("observability", observability); err != nil {
+			return err
+		}
+	}
+
 	elasticsearchFlattened := flattenElasticsearchResources(res.Resources.Elasticsearch)
 	if err := d.Set("elasticsearch", elasticsearchFlattened); err != nil {
 		return err

--- a/ec/ecdatasource/deploymentdatasource/datasource.go
+++ b/ec/ecdatasource/deploymentdatasource/datasource.go
@@ -104,7 +104,7 @@ func modelToState(d *schema.ResourceData, res *models.DeploymentGetResponse) err
 		}
 	}
 
-	if observability := flattenObservability(res.Settings); observability != nil {
+	if observability := flattenObservability(res.Settings); len(observability) > 0 {
 		if err := d.Set("observability", observability); err != nil {
 			return err
 		}

--- a/ec/ecdatasource/deploymentdatasource/datasource_test.go
+++ b/ec/ecdatasource/deploymentdatasource/datasource_test.go
@@ -58,6 +58,25 @@ func Test_modelToState(t *testing.T) {
 					ID:      &mock.ValidClusterID,
 					Healthy: ec.Bool(true),
 					Name:    ec.String("my_deployment_name"),
+					Settings: &models.DeploymentSettings{
+						TrafficFilterSettings: &models.TrafficFilterSettings{
+							Rulesets: []string{"0.0.0.0/0", "192.168.10.0/24"},
+						},
+						Observability: &models.DeploymentObservabilitySettings{
+							Logging: &models.DeploymentLoggingSettings{
+								Destination: &models.AbsoluteRefID{
+									DeploymentID: &mock.ValidClusterID,
+									RefID:        ec.String("main-elasticsearch"),
+								},
+							},
+							Metrics: &models.DeploymentMetricsSettings{
+								Destination: &models.AbsoluteRefID{
+									DeploymentID: &mock.ValidClusterID,
+									RefID:        ec.String("main-elasticsearch"),
+								},
+							},
+						},
+					},
 					Resources: &models.DeploymentResources{
 						Elasticsearch: []*models.ElasticsearchResourceInfo{
 							{
@@ -121,6 +140,8 @@ func newSampleDeployment() map[string]interface{} {
 		"deployment_template_id": "aws-io-optimized",
 		"healthy":                true,
 		"region":                 "us-east-1",
+		"traffic_filter":         []interface{}{"0.0.0.0/0", "192.168.10.0/24"},
+		"observability":          []interface{}{newObservabilitySample()},
 		"elasticsearch": []interface{}{map[string]interface{}{
 			"healthy": true,
 		}},
@@ -133,5 +154,14 @@ func newSampleDeployment() map[string]interface{} {
 		"enterprise_search": []interface{}{map[string]interface{}{
 			"healthy": true,
 		}},
+	}
+}
+
+func newObservabilitySample() map[string]interface{} {
+	return map[string]interface{}{
+		"deployment_id": mock.ValidClusterID,
+		"ref_id":        "main-elasticsearch",
+		"logs":          true,
+		"metrics":       true,
 	}
 }

--- a/ec/ecdatasource/deploymentdatasource/flatteners_observability.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_observability.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deploymentdatasource
+
+import "github.com/elastic/cloud-sdk-go/pkg/models"
+
+// flattenObservability parses a deployment's observability settings.
+func flattenObservability(settings *models.DeploymentSettings) []interface{} {
+	if settings == nil || settings.Observability == nil {
+		return nil
+	}
+
+	var m = make(map[string]interface{})
+
+	// We are only accepting a single deployment ID and refID for both logs and metrics.
+	// If either of them is not nil the deployment ID and refID will be filled.
+	if settings.Observability.Metrics != nil {
+		m["deployment_id"] = settings.Observability.Metrics.Destination.DeploymentID
+		m["ref_id"] = settings.Observability.Metrics.Destination.RefID
+		m["metrics"] = true
+	}
+
+	if settings.Observability.Logging != nil {
+		m["deployment_id"] = settings.Observability.Logging.Destination.DeploymentID
+		m["ref_id"] = settings.Observability.Logging.Destination.RefID
+		m["logs"] = true
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	return []interface{}{m}
+}

--- a/ec/ecdatasource/deploymentdatasource/flatteners_observability_test.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_observability_test.go
@@ -1,0 +1,118 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deploymentdatasource
+
+import (
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenObservability(t *testing.T) {
+	type args struct {
+		settings *models.DeploymentSettings
+	}
+	tests := []struct {
+		name string
+		args args
+		want []interface{}
+	}{
+		{
+			name: "flattens no observability settings when empty",
+			args: args{},
+		},
+		{
+			name: "flattens no observability settings when empty",
+			args: args{settings: &models.DeploymentSettings{}},
+		},
+		{
+			name: "flattens no observability settings when empty",
+			args: args{settings: &models.DeploymentSettings{Observability: &models.DeploymentObservabilitySettings{}}},
+		},
+		{
+			name: "flattens observability settings",
+			args: args{settings: &models.DeploymentSettings{
+				Observability: &models.DeploymentObservabilitySettings{
+					Logging: &models.DeploymentLoggingSettings{
+						Destination: &models.AbsoluteRefID{
+							DeploymentID: &mock.ValidClusterID,
+							RefID:        ec.String("main-elasticsearch"),
+						},
+					},
+				},
+			}},
+			want: []interface{}{map[string]interface{}{
+				"deployment_id": &mock.ValidClusterID,
+				"ref_id":        ec.String("main-elasticsearch"),
+				"logs":          true,
+			}},
+		},
+		{
+			name: "flattens observability settings",
+			args: args{settings: &models.DeploymentSettings{
+				Observability: &models.DeploymentObservabilitySettings{
+					Metrics: &models.DeploymentMetricsSettings{
+						Destination: &models.AbsoluteRefID{
+							DeploymentID: &mock.ValidClusterID,
+							RefID:        ec.String("main-elasticsearch"),
+						},
+					},
+				},
+			}},
+			want: []interface{}{map[string]interface{}{
+				"deployment_id": &mock.ValidClusterID,
+				"ref_id":        ec.String("main-elasticsearch"),
+				"metrics":       true,
+			}},
+		},
+		{
+			name: "flattens observability settings",
+			args: args{settings: &models.DeploymentSettings{
+				Observability: &models.DeploymentObservabilitySettings{
+					Logging: &models.DeploymentLoggingSettings{
+						Destination: &models.AbsoluteRefID{
+							DeploymentID: &mock.ValidClusterID,
+							RefID:        ec.String("main-elasticsearch"),
+						},
+					},
+					Metrics: &models.DeploymentMetricsSettings{
+						Destination: &models.AbsoluteRefID{
+							DeploymentID: &mock.ValidClusterID,
+							RefID:        ec.String("main-elasticsearch"),
+						},
+					},
+				},
+			}},
+			want: []interface{}{map[string]interface{}{
+				"deployment_id": &mock.ValidClusterID,
+				"ref_id":        ec.String("main-elasticsearch"),
+				"logs":          true,
+				"metrics":       true,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := flattenObservability(tt.args.settings)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ec/ecdatasource/deploymentdatasource/schema.go
+++ b/ec/ecdatasource/deploymentdatasource/schema.go
@@ -50,6 +50,11 @@ func newSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
+		"observability": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem:     newObservabilitySettings(),
+		},
 
 		// Deployment resources
 		"elasticsearch": {
@@ -71,6 +76,29 @@ func newSchema() map[string]*schema.Schema {
 			Type:     schema.TypeList,
 			Computed: true,
 			Elem:     newEnterpriseSearchResourceInfo(),
+		},
+	}
+}
+
+func newObservabilitySettings() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"deployment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ref_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"logs": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"metrics": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
The new observability block is now read by the `ec_deployment`
datasource as well.

## Related Issues
Closes: https://github.com/elastic/terraform-provider-ec/issues/148

## How Has This Been Tested?
Manually and through acceptance tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
