### PR TITLE
release: Amend make tag target to use a v prefix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,9 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  github:
+    owner: elastic
+    name: terraform-provider-ec
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:

--- a/build/Makefile.release
+++ b/build/Makefile.release
@@ -1,25 +1,24 @@
 OWNER = elastic
 REPO = terraform-provider-ec
+PREFIXED_V = v$(subst -dev,,$(VERSION))
 
 ### Release targets
 
 ## Tags the current commit as the release commit with $(VERSION) (minus -dev).
 tag:
 	@ git fetch
-ifeq ($(shell git tag -l $(STRIPPED_V)),$(STRIPPED_V))
-	@ echo "-> git tag $(STRIPPED_V) already exists, exiting..."
+ifeq ($(shell git tag -l $(PREFIXED_V)),$(PREFIXED_V))
+	@ echo "-> git tag $(PREFIXED_V) already exists, exiting..."
 	@ exit 1
 endif
 ifeq ($(shell git remote -v | grep $(OWNER)/$(REPO)),)
 	@ echo "-> git remote 'upstream' is not configured, exiting..."
 	@ exit 2
 endif
-	@ echo $(STRIPPED_V)
-	@ exit 1
 	@ $(eval REMOTE = $(shell git remote -v | grep $(OWNER)/$(REPO)| head -1 | awk '{print $$1}'))
-	@ echo "Pushing git tag $(STRIPPED_V) to remote \"$(REMOTE)\"..."
-	@ git tag $(STRIPPED_V)
-	@ git push -u $(REMOTE) $(STRIPPED_V)
+	@ echo "Pushing git tag $(PREFIXED_V) to remote \"$(REMOTE)\"..."
+	@ git tag $(PREFIXED_V)
+	@ git push -u $(REMOTE) $(PREFIXED_V)
 
 ## Creates a snapshot build of the terraform provider.
 snapshot: $(GOBIN)/goreleaser


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes the `make tag` target include a `v` prefix on the tag that is
pushed to GitHub. Additionally, explicitly specifies that the repository
is `elastic/terraform-provider-ec`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By releasing the `v0.1.0-beta` version.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)