### PR TITLE
acceptance: Set parallel tests to 4

### DIFF
--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -5,6 +5,7 @@ TEST_COUNT ?= 1
 TESTUNITARGS ?= -timeout 10s -p 4 -race -cover -coverprofile=reports/c.out
 TEST_ACC ?= github.com/elastic/terraform-provider-ec/ec/acc
 TEST_NAME ?= Test
+TEST_ACC_PARALLEL = 4
 
 REPORT_PATH ?= ./reports
 
@@ -24,10 +25,10 @@ unit: _report_path
 tests: unit
 
 .PHONY: testacc
-## Runs the Terraform acceptance tests. Use TEST_NAME, TESTARGS and TEST_COUNT to control execution
+## Runs the Terraform acceptance tests. Use TEST_NAME, TESTARGS, TEST_COUNT and TEST_ACC_PARALLEL to control execution.
 testacc:
 	@ echo "-> Running terraform acceptance tests..."
-	@ TF_ACC=1 go test $(TEST_ACC) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m -run $(TEST_NAME)
+	@ TF_ACC=1 go test $(TEST_ACC) -v -count $(TEST_COUNT) -parallel $(TEST_ACC_PARALLEL) $(TESTARGS) -timeout 120m -run $(TEST_NAME)
 
 .PHONY: sweep
 ## Destroys any dangling infrastructure created by the acceptance tests (terraform_acc_ prefix).

--- a/ec/ecresource/trafficfilterassocresource/resource.go
+++ b/ec/ecresource/trafficfilterassocresource/resource.go
@@ -34,7 +34,7 @@ func Resource() *schema.Resource {
 		DeleteContext: delete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Default: schema.DefaultTimeout(5 * time.Minute),
+			Default: schema.DefaultTimeout(10 * time.Minute),
 		},
 	}
 }

--- a/ec/ecresource/trafficfilterresource/resource.go
+++ b/ec/ecresource/trafficfilterresource/resource.go
@@ -38,7 +38,7 @@ func Resource() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Default: schema.DefaultTimeout(5 * time.Minute),
+			Default: schema.DefaultTimeout(10 * time.Minute),
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/terraform-provider-ec
 go 1.13
 
 require (
-	github.com/elastic/cloud-sdk-go v1.0.1-0.20201021033654-13f03d938751
+	github.com/elastic/cloud-sdk-go v1.0.1-0.20201022043812-171d06d2cd12
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.4
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elastic/cloud-sdk-go v1.0.1-0.20201021033654-13f03d938751 h1:8D4lDhAyg+rILMUFh+MsFP9VfTH+dhiBSTCpGkMmFZM=
-github.com/elastic/cloud-sdk-go v1.0.1-0.20201021033654-13f03d938751/go.mod h1:pQ1irKPT2mEvRL3TZrg0bCNCnuo1+k6wgQEtVxOz9SA=
+github.com/elastic/cloud-sdk-go v1.0.1-0.20201022043812-171d06d2cd12 h1:C559NJ1N1yWrQBFpI0XUbPdi9iTgQm+QArVeoeYE7CY=
+github.com/elastic/cloud-sdk-go v1.0.1-0.20201022043812-171d06d2cd12/go.mod h1:pQ1irKPT2mEvRL3TZrg0bCNCnuo1+k6wgQEtVxOz9SA=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
This change sets the maximum number of tests allowed to run to default
to `4` unless `TEST_ACC_PARALLEL` is set to a different value by the
user.

This avoids resource starvation on test running machines.

Additionally, updates the `cloud-sdk-go` dependency to include the last
change on the client timeouts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
running `make acceptance` while connected to a slow network.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
