### PR TITLE
acc: fix ec_deployment post-destroy check

### DIFF
--- a/ec/acc/deployment_destroy_test.go
+++ b/ec/acc/deployment_destroy_test.go
@@ -78,7 +78,7 @@ func testAccDeploymentDestroy(s *terraform.State) error {
 						continue
 					}
 					merr = merr.Append(
-						fmt.Errorf("deployment [%s] resource enterpriseSearch (%s) still exists",
+						fmt.Errorf("deployment [%s] resource enterprise_search (%s) still exists",
 							rs.Primary.ID, *res.ID,
 						),
 					)

--- a/ec/acc/deployment_destroy_test.go
+++ b/ec/acc/deployment_destroy_test.go
@@ -88,7 +88,7 @@ func testAccDeploymentDestroy(s *terraform.State) error {
 						continue
 					}
 					merr = merr.Append(
-						fmt.Errorf("deployment [%s] resource apm (%s) still exists",
+						fmt.Errorf("deployment [%s] resource kibana (%s) still exists",
 							rs.Primary.ID, *res.ID,
 						),
 					)

--- a/ec/acc/deployment_destroy_test.go
+++ b/ec/acc/deployment_destroy_test.go
@@ -47,9 +47,7 @@ func testAccDeploymentDestroy(s *terraform.State) error {
 		// cannot delete a deployment, so even when it's been shut down it will
 		// show up on the GET call.
 		if err == nil && !*res.Metadata.Hidden {
-			var merr = multierror.NewPrefixed("ec_deployment found",
-				fmt.Errorf("deployment (%s) still exists", rs.Primary.ID),
-			)
+			var merr = multierror.NewPrefixed("ec_deployment found")
 
 			// If any of its subresources isn't stopped, return an error
 			// which will indicate there's still dangling resources.
@@ -60,7 +58,9 @@ func testAccDeploymentDestroy(s *terraform.State) error {
 						continue
 					}
 					merr = merr.Append(
-						fmt.Errorf("resource apm (%s) still exists", *res.ID),
+						fmt.Errorf("deployment [%s] resource apm (%s) still exists",
+							rs.Primary.ID, *res.ID,
+						),
 					)
 				}
 				for _, res := range res.Resources.Elasticsearch {
@@ -68,7 +68,9 @@ func testAccDeploymentDestroy(s *terraform.State) error {
 						continue
 					}
 					merr = merr.Append(
-						fmt.Errorf("resource elasticsearch (%s) still exists", *res.ID),
+						fmt.Errorf("deployment [%s] resource elasticsearch (%s) still exists",
+							rs.Primary.ID, *res.ID,
+						),
 					)
 				}
 				for _, res := range res.Resources.EnterpriseSearch {
@@ -76,7 +78,9 @@ func testAccDeploymentDestroy(s *terraform.State) error {
 						continue
 					}
 					merr = merr.Append(
-						fmt.Errorf("resource enterpriseSearch (%s) still exists", *res.ID),
+						fmt.Errorf("deployment [%s] resource enterpriseSearch (%s) still exists",
+							rs.Primary.ID, *res.ID,
+						),
 					)
 				}
 				for _, res := range res.Resources.Kibana {
@@ -84,7 +88,9 @@ func testAccDeploymentDestroy(s *terraform.State) error {
 						continue
 					}
 					merr = merr.Append(
-						fmt.Errorf("resource apm (%s) still exists", *res.ID),
+						fmt.Errorf("deployment [%s] resource apm (%s) still exists",
+							rs.Primary.ID, *res.ID,
+						),
 					)
 				}
 			}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes the post-destroy check for the `ec_deployment` resource to only
error out when any of the deployments resources is still running and not
when the deployment is found on the backing API since it'll always be
there in ESS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Less acceptance test failures

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
