### PR TITLE
Fix in timeout option documentation & markup docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,10 +75,10 @@ They can either be hardcoded in the provider `.tf` configuration (not recommende
 
 ```hcl
 provider "ec" {
-  # ECE installation endpoint
+  # ECE installation endpoint
   endpoint = "https://my.ece-environment.corp"
 
-  # If the ECE installation has a self-signed certificate
+  # If the ECE installation has a self-signed certificate
   # you must set insecure to true.
   insecure = true
 
@@ -111,7 +111,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   Useful when targeting installation with self-signed certificates. Not recommended when
   targeting ESS.
 
-* `insecure` - (Optional) This setting allows the user to set a custom timeout in the
+* `timeout` - (Optional) This setting allows the user to set a custom timeout in the
   individual HTTP request level. Defaults to 1 minute (`"1m"`), but might need to be tweaked if timeouts
   are experienced.
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

## Description
This commit addresses 
* the erroneous reference of `insecure`, where `timeout` was intended
* spacing that renders as `&nbsp;`, in favour of space (UTF8 0x20)

## How Has This Been Tested?
Visual inspection in a GH markup editor.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
