### PR TITLE
Add beta header to the Elastic docs

### DIFF
--- a/docs-elastic/page_header.html
+++ b/docs-elastic/page_header.html
@@ -1,0 +1,1 @@
+This functionality is in beta and is subject to change. The design and code are less mature than official GA features and are being provided as-is with no warranties.


### PR DESCRIPTION
This PR adds a beta header into the v0.1.0-beta docs similar to what we have done in the past for other Cloud products, such as ecctl:

![image](https://user-images.githubusercontent.com/15148011/101796741-1a0a1e00-3abe-11eb-85a5-4edd9006ff1b.png)
