### PR TITLE
release: Add goreleaser config and github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+# This GitHub action can publish assets for release when a tag is created.
+# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+#
+# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your 
+# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
+# secret. If you would rather own your own GPG handling, please fork this action
+# or use an alternative one for key handling.
+#
+# You will need to pass the `--batch` flag to `gpg` in your signing step 
+# in `goreleaser` to indicate this is being used in a non-interactive mode.
+#
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      -
+        name: Import GPG key
+        id: import_gpg
+        uses: paultyng/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ examples/*/*.tfstate.backup
 .vscode
 .idea
 .apikey
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,62 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+before:
+  hooks:
+    # this is just an example and not a requirement for provider building/publishing
+    - go mod tidy
+builds:
+- env:
+    # goreleaser does not work with CGO, it could also complicate
+    # usage by users in CI/CD systems like Terraform Cloud where
+    # they are unable to install libraries.
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+  goos:
+    - freebsd
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
+  ignore:
+    - goos: darwin
+      goarch: '386'
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      # if you are using this is a GitHub action or some other automated pipeline, you 
+      # need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  # If you want to manually examine the release before its live, uncomment this line:
+  # draft: true
+changelog:
+  skip: true
+snapshot:
+  # Allows you to change the name of the generated snapshot
+  #
+  # Note that some pipes require this to be semantic version compliant (nfpm,
+  # for example).
+  #
+  # Default is `{{ .Tag }}-SNAPSHOT-{{.ShortCommit}}`.
+  name_template: '{{ replace .Tag "v" ""}}-SNAPSHOT-{{.ShortCommit}}'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 export GO111MODULE ?= on
-export VERSION := 0.1.0-dev
+export VERSION := 0.1.0-beta-dev
 export BINARY := terraform-provider-ec
 export GOBIN = $(shell pwd)/bin
 
@@ -14,3 +14,4 @@ include build/Makefile.deps
 include build/Makefile.tools
 include build/Makefile.lint
 include build/Makefile.format
+include build/Makefile.release

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ terraform {
 
   required_providers {
     ec = {
-      source = "elastic/ec"
+      source  = "elastic/ec"
+      version = "0.1.0-beta"
     }
   }
 }

--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -7,6 +7,7 @@ VERSION_GOBIN:=v0.0.13
 VERSION_GOLINT:=v0.0.0-20191125180803-fdd1cda4f05f
 VERSION_GOLICENSER:=v0.3.0
 VERSION_GOLANGCILINT:=v1.26.0
+VERSION_GORELEASER:=v0.149.0
 
 deps: $(GOBIN)/gobin $(GOBIN)/golint $(GOBIN)/go-licenser $(GOBIN)/golangci-lint
 
@@ -48,3 +49,11 @@ $(VERSION_DIR)/.version-golangci-lint-$(VERSION_GOLANGCILINT): | $(VERSION_DIR)
 $(GOBIN)/golangci-lint: $(VERSION_DIR)/.version-golangci-lint-$(VERSION_GOLANGCILINT) | $(GOBIN)
 	@ echo "-> Installing golangci-lint..."
 	@ curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) $(VERSION_GOLANGCILINT)
+
+$(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER): | $(VERSION_DIR)
+	@ rm -f $(VERSION_DIR)/.version-goreleaser-*
+	@ echo $(VERSION_GORELEASER) > $(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER)
+
+$(GOBIN)/goreleaser: $(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER) | $(GOBIN)
+	@ echo "-> Installing goreleaser..."
+	@ curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh| sh -s -- -b $(GOBIN) $(VERSION_GORELEASER)

--- a/build/Makefile.release
+++ b/build/Makefile.release
@@ -1,0 +1,30 @@
+OWNER = elastic
+REPO = terraform-provider-ec
+
+### Release targets
+
+## Tags the current commit as the release commit with $(VERSION) (minus -dev).
+tag:
+	@ git fetch
+ifeq ($(shell git tag -l $(STRIPPED_V)),$(STRIPPED_V))
+	@ echo "-> git tag $(STRIPPED_V) already exists, exiting..."
+	@ exit 1
+endif
+ifeq ($(shell git remote -v | grep $(OWNER)/$(REPO)),)
+	@ echo "-> git remote 'upstream' is not configured, exiting..."
+	@ exit 2
+endif
+	@ echo $(STRIPPED_V)
+	@ exit 1
+	@ $(eval REMOTE = $(shell git remote -v | grep $(OWNER)/$(REPO)| head -1 | awk '{print $$1}'))
+	@ echo "Pushing git tag $(STRIPPED_V) to remote \"$(REMOTE)\"..."
+	@ git tag $(STRIPPED_V)
+	@ git push -u $(REMOTE) $(STRIPPED_V)
+
+## Creates a snapshot build of the terraform provider.
+snapshot: $(GOBIN)/goreleaser
+	@ $(GOBIN)/goreleaser --rm-dist --snapshot --skip-validate
+
+## Releases a new version of the terraform provider with a matching tag.
+release: $(GOBIN)/goreleaser
+	@ $(GOBIN)/goreleaser --rm-dist --skip-validate

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,15 @@ APIs. Use the navigation to the left to read about data sources and resources su
 
 
 ```hcl
+terraform {
+  required_providers {
+    ec = {
+      source  = "elastic/ec"
+      version = "0.1.0-beta"
+    }
+  }
+}
+
 provider "ec" {
   apikey = "my-api-key"
 }

--- a/ec/acc/testdata/deployment_basic_defaults_3.tf
+++ b/ec/acc/testdata/deployment_basic_defaults_3.tf
@@ -11,7 +11,7 @@ resource "ec_deployment" "defaults" {
 
   elasticsearch {
     topology {
-      size = "1g"
+      size             = "1g"
       node_type_ingest = "false"
     }
   }

--- a/ec/version.go
+++ b/ec/version.go
@@ -18,4 +18,4 @@
 package ec
 
 // Version contains the current terraform provider version.
-const Version = "0.1.0-dev"
+const Version = "0.1.0-beta-dev"

--- a/examples/deployment/deployment.tf
+++ b/examples/deployment/deployment.tf
@@ -3,7 +3,8 @@ terraform {
 
   required_providers {
     ec = {
-      source = "elastic/ec"
+      source  = "elastic/ec"
+      version = "0.1.0-beta"
     }
   }
 }

--- a/examples/deployment_ccs/deployment.tf
+++ b/examples/deployment_ccs/deployment.tf
@@ -3,7 +3,8 @@ terraform {
 
   required_providers {
     ec = {
-      source = "elastic/ec"
+      source  = "elastic/ec"
+      version = "0.1.0-beta"
     }
   }
 }

--- a/examples/deployment_ec2_instance/provider.tf
+++ b/examples/deployment_ec2_instance/provider.tf
@@ -3,7 +3,8 @@ terraform {
 
   required_providers {
     ec = {
-      source = "elastic/ec"
+      source  = "elastic/ec"
+      version = "0.1.0-beta"
     }
 
     aws = {

--- a/examples/deployment_with_init/provider.tf
+++ b/examples/deployment_with_init/provider.tf
@@ -3,7 +3,8 @@ terraform {
 
   required_providers {
     ec = {
-      source = "elastic/ec"
+      source  = "elastic/ec"
+      version = "0.1.0-beta"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the goreleaser config and release github action for pushes of `v*`
tags. Adds three new targets: `tag`, `snapshot` and `release`.
The `release` target has been added as a fallback to perform a manual
release in case the GitHub action fails.

Last, it sets the version to `v0.1.0-beta` as agreed with the team.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Part of #44 