### PR TITLE
ci: Clean acc dangling deployments on cleanup step

### DIFF
--- a/.ci/pipelines/acceptance.Jenkinsfile
+++ b/.ci/pipelines/acceptance.Jenkinsfile
@@ -30,6 +30,8 @@ node('docker && gobld/machineType:n1-highcpu-8') {
             throw err
         } finally {
             stage("Clean up") {
+                // Sweeps any deployments older than 1h.
+                sh 'make sweep-ci'
                 sh 'make -C .ci clean'
                 sh 'rm -rf reports bin'
             }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,19 @@ Before running the acceptance tests make sure you have exported your API key to 
 - `TESTARGS` controls any additional flags you may want to pass to `go test`.
 - `TEST_COUNT` controls how many times each test is run. Defaults to 1.
 
+_Note: Acceptance tests may incur in charges for the deployments that are created. If you do not wish to run acceptance tests locally, you can rely on the acceptance tests which are run automatically on every pull request._
+
+##### Sweepers
+
 Additionally, there is a `make sweep` target which destroys any dangling infrastructure created by the acceptance tests. For more information on acceptance testing, check out the official Terraform [documentation](https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html).
 
-_Note: Acceptance tests may incur in charges for the deployments that are created. If you do not wish to run acceptance tests locally, you can rely on the acceptance tests which are run automatically on every pull request._
+Running the sweepers will remove all the `terraform_acc_` prefixed resources for the registered sweepers, each resource should add its own sweepers so that in cases dangling resources are left, they can be cleaned up with `make sweep`. There are three variables that can be passed to `sweep`:
+
+- `SWEEP` controls the region (if any) to pass to the resources to be swept. Defaults to `us-east-1`.
+- `SWEEP_DIR` controls the directory where the sweepers are found. Defaults to `github.com/elastic/terraform-provider-ec/ec/acc`.
+- `SWEEPARGS` controls the additional command flags to pass to the `go test` command:
+  - `-sweep-run` can be set to filter which sweepers are run (matching is done with `string.Contains`).
+  - `-sweep-allow-failures` can be set to allow all sweepers to be run when one or more have failed.
 
 ### Build terraform-provider-ec locally with your changes
 

--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -1,5 +1,6 @@
 SWEEP ?=us-east-1
 SWEEP_DIR ?= $(TEST_ACC)
+SWEEP_CI_RUN_FILTER ?= ec_deployments
 TEST ?= ./...
 TEST_COUNT ?= 1
 TESTUNITARGS ?= -timeout 10s -p 4 -race -cover -coverprofile=reports/c.out
@@ -33,10 +34,16 @@ testacc:
 .PHONY: sweep
 ## Destroys any dangling infrastructure created by the acceptance tests (terraform_acc_ prefix).
 sweep:
+ifndef BUILD_ID
 	@ echo "-> WARNING: This will destroy infrastructure. Use only in development accounts."
 	@ read -r -p "do you wish to continue? [y/N]: " res && if [[ "$${res:0:1}" =~ ^([yY]) ]]; then echo "-> Continuing..."; else exit 1; fi
+endif
 	@ go test $(SWEEP_DIR) -v -sweep=$(SWEEP) $(SWEEPARGS) -timeout 60m
 
 .PHONY: testacc-ci
 testacc-ci:
 	@ EC_API_KEY=$(shell cat .ci/.apikey) $(MAKE) testacc
+
+.PHONY: sweep-ci
+sweep-ci:
+	@ EC_API_KEY=$(shell cat .ci/.apikey) SWEEPARGS=-sweep-run=$(SWEEP_CI_RUN_FILTER) $(MAKE) sweep

--- a/ec/acc/deployment_sweep_test.go
+++ b/ec/acc/deployment_sweep_test.go
@@ -34,6 +34,9 @@ import (
 )
 
 func init() {
+	// Registering the sweeper as "ec_deployments" instead of "ec_deployment"
+	// since sweeping with --sweep-name will target any sweepers which contain
+	// "*ec_deployment*". Not to be confused with "ec_deployments" data source.
 	resource.AddTestSweepers("ec_deployments", &resource.Sweeper{
 		Name: "ec_deployments",
 		F:    testSweepDeployment,

--- a/ec/acc/deployment_sweep_test.go
+++ b/ec/acc/deployment_sweep_test.go
@@ -18,6 +18,7 @@
 package acc
 
 import (
+	"log"
 	"strings"
 	"sync"
 	"time"
@@ -33,8 +34,8 @@ import (
 )
 
 func init() {
-	resource.AddTestSweepers("ec_deployment", &resource.Sweeper{
-		Name: "ec_deployment",
+	resource.AddTestSweepers("ec_deployments", &resource.Sweeper{
+		Name: "ec_deployments",
 		F:    testSweepDeployment,
 	})
 }
@@ -79,6 +80,7 @@ func testSweepDeployment(_ string) error {
 	for _, dep := range sweepDeployments {
 		wg.Add(1)
 		go func(id string) {
+			log.Printf("[DEBUG] Shutting down deployment %s", id)
 			if err := shutdownDeployment(client, id, &wg); err != nil {
 				merr = merr.Append(err)
 			}

--- a/ec/acc/deployment_traffic_filter_sweep_test.go
+++ b/ec/acc/deployment_traffic_filter_sweep_test.go
@@ -29,8 +29,9 @@ import (
 
 func init() {
 	resource.AddTestSweepers("ec_deployment_traffic_filter", &resource.Sweeper{
-		Name: "ec_deployment_traffic_filter",
-		F:    testSweepDeploymentTrafficFilter,
+		Name:         "ec_deployment_traffic_filter",
+		F:            testSweepDeploymentTrafficFilter,
+		Dependencies: []string{"ec_deployments"},
 	})
 }
 
@@ -45,7 +46,7 @@ func testSweepDeploymentTrafficFilter(region string) error {
 		Region: region,
 	})
 	if err != nil {
-		return api.UnwrapError(err)
+		return err
 	}
 
 	var sweepFilters []string


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch adds a new target `sweep-ci` which sweeps `ec_deployments`
resources that have had their last change > 1h ago, it doesn't target
other resource sweepers as it makes use of the flag `-sweep-name`.

`make sweep-ci` will be called on the cleanup step which is always run
ensuring that we don't periodically leave costly dangling resources as
a result of our acceptance tests.

The sweeper for `ec_deployment` has been renamed to `ec_deployments` to
avoid matching other resources prefixed with `ec_deployments` since the
terraform sweep filter uses the Go func `strings.Contains`. A debug log
line has also been added to each deployment that is swept as a trail.

Last, the `CONTRIBUTING.md` file has been edited to add more information
about the sweepers.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #207

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
No more dangling resources!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running `make sweep-ci` locally.
