### PR TITLE
release: Add Jenkins release job and file

### DIFF
--- a/.ci/.env
+++ b/.ci/.env
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+export GITHUB_TOKEN=$(cat .ci/.github_token)
+export GPG_FINGERPRINT=$(cat .ci/.gpg_fingerprint)

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -15,7 +15,25 @@ endif
 
 .PHONY: clean
 clean: ## Delete credentials
-	@ rm -f .apikey
+	@ rm -f .apikey .gpg_private .gpg_passphrase .github_token .gpg_fingerprint
 
 .apikey:
 	@ VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -field=apikey secret/devops-ci/terraform-provider-ec > .apikey
+
+.gpg_private:
+	@ VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -field=gpg_private secret/devops-ci/terraform-provider-ec  | base64 -d > .gpg_private
+
+.gpg_passphrase:
+	@ VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -field=gpg_passphrase secret/devops-ci/terraform-provider-ec > .gpg_passphrase
+
+.gpg_fingerprint:
+	@ VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -field=gpg_fingerprint secret/devops-ci/terraform-provider-ec > .gpg_fingerprint
+
+.github_token:
+	@ VAULT_TOKEN=$(VAULT_TOKEN) $(vault) read -field=gh_personal_access_token secret/devops-ci/terraform-provider-ec > .github_token
+
+import-gpg-key:
+	@ cat .gpg_passphrase | gpg --import --batch --yes --passphrase-fd 0 .gpg_private
+
+cache-gpg-passphrase:
+	@ cat .gpg_passphrase | gpg --armor --detach-sign --passphrase-fd 0 --pinentry-mode loopback

--- a/.ci/jobs/elastic+terraform-provider-ec+tag.yml
+++ b/.ci/jobs/elastic+terraform-provider-ec+tag.yml
@@ -1,0 +1,14 @@
+---
+- job:
+    name: elastic+terraform-provider-ec+release
+    display-name: elastic / terraform-provider-ec - release job
+    description: Releases job
+    project-type: pipeline
+    triggers:
+        - github
+    pipeline-scm:
+        script-path: .ci/pipelines/release.Jenkinsfile
+        scm:
+            - git:
+                branches:
+                    - refs/tags/v*

--- a/.ci/pipelines/release.Jenkinsfile
+++ b/.ci/pipelines/release.Jenkinsfile
@@ -1,0 +1,41 @@
+#!/usr/bin/env groovy
+
+node('docker') {
+    String DOCKER_IMAGE = "golang:1.15"
+    String APP_PATH = "/go/src/github.com/elastic/terraform-provider-ec"
+
+    stage('Checkout from GitHub') {
+	    checkout scm
+    }
+    withCredentials([
+        string(credentialsId: 'vault-addr', variable: 'VAULT_ADDR'),
+        string(credentialsId: 'vault-secret-id', variable: 'VAULT_SECRET_ID'),
+        string(credentialsId: 'vault-role-id', variable: 'VAULT_ROLE_ID')
+    ]) {
+        stage("Get secrets from vault") {
+            withEnv(["VAULT_SECRET_ID=${VAULT_SECRET_ID}", "VAULT_ROLE_ID=${VAULT_ROLE_ID}", "VAULT_ADDR=${VAULT_ADDR}"]) {
+                sh 'make -C .ci .gpg_private .gpg_passphrase .github_token'
+            }
+        }
+    }
+    docker.image("${DOCKER_IMAGE}").inside("-u root:root -v ${pwd()}:${APP_PATH} -w ${APP_PATH}") {
+        try {
+            stage("Download dependencies") {
+                sh 'make vendor'
+            }
+            stage("Import gpg key") {
+                sh 'make -C .ci import-gpg-key'
+            }
+            stage("Cache GPG key and release the binaries") {
+                sh '. .ci/.env; make -C .ci cache-gpg-passphrase; make release'
+            }
+        } catch (Exception err) {
+            throw err
+        } finally {
+            stage("Clean up") {
+                sh 'make -C .ci clean'
+                sh 'rm -rf dist bin'
+            }
+        }
+    }
+}

--- a/.ci/pipelines/release.Jenkinsfile
+++ b/.ci/pipelines/release.Jenkinsfile
@@ -14,7 +14,7 @@ node('docker') {
     ]) {
         stage("Get secrets from vault") {
             withEnv(["VAULT_SECRET_ID=${VAULT_SECRET_ID}", "VAULT_ROLE_ID=${VAULT_ROLE_ID}", "VAULT_ADDR=${VAULT_ADDR}"]) {
-                sh 'make -C .ci .gpg_private .gpg_passphrase .github_token'
+                sh 'make -C .ci .gpg_private .gpg_passphrase .github_token .gpg_fingerprint'
             }
         }
     }

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ examples/*/*.tfstate.backup
 .idea
 .apikey
 dist
+.ci/.gpg_*
+.ci/.github_*

--- a/build/Makefile.release
+++ b/build/Makefile.release
@@ -28,3 +28,7 @@ snapshot: $(GOBIN)/goreleaser
 ## Releases a new version of the terraform provider with a matching tag.
 release: $(GOBIN)/goreleaser
 	@ $(GOBIN)/goreleaser --rm-dist --skip-validate
+
+## Builds a new version of the terraform provider with a matching tag without publishing it.
+release-no-publish: $(GOBIN)/goreleaser
+	@ $(GOBIN)/goreleaser --rm-dist --skip-validate --skip-publish


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new Jenkins job which should be triggered every time a `v*`  tag
is pushed to the repository.

The job will import the GPG private key, export the required environment
variables and run the `goreleaser` binary to trigger a new release. The
GPG key passphrase will be cached within GPG so `goreleaser` can sign
the release without interactively asking for the passphrase.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Part of #201 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually in a docker container:

```
# Log into vault with your credentials and export a `VAULT_TOKEN` to the environment.
$ make -C .ci .gpg_private .gpg_passphrase .github_token .gpg_fingerprint
$ docker run -ti --rm -v $(pwd):/go/src/github.com/elastic/terraform-provider-ec -w /go/src/github.com/elastic/terraform-provider-ec golang:1.15 bash
$ make vendor
$ make -C .ci import-gpg-key
$ . .ci/.env; make -C .ci cache-gpg-passphrase; make release-no-publish
```