### PR TITLE
ec_deployment: Add tags key value map

### DIFF
--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -97,6 +97,27 @@ resource "ec_deployment" "ccs" {
 }
 ```
 
+### With tags
+
+```hcl
+resource "ec_deployment" "with_tags" {
+  # Optional name.
+  name = "my_example_deployment"
+
+  # Mandatory fields
+  region                 = "us-east-1"
+  version                = "7.9.2"
+  deployment_template_id = "aws-io-optimized-v2"
+
+  elasticsearch {}
+
+  tags = {
+    owner     = "elastic cloud"
+    component = "search"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -115,6 +136,7 @@ The following arguments are supported:
 * `enterprise_search` (Optional) Enterprise Search server definition, can only be specified once. For multi-node Enterprise Search deployments, use multiple `topology` blocks.
 * `traffic_filter` (Optional) List of traffic filter rule identifiers that will be applied to the deployment.
 * `observability` (Optional) Observability settings that you can set to ship logs and metrics to a separate deployment.
+* `tags` (Optional) Key value map of arbitrary string tags.
 
 ### Resources
 

--- a/ec/acc/deployment_basic_tags_test.go
+++ b/ec/acc/deployment_basic_tags_test.go
@@ -1,0 +1,143 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// This test case takes ensures that several features of the "ec_deployment"
+// resource are asserted:
+// * Create a deployment with tags.
+// * Remove a tag.
+// * Remove the tag block.
+func TestAccDeployment_basic_tags(t *testing.T) {
+	resName := "ec_deployment.tags"
+	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	startCfg := "testdata/deployment_basic_tags_1.tf"
+	secondCfg := "testdata/deployment_basic_tags_2.tf"
+	thirdCfg := "testdata/deployment_basic_tags_3.tf"
+	fourthCfg := "testdata/deployment_basic_tags_4.tf"
+	cfg := fixtureAccDeploymentResourceBasicDefaults(t, startCfg, randomName, getRegion(), defaultTemplate)
+	secondConfigCfg := fixtureAccDeploymentResourceBasicDefaults(t, secondCfg, randomName, getRegion(), defaultTemplate)
+	thirdConfigCfg := fixtureAccDeploymentResourceBasicDefaults(t, thirdCfg, randomName, getRegion(), defaultTemplate)
+	fourthConfigCfg := fixtureAccDeploymentResourceBasicDefaults(t, fourthCfg, randomName, getRegion(), defaultTemplate)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create a deployment with tags.
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size", "2g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", "false"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "2"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "0"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+
+					// Tags
+					resource.TestCheckResourceAttr(resName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resName, "tags.owner", "elastic"),
+					resource.TestCheckResourceAttr(resName, "tags.cost-center", "rnd"),
+				),
+			},
+			{
+				// Remove a tag.
+				Config: secondConfigCfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size", "2g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", "false"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "2"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "0"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+
+					// Tags
+					resource.TestCheckResourceAttr(resName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resName, "tags.owner", "elastic"),
+				),
+			},
+			{
+				// Remove the tags block.
+				Config: thirdConfigCfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size", "2g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", "false"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "2"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "0"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+
+					// Tags
+					resource.TestCheckResourceAttr(resName, "tags.%", "0"),
+				),
+			},
+			{
+				// Add the tags block with a single tag.
+				Config: fourthConfigCfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size", "2g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", "true"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", "false"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "2"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "0"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+
+					// Tags
+					resource.TestCheckResourceAttr(resName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resName, "tags.new", "tag"),
+				),
+			},
+		},
+	})
+}

--- a/ec/acc/testdata/deployment_basic_tags_1.tf
+++ b/ec/acc/testdata/deployment_basic_tags_1.tf
@@ -1,0 +1,22 @@
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
+
+resource "ec_deployment" "tags" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
+
+  elasticsearch {
+    topology {
+      size = "2g"
+    }
+  }
+
+  tags = {
+    owner       = "elastic"
+    cost-center = "rnd"
+  }
+}

--- a/ec/acc/testdata/deployment_basic_tags_2.tf
+++ b/ec/acc/testdata/deployment_basic_tags_2.tf
@@ -1,0 +1,21 @@
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
+
+resource "ec_deployment" "tags" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
+
+  elasticsearch {
+    topology {
+      size = "2g"
+    }
+  }
+
+  tags = {
+    owner = "elastic"
+  }
+}

--- a/ec/acc/testdata/deployment_basic_tags_3.tf
+++ b/ec/acc/testdata/deployment_basic_tags_3.tf
@@ -1,0 +1,17 @@
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
+
+resource "ec_deployment" "tags" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
+
+  elasticsearch {
+    topology {
+      size = "2g"
+    }
+  }
+}

--- a/ec/acc/testdata/deployment_basic_tags_4.tf
+++ b/ec/acc/testdata/deployment_basic_tags_4.tf
@@ -1,0 +1,21 @@
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
+
+resource "ec_deployment" "tags" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
+
+  elasticsearch {
+    topology {
+      size = "2g"
+    }
+  }
+
+  tags = {
+    new = "tag"
+  }
+}

--- a/ec/ecresource/deploymentresource/expanders_test.go
+++ b/ec/ecresource/deploymentresource/expanders_test.go
@@ -127,6 +127,30 @@ func Test_createResourceToModel(t *testing.T) {
 		},
 	})
 
+	deploymentWithTags := util.NewResourceData(t, util.ResDataParams{
+		ID: mock.ValidClusterID,
+		State: map[string]interface{}{
+			"name":                   "my_deployment_name",
+			"deployment_template_id": "aws-io-optimized-v2",
+			"region":                 "us-east-1",
+			"version":                "7.10.1",
+			"elasticsearch": []interface{}{
+				map[string]interface{}{
+					"topology": []interface{}{map[string]interface{}{
+						"instance_configuration_id": "aws.data.highio.i3",
+						"size":                      "8g",
+					}},
+				},
+			},
+			"tags": map[string]interface{}{
+				"aaa":         "bbb",
+				"owner":       "elastic",
+				"cost-center": "rnd",
+			},
+		},
+		Schema: newSchema(),
+	})
+
 	type args struct {
 		d      *schema.ResourceData
 		client *api.API
@@ -177,6 +201,9 @@ func Test_createResourceToModel(t *testing.T) {
 							},
 						},
 					},
+				},
+				Metadata: &models.DeploymentCreateMetadata{
+					Tags: []*models.MetadataItem{},
 				},
 				Resources: &models.DeploymentCreateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
@@ -306,6 +333,9 @@ func Test_createResourceToModel(t *testing.T) {
 						Rulesets: []string{"0.0.0.0/0", "192.168.10.0/24"},
 					},
 				},
+				Metadata: &models.DeploymentCreateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentCreateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
 						{
@@ -413,6 +443,9 @@ func Test_createResourceToModel(t *testing.T) {
 					TrafficFilterSettings: &models.TrafficFilterSettings{
 						Rulesets: []string{"0.0.0.0/0", "192.168.10.0/24"},
 					},
+				},
+				Metadata: &models.DeploymentCreateMetadata{
+					Tags: []*models.MetadataItem{},
 				},
 				Resources: &models.DeploymentCreateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
@@ -522,6 +555,9 @@ func Test_createResourceToModel(t *testing.T) {
 						Rulesets: []string{"0.0.0.0/0", "192.168.10.0/24"},
 					},
 				},
+				Metadata: &models.DeploymentCreateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentCreateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
 						{
@@ -626,6 +662,9 @@ func Test_createResourceToModel(t *testing.T) {
 			want: &models.DeploymentCreateRequest{
 				Name:     "my_deployment_name",
 				Settings: &models.DeploymentCreateSettings{},
+				Metadata: &models.DeploymentCreateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentCreateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
 						{
@@ -715,6 +754,9 @@ func Test_createResourceToModel(t *testing.T) {
 			want: &models.DeploymentCreateRequest{
 				Name:     "my_deployment_name",
 				Settings: &models.DeploymentCreateSettings{},
+				Metadata: &models.DeploymentCreateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentCreateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
 						{
@@ -761,6 +803,52 @@ func Test_createResourceToModel(t *testing.T) {
 										},
 									},
 								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "parses the resources with tags",
+			args: args{
+				d:      deploymentWithTags,
+				client: api.NewMock(mock.New200Response(ioOptimizedTpl())),
+			},
+			want: &models.DeploymentCreateRequest{
+				Name:     "my_deployment_name",
+				Settings: &models.DeploymentCreateSettings{},
+				Metadata: &models.DeploymentCreateMetadata{Tags: []*models.MetadataItem{
+					{Key: ec.String("aaa"), Value: ec.String("bbb")},
+					{Key: ec.String("cost-center"), Value: ec.String("rnd")},
+					{Key: ec.String("owner"), Value: ec.String("elastic")},
+				}},
+				Resources: &models.DeploymentCreateResources{
+					Elasticsearch: []*models.ElasticsearchPayload{
+						{
+							Region: ec.String("us-east-1"),
+							RefID:  ec.String("main-elasticsearch"),
+							Settings: &models.ElasticsearchClusterSettings{
+								DedicatedMastersThreshold: 6,
+							},
+							Plan: &models.ElasticsearchClusterPlan{
+								Elasticsearch: &models.ElasticsearchConfiguration{},
+								DeploymentTemplate: &models.DeploymentTemplateReference{
+									ID: ec.String("aws-io-optimized-v2"),
+								},
+								ClusterTopology: []*models.ElasticsearchClusterTopologyElement{{
+									ZoneCount:               2,
+									InstanceConfigurationID: "aws.data.highio.i3",
+									Size: &models.TopologySize{
+										Resource: ec.String("memory"),
+										Value:    ec.Int32(8192),
+									},
+									NodeType: &models.ElasticsearchNodeType{
+										Data:   ec.Bool(true),
+										Ingest: ec.Bool(true),
+										Master: ec.Bool(true),
+									},
+								}},
 							},
 						},
 					},
@@ -1000,6 +1088,30 @@ func Test_updateResourceToModel(t *testing.T) {
 		Schema: newSchema(),
 	})
 
+	deploymentWithTags := util.NewResourceData(t, util.ResDataParams{
+		ID: mock.ValidClusterID,
+		State: map[string]interface{}{
+			"name":                   "my_deployment_name",
+			"deployment_template_id": "aws-io-optimized-v2",
+			"region":                 "us-east-1",
+			"version":                "7.10.1",
+			"elasticsearch": []interface{}{
+				map[string]interface{}{
+					"topology": []interface{}{map[string]interface{}{
+						"instance_configuration_id": "aws.data.highio.i3",
+						"size":                      "8g",
+					}},
+				},
+			},
+			"tags": map[string]interface{}{
+				"aaa":         "bbb",
+				"owner":       "elastic",
+				"cost-center": "rnd",
+			},
+		},
+		Schema: newSchema(),
+	})
+
 	type args struct {
 		d      *schema.ResourceData
 		client *api.API
@@ -1048,6 +1160,9 @@ func Test_updateResourceToModel(t *testing.T) {
 							},
 						},
 					},
+				},
+				Metadata: &models.DeploymentUpdateMetadata{
+					Tags: []*models.MetadataItem{},
 				},
 				Resources: &models.DeploymentUpdateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
@@ -1174,6 +1289,9 @@ func Test_updateResourceToModel(t *testing.T) {
 				Name:         "my_deployment_name",
 				PruneOrphans: ec.Bool(true),
 				Settings:     &models.DeploymentUpdateSettings{},
+				Metadata: &models.DeploymentUpdateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentUpdateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
 						{
@@ -1279,6 +1397,9 @@ func Test_updateResourceToModel(t *testing.T) {
 				Name:         "my_deployment_name",
 				PruneOrphans: ec.Bool(true),
 				Settings:     &models.DeploymentUpdateSettings{},
+				Metadata: &models.DeploymentUpdateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentUpdateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
 						{
@@ -1384,6 +1505,9 @@ func Test_updateResourceToModel(t *testing.T) {
 				Name:         "my_deployment_name",
 				PruneOrphans: ec.Bool(true),
 				Settings:     &models.DeploymentUpdateSettings{},
+				Metadata: &models.DeploymentUpdateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentUpdateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{
 						{
@@ -1476,6 +1600,9 @@ func Test_updateResourceToModel(t *testing.T) {
 				Settings: &models.DeploymentUpdateSettings{
 					Observability: &models.DeploymentObservabilitySettings{},
 				},
+				Metadata: &models.DeploymentUpdateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentUpdateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{{
 						Region:   ec.String("us-east-1"),
@@ -1540,6 +1667,9 @@ func Test_updateResourceToModel(t *testing.T) {
 				Name:         "my_deployment_name",
 				PruneOrphans: ec.Bool(true),
 				Settings:     &models.DeploymentUpdateSettings{},
+				Metadata: &models.DeploymentUpdateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentUpdateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{{
 						Region:   ec.String("us-east-1"),
@@ -1599,6 +1729,9 @@ func Test_updateResourceToModel(t *testing.T) {
 				Name:         "my_deployment_name",
 				PruneOrphans: ec.Bool(true),
 				Settings:     &models.DeploymentUpdateSettings{},
+				Metadata: &models.DeploymentUpdateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
 				Resources: &models.DeploymentUpdateResources{
 					Elasticsearch: []*models.ElasticsearchPayload{{
 						Region: ec.String("us-east-1"),
@@ -1683,6 +1816,53 @@ func Test_updateResourceToModel(t *testing.T) {
 							},
 						},
 					}},
+				},
+			},
+		},
+		{
+			name: "parses the resources with tags",
+			args: args{
+				d:      deploymentWithTags,
+				client: api.NewMock(mock.New200Response(ioOptimizedTpl())),
+			},
+			want: &models.DeploymentUpdateRequest{
+				Name:         "my_deployment_name",
+				PruneOrphans: ec.Bool(true),
+				Settings:     &models.DeploymentUpdateSettings{},
+				Metadata: &models.DeploymentUpdateMetadata{Tags: []*models.MetadataItem{
+					{Key: ec.String("aaa"), Value: ec.String("bbb")},
+					{Key: ec.String("cost-center"), Value: ec.String("rnd")},
+					{Key: ec.String("owner"), Value: ec.String("elastic")},
+				}},
+				Resources: &models.DeploymentUpdateResources{
+					Elasticsearch: []*models.ElasticsearchPayload{
+						{
+							Region: ec.String("us-east-1"),
+							RefID:  ec.String("main-elasticsearch"),
+							Settings: &models.ElasticsearchClusterSettings{
+								DedicatedMastersThreshold: 6,
+							},
+							Plan: &models.ElasticsearchClusterPlan{
+								Elasticsearch: &models.ElasticsearchConfiguration{},
+								DeploymentTemplate: &models.DeploymentTemplateReference{
+									ID: ec.String("aws-io-optimized-v2"),
+								},
+								ClusterTopology: []*models.ElasticsearchClusterTopologyElement{{
+									ZoneCount:               2,
+									InstanceConfigurationID: "aws.data.highio.i3",
+									Size: &models.TopologySize{
+										Resource: ec.String("memory"),
+										Value:    ec.Int32(8192),
+									},
+									NodeType: &models.ElasticsearchNodeType{
+										Data:   ec.Bool(true),
+										Ingest: ec.Bool(true),
+										Master: ec.Bool(true),
+									},
+								}},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/ec/ecresource/deploymentresource/flatteners.go
+++ b/ec/ecresource/deploymentresource/flatteners.go
@@ -34,6 +34,12 @@ func modelToState(d *schema.ResourceData, res *models.DeploymentGetResponse, rem
 		return err
 	}
 
+	if res.Metadata != nil {
+		if err := d.Set("tags", flattenTags(res.Metadata.Tags)); err != nil {
+			return err
+		}
+	}
+
 	if res.Resources != nil {
 		dt, err := getDeploymentTemplateID(res.Resources)
 		if err != nil {
@@ -207,4 +213,17 @@ func hasRunningResources(res *models.DeploymentGetResponse) bool {
 		}
 	}
 	return hasRunning
+}
+
+func flattenTags(tags []*models.MetadataItem) map[string]interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	result := make(map[string]interface{}, len(tags))
+	for _, tag := range tags {
+		result[*tag.Key] = *tag.Value
+	}
+
+	return result
 }

--- a/ec/ecresource/deploymentresource/flatteners_test.go
+++ b/ec/ecresource/deploymentresource/flatteners_test.go
@@ -168,6 +168,75 @@ func Test_modelToState(t *testing.T) {
 		Schema: newSchema(),
 	})
 
+	awsIOOptimizedTagsRes := openDeploymentGet(t, "testdata/deployment-aws-io-optimized-tags.json")
+	awsIOOptimizedTagsRD := schema.TestResourceDataRaw(t, newSchema(), nil)
+	awsIOOptimizedTagsRD.SetId(mock.ValidClusterID)
+	wantAwsIOOptimizedDeploymentTags := util.NewResourceData(t, util.ResDataParams{
+		ID: mock.ValidClusterID,
+		State: map[string]interface{}{
+			"deployment_template_id": "aws-io-optimized-v2",
+			"id":                     "123b7b540dfc967a7a649c18e2fce4ed",
+			"name":                   "up2d",
+			"region":                 "aws-eu-central-1",
+			"tags": map[string]interface{}{
+				"aaa":   "bbb",
+				"cost":  "rnd",
+				"owner": "elastic",
+			},
+			"version": "7.9.2",
+			"apm": []interface{}{map[string]interface{}{
+				"elasticsearch_cluster_ref_id": "main-elasticsearch",
+				"ref_id":                       "main-apm",
+				"region":                       "aws-eu-central-1",
+				"resource_id":                  "12328579b3bf40c8b58c1a0ed5a4bd8b",
+				"version":                      "7.9.2",
+				"http_endpoint":                "http://12328579b3bf40c8b58c1a0ed5a4bd8b.apm.eu-central-1.aws.cloud.es.io:80",
+				"https_endpoint":               "https://12328579b3bf40c8b58c1a0ed5a4bd8b.apm.eu-central-1.aws.cloud.es.io:443",
+				"topology": []interface{}{map[string]interface{}{
+					"instance_configuration_id": "aws.apm.r5d",
+					"size":                      "0.5g",
+					"size_resource":             "memory",
+					"zone_count":                1,
+				}},
+			}},
+			"elasticsearch": []interface{}{map[string]interface{}{
+				"cloud_id":       "up2d:someCloudID",
+				"http_endpoint":  "http://1239f7ee7196439ba2d105319ac5eba7.eu-central-1.aws.cloud.es.io:9200",
+				"https_endpoint": "https://1239f7ee7196439ba2d105319ac5eba7.eu-central-1.aws.cloud.es.io:9243",
+				"ref_id":         "main-elasticsearch",
+				"region":         "aws-eu-central-1",
+				"resource_id":    "1239f7ee7196439ba2d105319ac5eba7",
+				"version":        "7.9.2",
+				"topology": []interface{}{map[string]interface{}{
+					"instance_configuration_id": "aws.data.highio.i3",
+					"node_type_data":            "true",
+					"node_type_ingest":          "true",
+					"node_type_master":          "true",
+					"node_type_ml":              "false",
+					"size":                      "8g",
+					"size_resource":             "memory",
+					"zone_count":                2,
+				}},
+			}},
+			"kibana": []interface{}{map[string]interface{}{
+				"elasticsearch_cluster_ref_id": "main-elasticsearch",
+				"ref_id":                       "main-kibana",
+				"region":                       "aws-eu-central-1",
+				"resource_id":                  "123dcfda06254ca789eb287e8b73ff4c",
+				"version":                      "7.9.2",
+				"http_endpoint":                "http://123dcfda06254ca789eb287e8b73ff4c.eu-central-1.aws.cloud.es.io:9200",
+				"https_endpoint":               "https://123dcfda06254ca789eb287e8b73ff4c.eu-central-1.aws.cloud.es.io:9243",
+				"topology": []interface{}{map[string]interface{}{
+					"instance_configuration_id": "aws.kibana.r5d",
+					"size":                      "1g",
+					"size_resource":             "memory",
+					"zone_count":                1,
+				}},
+			}},
+		},
+		Schema: newSchema(),
+	})
+
 	gcpIOOptimizedRes := openDeploymentGet(t, "testdata/deployment-gcp-io-optimized.json")
 	gcpIOOptimizedRD := schema.TestResourceDataRaw(t, newSchema(), nil)
 	gcpIOOptimizedRD.SetId(mock.ValidClusterID)
@@ -581,6 +650,11 @@ func Test_modelToState(t *testing.T) {
 			name: "flattens an aws plan (io-optimized)",
 			args: args{d: awsIOOptimizedRD, res: awsIOOptimizedRes},
 			want: wantAwsIOOptimizedDeployment,
+		},
+		{
+			name: "flattens an aws plan (io-optimized) with tags",
+			args: args{d: awsIOOptimizedTagsRD, res: awsIOOptimizedTagsRes},
+			want: wantAwsIOOptimizedDeploymentTags,
 		},
 		{
 			name: "flattens a gcp plan (io-optimized)",

--- a/ec/ecresource/deploymentresource/schema.go
+++ b/ec/ecresource/deploymentresource/schema.go
@@ -132,6 +132,15 @@ func newSchema() map[string]*schema.Schema {
 			MaxItems:    1,
 			Elem:        newObservabilitySettings(),
 		},
+
+		"tags": {
+			Description: "Optional map of deployment tags",
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 	}
 }
 

--- a/ec/ecresource/deploymentresource/testdata/deployment-aws-io-optimized-tags.json
+++ b/ec/ecresource/deploymentresource/testdata/deployment-aws-io-optimized-tags.json
@@ -1,0 +1,351 @@
+{
+    "healthy": true,
+    "id": "123365f2805e46808d40849b1c0b266b",
+    "name": "up2d",
+    "metadata": {
+        "tags": [
+            {"key": "aaa", "value": "bbb"},
+            {"key": "cost", "value": "rnd"},
+            {"key": "owner", "value": "elastic"}
+        ]
+    },
+    "resources": {
+        "apm": [
+            {
+                "elasticsearch_cluster_ref_id": "main-elasticsearch",
+                "id": "12328579b3bf40c8b58c1a0ed5a4bd8b",
+                "info": {
+                    "deployment_id": "123365f2805e46808d40849b1c0b266b",
+                    "elasticsearch_cluster": {
+                        "elasticsearch_id": "1239f7ee7196439ba2d105319ac5eba7"
+                    },
+                    "external_links": [],
+                    "healthy": true,
+                    "id": "12328579b3bf40c8b58c1a0ed5a4bd8b",
+                    "metadata": {
+                        "endpoint": "12328579b3bf40c8b58c1a0ed5a4bd8b.apm.eu-central-1.aws.cloud.es.io",
+                        "last_modified": "2020-10-14T05:02:27.645Z",
+                        "ports": {
+                            "http": 80,
+                            "https": 443,
+                            "transport_passthrough": 9400
+                        },
+                        "version": 7
+                    },
+                    "name": "up2d",
+                    "plan_info": {
+                        "current": {
+                            "attempt_end_time": "2020-10-14T05:04:55.439Z",
+                            "attempt_start_time": "2020-10-14T05:02:27.266Z",
+                            "healthy": true,
+                            "plan": {
+                                "apm": {
+                                    "system_settings": {
+                                        "secret_token": "yMpNQNOBVxZhlgFnBY"
+                                    },
+                                    "version": "7.9.2"
+                                },
+                                "cluster_topology": [
+                                    {
+                                        "apm": {
+                                            "system_settings": {
+                                                "debug_enabled": false,
+                                                "secret_token": "yMpNQNOBVxZhlgFnBY"
+                                            }
+                                        },
+                                        "instance_configuration_id": "aws.apm.r5d",
+                                        "size": {
+                                            "resource": "memory",
+                                            "value": 512
+                                        },
+                                        "zone_count": 1
+                                    }
+                                ]
+                            },
+                            "plan_attempt_id": "26dd8a24-c8e2-42a4-ad7a-13ddf8c77b43",
+                            "plan_attempt_log": [],
+                            "plan_end_time": "0001-01-01T00:00:00.000Z"
+                        },
+                        "healthy": true,
+                        "history": []
+                    },
+                    "region": "aws-eu-central-1",
+                    "status": "started"
+                },
+                "ref_id": "main-apm",
+                "region": "aws-eu-central-1"
+            }
+        ],
+        "appsearch": [],
+        "elasticsearch": [
+            {
+                "id": "1239f7ee7196439ba2d105319ac5eba7",
+                "info": {
+                    "associated_apm_clusters": [
+                        {
+                            "apm_id": "12328579b3bf40c8b58c1a0ed5a4bd8b",
+                            "enabled": true
+                        }
+                    ],
+                    "associated_appsearch_clusters": [],
+                    "associated_enterprise_search_clusters": [],
+                    "associated_kibana_clusters": [
+                        {
+                            "enabled": true,
+                            "kibana_id": "123dcfda06254ca789eb287e8b73ff4c"
+                        }
+                    ],
+                    "cluster_id": "1239f7ee7196439ba2d105319ac5eba7",
+                    "cluster_name": "up2d",
+                    "deployment_id": "123365f2805e46808d40849b1c0b266b",
+                    "elasticsearch": {
+                        "blocking_issues": {
+                            "cluster_level": [],
+                            "healthy": true,
+                            "index_level": []
+                        },
+                        "healthy": true
+                    },
+                    "external_links": [],
+                    "healthy": true,
+                    "locked": false,
+                    "metadata": {
+                        "cloud_id": "up2d:someCloudID",
+                        "endpoint": "1239f7ee7196439ba2d105319ac5eba7.eu-central-1.aws.cloud.es.io",
+                        "last_modified": "2020-10-14T05:04:56.085Z",
+                        "ports": {
+                            "http": 9200,
+                            "https": 9243,
+                            "transport_passthrough": 9400
+                        },
+                        "version": 23
+                    },
+                    "plan_info": {
+                        "current": {
+                            "attempt_end_time": "2020-10-14T05:03:31.757Z",
+                            "attempt_start_time": "2020-10-14T05:02:24.559Z",
+                            "healthy": true,
+                            "plan": {
+                                "cluster_topology": [
+                                    {
+                                        "elasticsearch": {
+                                            "system_settings": {
+                                                "auto_create_index": true,
+                                                "destructive_requires_name": false,
+                                                "enable_close_index": true,
+                                                "monitoring_collection_interval": -1,
+                                                "monitoring_history_duration": "3d",
+                                                "reindex_whitelist": [],
+                                                "scripting": {
+                                                    "inline": {
+                                                        "enabled": true
+                                                    },
+                                                    "stored": {
+                                                        "enabled": true
+                                                    }
+                                                },
+                                                "use_disk_threshold": true
+                                            }
+                                        },
+                                        "instance_configuration_id": "aws.data.highio.i3",
+                                        "node_type": {
+                                            "data": true,
+                                            "ingest": true,
+                                            "master": true,
+                                            "ml": false
+                                        },
+                                        "size": {
+                                            "resource": "memory",
+                                            "value": 8192
+                                        },
+                                        "zone_count": 2
+                                    },
+                                    {
+                                        "elasticsearch": {
+                                            "system_settings": {
+                                                "auto_create_index": true,
+                                                "destructive_requires_name": false,
+                                                "enable_close_index": true,
+                                                "monitoring_collection_interval": -1,
+                                                "monitoring_history_duration": "3d",
+                                                "reindex_whitelist": [],
+                                                "scripting": {
+                                                    "inline": {
+                                                        "enabled": true
+                                                    },
+                                                    "stored": {
+                                                        "enabled": true
+                                                    }
+                                                },
+                                                "use_disk_threshold": true
+                                            }
+                                        },
+                                        "instance_configuration_id": "aws.coordinating.m5d",
+                                        "node_type": {
+                                            "data": false,
+                                            "ingest": true,
+                                            "master": false,
+                                            "ml": false
+                                        },
+                                        "size": {
+                                            "resource": "memory",
+                                            "value": 0
+                                        },
+                                        "zone_count": 2
+                                    },
+                                    {
+                                        "elasticsearch": {
+                                            "system_settings": {
+                                                "auto_create_index": true,
+                                                "destructive_requires_name": false,
+                                                "enable_close_index": true,
+                                                "monitoring_collection_interval": -1,
+                                                "monitoring_history_duration": "3d",
+                                                "reindex_whitelist": [],
+                                                "scripting": {
+                                                    "inline": {
+                                                        "enabled": true
+                                                    },
+                                                    "stored": {
+                                                        "enabled": true
+                                                    }
+                                                },
+                                                "use_disk_threshold": true
+                                            }
+                                        },
+                                        "instance_configuration_id": "aws.master.r5d",
+                                        "node_type": {
+                                            "data": false,
+                                            "ingest": false,
+                                            "master": true,
+                                            "ml": false
+                                        },
+                                        "size": {
+                                            "resource": "memory",
+                                            "value": 0
+                                        },
+                                        "zone_count": 3
+                                    },
+                                    {
+                                        "elasticsearch": {
+                                            "system_settings": {
+                                                "auto_create_index": true,
+                                                "destructive_requires_name": false,
+                                                "enable_close_index": true,
+                                                "monitoring_collection_interval": -1,
+                                                "monitoring_history_duration": "3d",
+                                                "reindex_whitelist": [],
+                                                "scripting": {
+                                                    "inline": {
+                                                        "enabled": true
+                                                    },
+                                                    "stored": {
+                                                        "enabled": true
+                                                    }
+                                                },
+                                                "use_disk_threshold": true
+                                            }
+                                        },
+                                        "instance_configuration_id": "aws.ml.m5d",
+                                        "node_type": {
+                                            "data": false,
+                                            "ingest": false,
+                                            "master": false,
+                                            "ml": true
+                                        },
+                                        "size": {
+                                            "resource": "memory",
+                                            "value": 0
+                                        },
+                                        "zone_count": 1
+                                    }
+                                ],
+                                "deployment_template": {
+                                    "id": "aws-io-optimized-v2"
+                                },
+                                "elasticsearch": {
+                                    "version": "7.9.2"
+                                },
+                                "tiebreaker_topology": {
+                                    "memory_per_node": 1024
+                                }
+                            },
+                            "plan_attempt_id": "42025723-f52a-40ed-b6d2-126fe6b9cabe",
+                            "plan_attempt_log": [],
+                            "plan_end_time": "0001-01-01T00:00:00.000Z"
+                        },
+                        "healthy": true,
+                        "history": []
+                    },
+                    "region": "aws-eu-central-1",
+                    "status": "started",
+                    "system_alerts": []
+                },
+                "ref_id": "main-elasticsearch",
+                "region": "aws-eu-central-1"
+            }
+        ],
+        "enterprise_search": [],
+        "kibana": [
+            {
+                "elasticsearch_cluster_ref_id": "main-elasticsearch",
+                "id": "123dcfda06254ca789eb287e8b73ff4c",
+                "info": {
+                    "cluster_id": "123dcfda06254ca789eb287e8b73ff4c",
+                    "cluster_name": "up2d",
+                    "deployment_id": "123365f2805e46808d40849b1c0b266b",
+                    "elasticsearch_cluster": {
+                        "elasticsearch_id": "1239f7ee7196439ba2d105319ac5eba7"
+                    },
+                    "external_links": [],
+                    "healthy": true,
+                    "metadata": {
+                        "endpoint": "123dcfda06254ca789eb287e8b73ff4c.eu-central-1.aws.cloud.es.io",
+                        "last_modified": "2020-10-14T05:04:55.982Z",
+                        "ports": {
+                            "http": 9200,
+                            "https": 9243,
+                            "transport_passthrough": 9400
+                        },
+                        "version": 10
+                    },
+                    "plan_info": {
+                        "current": {
+                            "attempt_end_time": "2020-10-14T05:06:38.610Z",
+                            "attempt_start_time": "2020-10-14T05:04:55.535Z",
+                            "healthy": true,
+                            "plan": {
+                                "cluster_topology": [
+                                    {
+                                        "instance_configuration_id": "aws.kibana.r5d",
+                                        "kibana": {
+                                            "system_settings": {}
+                                        },
+                                        "size": {
+                                            "resource": "memory",
+                                            "value": 1024
+                                        },
+                                        "zone_count": 1
+                                    }
+                                ],
+                                "kibana": {
+                                    "system_settings": {},
+                                    "version": "7.9.2"
+                                }
+                            },
+                            "plan_attempt_id": "b414904a-5f2b-485f-9e2a-05a181443247",
+                            "plan_attempt_log": [],
+                            "plan_end_time": "0001-01-01T00:00:00.000Z"
+                        },
+                        "healthy": true,
+                        "history": []
+                    },
+                    "region": "aws-eu-central-1",
+                    "status": "started"
+                },
+                "ref_id": "main-kibana",
+                "region": "aws-eu-central-1"
+            }
+        ]
+    }
+}

--- a/go.sum
+++ b/go.sum
@@ -479,6 +479,7 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new key value map `tags` to the `ec_deployment` resource.

```hcl
resource "ec_deployment" "with_tags" {
  # Optional name.
  name = "my_example_deployment"

  # Mandatory fields
  region                 = "us-east-1"
  version                = "7.9.2"
  deployment_template_id = "aws-io-optimized-v2"

  elasticsearch {}

  tags = {
    owner     = "elastic cloud"
    component = "search"
  }
}
```

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #213

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and running the acceptance tests.

```console
$ make testacc TEST_NAME=TestAccDeployment_basic_tags
-> Running terraform acceptance tests...
=== RUN   TestAccDeployment_basic_tags
=== PAUSE TestAccDeployment_basic_tags
=== CONT  TestAccDeployment_basic_tags
--- PASS: TestAccDeployment_basic_tags (213.88s)
PASS
ok  	github.com/elastic/terraform-provider-ec/ec/acc	214.236s
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)