### PR TITLE
testacc: Sweep all existing 1h+ old deployments

### DIFF
--- a/ec/acc/deployment_sweep_test_test.go
+++ b/ec/acc/deployment_sweep_test_test.go
@@ -1,0 +1,61 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_staleDeployment(t *testing.T) {
+	type args struct {
+		lastModified time.Time
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "hour old deployment is not stale",
+			args: args{
+				lastModified: time.Now().Add(-time.Minute * 59),
+			},
+		},
+		{
+			name: "10m old deployment is not stale",
+			args: args{
+				lastModified: time.Now().Add(-time.Minute * 10),
+			},
+		},
+		{
+			name: "hour old+ deployment is stale",
+			args: args{
+				lastModified: time.Now().Add(-time.Minute * 62),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := staleDeployment(tt.args.lastModified); got != tt.want {
+				t.Errorf("staleDeployment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Changes the deployment sweep logic to be time based, deleting all the
deployments that are 1h or older since their last change.
The change will remove any deployments found in the account with the
`terraform_acc_` prefix, without checking the status of any of the
deployment resources.

This results in a proper cleanup of the dev account since the account
had a lot of dangling resources which were costing costing us a few $.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Being able to run `make sweep` non disruptively in a nightly basis.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running `make sweep` without disrupting ongoing acceptance tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)