### PR TITLE
lint: Fix terraform fmt to return exit code > 0

### DIFF
--- a/build/Makefile.lint
+++ b/build/Makefile.lint
@@ -39,4 +39,4 @@ validate-examples:
 ## Formats all the terraform ".tf" files in the repository
 fmt:
 	@ echo "-> Checking that the terraform .tf files are formatted..."
-	@ terraform fmt -write=false -recursive
+	@ terraform fmt -write=false -recursive -check


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes a bug where the `lint` target didn't have the `-check` flag set,
which caused the target to return with status code 0 even when there are
files that aren't formatted according to `terraform fmt`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Proper validation of terraform formatted files in our CI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make lint`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
