### PR TITLE
testacc: limit maximum concurrent tests to 4

### DIFF
--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -5,7 +5,7 @@ TEST_COUNT ?= 1
 TESTUNITARGS ?= -timeout 10s -p 4 -race -cover -coverprofile=reports/c.out
 TEST_ACC ?= github.com/elastic/terraform-provider-ec/ec/acc
 TEST_NAME ?= Test
-TEST_ACC_PARALLEL = 6
+TEST_ACC_PARALLEL = 4
 
 REPORT_PATH ?= ./reports
 

--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -4,7 +4,7 @@ TEST ?= ./...
 TEST_COUNT ?= 1
 TESTUNITARGS ?= -timeout 10s -p 4 -race -cover -coverprofile=reports/c.out
 TEST_ACC ?= github.com/elastic/terraform-provider-ec/ec/acc
-TEST_NAME ?= Test
+TEST_NAME ?= TestAcc
 TEST_ACC_PARALLEL = 4
 
 REPORT_PATH ?= ./reports


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Limits the maximum concurrent acceptance tests to `4` by default.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Part of #210 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reduce the CI load and reducing the amount of capacity used for tests concurrently.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make testacc`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
