### PR TITLE
ec_deployment: Stop making use of AsList field in deployment template get calls

### DIFF
--- a/ec/acc/deployment_config_test.go
+++ b/ec/acc/deployment_config_test.go
@@ -107,7 +107,6 @@ func getResources(deploymentTemplate string) (*models.DeploymentCreateResources,
 		API:        client,
 		TemplateID: deploymentTemplate,
 		Region:     getRegion(),
-		AsList:     true,
 	})
 	if err != nil {
 		return nil, err

--- a/ec/ecresource/deploymentresource/expanders.go
+++ b/ec/ecresource/deploymentresource/expanders.go
@@ -40,7 +40,6 @@ func createResourceToModel(d *schema.ResourceData, client *api.API) (*models.Dep
 		API:                        client,
 		TemplateID:                 dtID,
 		Region:                     d.Get("region").(string),
-		AsList:                     true,
 		HideInstanceConfigurations: true,
 	})
 	if err != nil {
@@ -109,7 +108,6 @@ func updateResourceToModel(d *schema.ResourceData, client *api.API) (*models.Dep
 		API:                        client,
 		TemplateID:                 dtID,
 		Region:                     d.Get("region").(string),
-		AsList:                     true,
 		HideInstanceConfigurations: true,
 	})
 	if err != nil {

--- a/ec/ecresource/deploymentresource/expanders_test.go
+++ b/ec/ecresource/deploymentresource/expanders_test.go
@@ -45,11 +45,9 @@ func fileAsResponseBody(t *testing.T, name string) io.ReadCloser {
 	defer f.Close()
 
 	var buf = new(bytes.Buffer)
-	buf.WriteString("[\n")
 	if _, err := io.Copy(buf, f); err != nil {
 		t.Fatal(err)
 	}
-	buf.WriteString("]\n")
 	buf.WriteString("\n")
 
 	return ioutil.NopCloser(buf)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

## Description
As the bug with the `GET deployments/template/{template_id}` endpoint
has been fixed, we no longer need to use the `AsList` field when calling it.

## Motivation and Context
Stay up to date!

## How Has This Been Tested?
With acc tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
