### PR TITLE
ec_deployments: Bugfix for queries with hyphens

### DIFF
--- a/ec/acc/datasource_deployment_basic_test.go
+++ b/ec/acc/datasource_deployment_basic_test.go
@@ -31,7 +31,7 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 	datasourceName := "data.ec_deployment.success"
 	depsDatasourceName := "data.ec_deployments.query"
 	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	secondRandomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	secondRandomName := prefix + "-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	depCfg := "testdata/datasource_deployment_basic.tf"
 	cfg := fixtureAccDeploymentDatasourceBasic(t, depCfg, randomName, secondRandomName, getRegion(), computeOpTemplate)
 	var namePrefix = secondRandomName[:22]
@@ -56,14 +56,14 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.http_endpoint_id", resourceName, "elasticsearch.0.http_endpoint_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.https_endpoint_id", resourceName, "elasticsearch.0.https_endpoint_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.version", resourceName, "elasticsearch.0.version"),
-					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.instance_configuration_id", resourceName, "elasticsearch.0.topology.0.instance_configuration_id"),
-					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.size", resourceName, "elasticsearch.0.topology.0.size"),
-					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.size_resource", resourceName, "elasticsearch.0.topology.0.size_resource"),
-					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.zone_count", resourceName, "elasticsearch.0.topology.0.zone_count"),
-					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.node_type_data", resourceName, "elasticsearch.0.topology.0.node_type_data"),
-					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.node_type_master", resourceName, "elasticsearch.0.topology.0.node_type_master"),
-					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.node_type_ingest", resourceName, "elasticsearch.0.topology.0.node_type_ingest"),
-					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.node_type_ml", resourceName, "elasticsearch.0.topology.0.node_type_ml"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.1.instance_configuration_id", resourceName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.1.size", resourceName, "elasticsearch.0.topology.0.size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.1.size_resource", resourceName, "elasticsearch.0.topology.0.size_resource"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.1.zone_count", resourceName, "elasticsearch.0.topology.0.zone_count"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.1.node_type_data", resourceName, "elasticsearch.0.topology.0.node_type_data"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.1.node_type_master", resourceName, "elasticsearch.0.topology.0.node_type_master"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.1.node_type_ingest", resourceName, "elasticsearch.0.topology.0.node_type_ingest"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.1.node_type_ml", resourceName, "elasticsearch.0.topology.0.node_type_ml"),
 
 					// Kibana
 					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.elasticsearch_cluster_ref_id", resourceName, "kibana.0.elasticsearch_cluster_ref_id"),

--- a/ec/acc/testdata/datasource_deployment_basic.tf
+++ b/ec/acc/testdata/datasource_deployment_basic.tf
@@ -25,7 +25,8 @@ resource "ec_deployment" "basic_datasource" {
 
   elasticsearch {
     topology {
-      size = "1g"
+      size       = "1g"
+      zone_count = 1
     }
   }
 

--- a/ec/ecdatasource/deploymentsdatasource/expanders.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders.go
@@ -34,7 +34,9 @@ func expandFilters(d *schema.ResourceData) (*models.SearchRequest, error) {
 	if namePrefix != "" {
 		queries = append(queries, &models.QueryContainer{
 			Prefix: map[string]models.PrefixQuery{
-				"name": {Value: ec.String(namePrefix)},
+				// The "keyword" addition denotes that the query will be using a keyword
+				// field rather than a text field in order to ensure the query is not analyzed
+				"name.keyword": {Value: ec.String(namePrefix)},
 			},
 		})
 	}

--- a/ec/ecdatasource/deploymentsdatasource/expanders_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders_test.go
@@ -128,7 +128,7 @@ func newTestQuery() []*models.QueryContainer {
 	return []*models.QueryContainer{
 		{
 			Prefix: map[string]models.PrefixQuery{
-				"name": {Value: ec.String("test")},
+				"name.keyword": {Value: ec.String("test")},
 			},
 		},
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes a bug where the name prefix query was using a text field rather
than a keyword field in order to ensure the query is not analyzed.

Additionally the acceptance tests have been fixed since recently it
appears the deployment read API returns all possible topology elements
even if the size is set to 0. This means that the `ec_deployment` datasource
will return more topology elements than what is set in the `ec_deployment`
resource. I will open up a follow up PR with the fix for this, but I wanted to 
leave the tests passing for now.

## Related Issues
Closes: https://github.com/elastic/terraform-provider-ec/issues/239

## How Has This Been Tested?
Manually and through acceptance tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
