### PR TITLE
ec_deployment: Limit version to 6.6.0 or higher

### DIFF
--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -105,6 +105,9 @@ The following arguments are supported:
 
 * `deployment_template_id` - (Required) Deployment template identifier to create the deployment from. See the [full list](https://www.elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html) of regions and deployment templates available in ESS.
 * `version` - (Required) Elastic Stack version to use for all the deployment resources.
+
+~> Using an Elastic Stack version prior to `6.6.0` is not supported.
+
 * `name` - (Optional) Name of the deployment.
 * `request_id` - (Optional) Request ID to set when you create the deployment. Use it only when previous attempts return an error and `request_id` is returned as part of the error.
 * `elasticsearch` (Required) Elasticsearch cluster definition, can only be specified once. For multi-node Elasticsearch clusters, use multiple `topology` blocks.
@@ -316,6 +319,8 @@ In addition to all the arguments above, the following attributes are exported:
 ## Import
 
 ~> **Note on legacy (pre-slider) deployments** Importing deployments created prior to the addition of sliders in ECE or ESS, without being migrated to use sliders, is not supported.
+
+~> **Note on pre 6.6.0 deployments** Importing deployments with a version lower than `6.6.0` is not supported.
 
 Deployments can be imported using the `id`, for example:
 

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -8,6 +8,8 @@ description: |-
 
 Provides an Elastic Cloud deployment resource, which allows deployments to be created, updated, and deleted.
 
+~> **Note on Elastic Stack versions** Using a version prior to `6.6.0` is not supported.
+
 ~> **Note on traffic filters** If you use `traffic_filter` on an `ec_deployment`, Terraform will manage the full set of traffic rules for the deployment, and treat additional traffic filters as drift. For this reason, `traffic_filter` cannot be mixed with the `ec_deployment_traffic_filter_association` resource for a given deployment.
 
 -> **Note on regions and deployment templates** Before you start, you might want to read about [Elastic Cloud deployments](https://www.elastic.co/guide/en/cloud/current/ec-create-deployment.html) and check the [full list](https://www.elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html) of regions and deployment templates available in Elasticsearch Service (ESS).
@@ -105,9 +107,6 @@ The following arguments are supported:
 
 * `deployment_template_id` - (Required) Deployment template identifier to create the deployment from. See the [full list](https://www.elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html) of regions and deployment templates available in ESS.
 * `version` - (Required) Elastic Stack version to use for all the deployment resources.
-
-~> Using an Elastic Stack version prior to `6.6.0` is not supported.
-
 * `name` - (Optional) Name of the deployment.
 * `request_id` - (Optional) Request ID to set when you create the deployment. Use it only when previous attempts return an error and `request_id` is returned as part of the error.
 * `elasticsearch` (Required) Elasticsearch cluster definition, can only be specified once. For multi-node Elasticsearch clusters, use multiple `topology` blocks.

--- a/ec/ecresource/deploymentresource/import.go
+++ b/ec/ecresource/deploymentresource/import.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deploymentresource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/blang/semver/v4"
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/deputil"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Setting this variable here so that it is parsed at compile time in case
+// any errors are thrown, they are at compile time not when the user runs it.
+var ilmVersion = semver.MustParse("6.6.0")
+
+// imports a deployment limitting the allowed version to 6.6.0 or higher.
+// TODO: It might be desired to provide the ability to import a deployment
+// specifying key:value pairs of secrets to populate as part of the
+// import with an implementation of schema.StateContextFunc.
+func importFunc(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	client := m.(*api.API)
+	res, err := deploymentapi.Get(deploymentapi.GetParams{
+		API:          client,
+		DeploymentID: d.Id(),
+		QueryParams: deputil.QueryParams{
+			ShowPlans: true,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Resources.Elasticsearch) == 0 {
+		return nil, errors.New(
+			"invalid deployment: deployment has no elasticsearch resources",
+		)
+	}
+
+	v, err := semver.New(
+		res.Resources.Elasticsearch[0].Info.PlanInfo.Current.Plan.Elasticsearch.Version,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse deployment version: %w", err)
+	}
+
+	if v.LT(ilmVersion) {
+		return nil, fmt.Errorf(
+			`invalid deployment version "%s": minimum supported version is "%s"`,
+			v.String(), ilmVersion.String(),
+		)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/ec/ecresource/deploymentresource/import_test.go
+++ b/ec/ecresource/deploymentresource/import_test.go
@@ -1,0 +1,228 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deploymentresource
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+)
+
+func Test_importFunc(t *testing.T) {
+	deploymentWithImportableVersion := util.NewResourceData(t, util.ResDataParams{
+		ID:     mock.ValidClusterID,
+		Schema: newSchema(),
+		State: map[string]interface{}{
+			"name":                   "my_deployment_name",
+			"deployment_template_id": "aws-cross-cluster-search-v2",
+			"region":                 "us-east-1",
+			"version":                "7.9.2",
+			"elasticsearch":          []interface{}{map[string]interface{}{}},
+		},
+	})
+	deploymentWithNonImportableVersion := util.NewResourceData(t, util.ResDataParams{
+		ID:     mock.ValidClusterID,
+		Schema: newSchema(),
+		State: map[string]interface{}{
+			"name":                   "my_deployment_name",
+			"deployment_template_id": "aws-cross-cluster-search-v2",
+			"region":                 "us-east-1",
+			"version":                "5.6.1",
+			"elasticsearch":          []interface{}{map[string]interface{}{}},
+		},
+	})
+	deploymentWithNonImportableVersionSix := util.NewResourceData(t, util.ResDataParams{
+		ID:     mock.ValidClusterID,
+		Schema: newSchema(),
+		State: map[string]interface{}{
+			"name":                   "my_deployment_name",
+			"deployment_template_id": "aws-cross-cluster-search-v2",
+			"region":                 "us-east-1",
+			"version":                "6.5.1",
+			"elasticsearch":          []interface{}{map[string]interface{}{}},
+		},
+	})
+	type args struct {
+		ctx context.Context
+		d   *schema.ResourceData
+		m   interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+		err  error
+	}{
+		{
+			name: "succeeds with an importable version",
+			args: args{
+				d: deploymentWithImportableVersion,
+				m: api.NewMock(mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+					Resources: &models.DeploymentResources{Elasticsearch: []*models.ElasticsearchResourceInfo{
+						{
+							Info: &models.ElasticsearchClusterInfo{
+								PlanInfo: &models.ElasticsearchClusterPlansInfo{
+									Current: &models.ElasticsearchClusterPlanInfo{
+										Plan: &models.ElasticsearchClusterPlan{
+											Elasticsearch: &models.ElasticsearchConfiguration{
+												Version: "7.9.2",
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				}))),
+			},
+			want: map[string]string{
+				"id": "320b7b540dfc967a7a649c18e2fce4ed",
+
+				"name":                   "my_deployment_name",
+				"region":                 "us-east-1",
+				"version":                "7.9.2",
+				"deployment_template_id": "aws-cross-cluster-search-v2",
+
+				"elasticsearch.#":                   "1",
+				"elasticsearch.0.cloud_id":          "",
+				"elasticsearch.0.snapshot_source.#": "0",
+				"elasticsearch.0.config.#":          "0",
+				"elasticsearch.0.http_endpoint":     "",
+				"elasticsearch.0.https_endpoint":    "",
+				"elasticsearch.0.ref_id":            "main-elasticsearch",
+				"elasticsearch.0.region":            "",
+				"elasticsearch.0.remote_cluster.#":  "0",
+				"elasticsearch.0.resource_id":       "",
+				"elasticsearch.0.topology.#":        "0",
+				"elasticsearch.0.version":           "",
+			},
+		},
+		{
+			name: "fails with a non importable version (5.6.1)",
+			args: args{
+				d: deploymentWithNonImportableVersion,
+				m: api.NewMock(mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+					Resources: &models.DeploymentResources{Elasticsearch: []*models.ElasticsearchResourceInfo{
+						{
+							Info: &models.ElasticsearchClusterInfo{
+								PlanInfo: &models.ElasticsearchClusterPlansInfo{
+									Current: &models.ElasticsearchClusterPlanInfo{
+										Plan: &models.ElasticsearchClusterPlan{
+											Elasticsearch: &models.ElasticsearchConfiguration{
+												Version: "5.6.1",
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				}))),
+			},
+			err: errors.New(`invalid deployment version "5.6.1": minimum supported version is "6.6.0"`),
+			want: map[string]string{
+				"id": "320b7b540dfc967a7a649c18e2fce4ed",
+
+				"name":                   "my_deployment_name",
+				"region":                 "us-east-1",
+				"version":                "5.6.1",
+				"deployment_template_id": "aws-cross-cluster-search-v2",
+
+				"elasticsearch.#":                   "1",
+				"elasticsearch.0.cloud_id":          "",
+				"elasticsearch.0.snapshot_source.#": "0",
+				"elasticsearch.0.config.#":          "0",
+				"elasticsearch.0.http_endpoint":     "",
+				"elasticsearch.0.https_endpoint":    "",
+				"elasticsearch.0.ref_id":            "main-elasticsearch",
+				"elasticsearch.0.region":            "",
+				"elasticsearch.0.remote_cluster.#":  "0",
+				"elasticsearch.0.resource_id":       "",
+				"elasticsearch.0.topology.#":        "0",
+				"elasticsearch.0.version":           "",
+			},
+		},
+		{
+			name: "fails with a non importable version (6.5.1)",
+			args: args{
+				d: deploymentWithNonImportableVersionSix,
+				m: api.NewMock(mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+					Resources: &models.DeploymentResources{Elasticsearch: []*models.ElasticsearchResourceInfo{
+						{
+							Info: &models.ElasticsearchClusterInfo{
+								PlanInfo: &models.ElasticsearchClusterPlansInfo{
+									Current: &models.ElasticsearchClusterPlanInfo{
+										Plan: &models.ElasticsearchClusterPlan{
+											Elasticsearch: &models.ElasticsearchConfiguration{
+												Version: "6.5.1",
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				}))),
+			},
+			err: errors.New(`invalid deployment version "6.5.1": minimum supported version is "6.6.0"`),
+			want: map[string]string{
+				"id": "320b7b540dfc967a7a649c18e2fce4ed",
+
+				"name":                   "my_deployment_name",
+				"region":                 "us-east-1",
+				"version":                "6.5.1",
+				"deployment_template_id": "aws-cross-cluster-search-v2",
+
+				"elasticsearch.#":                   "1",
+				"elasticsearch.0.cloud_id":          "",
+				"elasticsearch.0.snapshot_source.#": "0",
+				"elasticsearch.0.config.#":          "0",
+				"elasticsearch.0.http_endpoint":     "",
+				"elasticsearch.0.https_endpoint":    "",
+				"elasticsearch.0.ref_id":            "main-elasticsearch",
+				"elasticsearch.0.region":            "",
+				"elasticsearch.0.remote_cluster.#":  "0",
+				"elasticsearch.0.resource_id":       "",
+				"elasticsearch.0.topology.#":        "0",
+				"elasticsearch.0.version":           "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := importFunc(tt.args.ctx, tt.args.d, tt.args.m)
+			if tt.err != nil {
+				if !assert.EqualError(t, err, tt.err.Error()) {
+					t.Error(err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, tt.args.d.State().Attributes)
+		})
+	}
+}

--- a/ec/ecresource/deploymentresource/resource.go
+++ b/ec/ecresource/deploymentresource/resource.go
@@ -35,10 +35,7 @@ func Resource() *schema.Resource {
 
 		Description: "Elastic Cloud Deployment resource",
 		Importer: &schema.ResourceImporter{
-			// It might be desired to provide the ability to import a deployment
-			// specifying key:value pairs of secrets to populate as part of the
-			// import with an implementation of schema.StateContextFunc.
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: importFunc,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/elastic/terraform-provider-ec
 go 1.13
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/elastic/cloud-sdk-go v1.1.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -401,6 +401,7 @@ github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyX
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -588,6 +589,7 @@ go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.mongodb.org/mongo-driver v1.3.0/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.3.4 h1:zs/dKNwX0gYUtzwrN9lLiR15hCO0nDwQj5xXx+vjCdE=
 go.mongodb.org/mongo-driver v1.3.4/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
+go.mongodb.org/mongo-driver v1.4.2 h1:WlnEglfTg/PfPq4WXs2Vkl/5ICC6hoG8+r+LraPmGk4=
 go.mongodb.org/mongo-driver v1.4.2/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a custom import function limiting the imported version to `6.6.0`
or higher. Additionally, always removes the Elasticsearch curation
settings if found.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Superseeds #178 and #167 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually trying to import a `2.4.5` deployment:

```console
$ terraform import ec_deployment.example_minimal 18xxxxx
ec_deployment.example_minimal: Importing from ID "18xxxxx"...

Error: invalid deployment version "2.4.5": minimum supported version is "6.6.0"
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [x] Documentation
