### PR TITLE
testacc: Update default -parallel from 4 to 6

### DIFF
--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -5,7 +5,7 @@ TEST_COUNT ?= 1
 TESTUNITARGS ?= -timeout 10s -p 4 -race -cover -coverprofile=reports/c.out
 TEST_ACC ?= github.com/elastic/terraform-provider-ec/ec/acc
 TEST_NAME ?= Test
-TEST_ACC_PARALLEL = 4
+TEST_ACC_PARALLEL = 6
 
 REPORT_PATH ?= ./reports
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Updates the `TEST_ACC_PARALLEL` to `6` to help speed up the acceptance
tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Faster acceptance test runs, but still stable.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
