### PR TITLE
Terraform init is required before apply

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,4 +2,4 @@
 
 This directory contains a set of examples that show you how to use Elastic Cloud resources with Terraform. For each example there is a README file with a detailed description.
 
-To run any example, clone the repository. Build the provider using `make install` from the main folder. From within the example's directory, run `terraform init` to initialize Terraform, and `terraform apply` to see if it works.
+To run any example, clone the repository. Build the provider using `make install` from the main folder. From within the example's directory, run `terraform init` to initialize Terraform, and `terraform apply` to apply the changes.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,4 +2,4 @@
 
 This directory contains a set of examples of using various Elastic Cloud resources with Terraform. The examples each have their own README containing more details on what the example does.
 
-To run any example, clone the repository and run `terraform init && terraform apply` within the example's own directory.
+To run any example clone the repository. Build the provider using `make install` from the main folder. From within the example's directory run `terrafrom init` to initialize Terrafrom, and `terraform apply` to see it work.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,4 +2,4 @@
 
 This directory contains a set of examples of using various Elastic Cloud resources with Terraform. The examples each have their own README containing more details on what the example does.
 
-To run any example, clone the repository and run `terraform apply` within the example's own directory.
+To run any example, clone the repository and run `terraform init && terraform apply` within the example's own directory.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,5 +2,4 @@
 
 This directory contains a set of examples that show you how to use Elastic Cloud resources with Terraform. For each example there is a README file with a detailed description.
 
-To run any example clone the repository. Build the provider using `make install` from the main folder. From within the example's directory run `terrafrom init` to initialize Terrafrom, and `terraform apply` to see it work.
-
+To run any example, clone the repository. Build the provider using `make install` from the main folder. From within the example's directory, run `terraform init` to initialize Terraform, and `terraform apply` to see if it works.

--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -5,4 +5,4 @@ The created resources are a single-node Elasticsearch cluster with a Kibana, APM
 
 ## Running the example
 
-run `terraform init && terraform apply` to see it work.
+Build the provider using `make install` from the main folder. From within the example's directory run `terrafrom init` to initialize Terrafrom, and `terraform apply` to see it work.

--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -5,4 +5,4 @@ The created resources are a single-node Elasticsearch cluster with a Kibana, APM
 
 ## Running the example
 
-run `terraform apply` to see it work.
+run `terraform init && terraform apply` to see it work.

--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -5,4 +5,4 @@ The created resources are a single-node Elasticsearch cluster with a Kibana, APM
 
 ## Running the example
 
-Build the provider using `make install` from the main folder. From within the example's directory, run `terraform init` to initialize Terraform, and `terraform apply` to see if it works.
+Build the provider using `make install` from the main folder. From within the example's directory, run `terraform init` to initialize Terraform, and `terraform apply` to apply the changes.

--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -5,4 +5,4 @@ The created resources are a single-node Elasticsearch cluster with a Kibana, APM
 
 ## Running the example
 
-Build the provider using `make install` from the main folder. From within the example's directory run `terrafrom init` to initialize Terrafrom, and `terraform apply` to see it work.
+Build the provider using `make install` from the main folder. From within the example's directory, run `terraform init` to initialize Terraform, and `terraform apply` to see if it works.

--- a/examples/deployment_ccs/README.md
+++ b/examples/deployment_ccs/README.md
@@ -5,4 +5,4 @@ The created resources are: two single node Elasticsearch clusters acting as sour
 
 ## Running the example
 
-run `terraform apply` to see it work.
+run `terraform init && terraform apply` to see it work.

--- a/examples/deployment_ccs/README.md
+++ b/examples/deployment_ccs/README.md
@@ -5,4 +5,4 @@ The created resources are: two single node Elasticsearch clusters acting as sour
 
 ## Running the example
 
-run `terraform init && terraform apply` to see it work.
+Build the provider using `make install` from the main folder. From within the example's directory run `terrafrom init` to initialize Terrafrom, and `terraform apply` to see it work.

--- a/examples/deployment_ccs/README.md
+++ b/examples/deployment_ccs/README.md
@@ -5,4 +5,4 @@ The example creates two single node Elasticsearch clusters acting as sources for
 
 ## Running the example
 
-Build the provider using `make install` from the main folder. From within the example's directory run `terrafrom init` to initialize Terrafrom, and `terraform apply` to see it work.
+Build the provider using `make install` from the main folder. From within the example's directory, run `terraform init` to initialize Terraform, and `terraform apply` to see if it works.

--- a/examples/deployment_ccs/README.md
+++ b/examples/deployment_ccs/README.md
@@ -5,4 +5,4 @@ The example creates two single node Elasticsearch clusters acting as sources for
 
 ## Running the example
 
-Build the provider using `make install` from the main folder. From within the example's directory, run `terraform init` to initialize Terraform, and `terraform apply` to see if it works.
+Build the provider using `make install` from the main folder. From within the example's directory, run `terraform init` to initialize Terraform, and `terraform apply` to apply the changes.


### PR DESCRIPTION
## Description
Just a doco change, noticed when running through examples.

Are these examples supposed to spin up enterprise search as well? Found it confusing when I hit the UI and saw lots of "Getting started with Enterprise Search" text. 


## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation


