### PR TITLE
Filter ec_deployments datasource by tags

### DIFF
--- a/docs/data-sources/ec_deployments.md
+++ b/docs/data-sources/ec_deployments.md
@@ -15,6 +15,10 @@ data "ec_deployments" "example" {
   name_prefix            = "test"
   deployment_template_id = "azure-compute-optimized"
 
+  tags = {
+    "foo" = "bar"
+  }
+
   elasticsearch {
     healthy = "true"
   }
@@ -37,6 +41,7 @@ data "ec_deployments" "example" {
 
 * `name_prefix` - Prefix that one or several deployment names have in common.
 * `deployment_template_id` - ID of the deployment template used to create the deployment.
+* `tags` - Key value map of arbitrary string tags for the deployment.
 * `healthy` - Overall health status of the deployment.
 * `elasticsearch` - Filter by Elasticsearch resource kind status or configuration.
   * `elasticsearch.#.status` - Resource kind status (Available statuses are: initializing, stopping, stopped, rebooting, restarting, reconfiguring, and started).

--- a/ec/acc/datasource_tags_test.go
+++ b/ec/acc/datasource_tags_test.go
@@ -31,12 +31,16 @@ import (
 // * Create a deployment resource with tags.
 // * Create a datasource from the resource.
 // * Ensure tags exist.
+// * Create a datasource with filters for the unique tag
+// * Ensure that only a single deployment is returned
 func TestAccDatasource_basic_tags(t *testing.T) {
 
-	datasourceName := "data.ec_deployment.tags"
+	datasourceName := "data.ec_deployment.tagdata"
+	filterDatasourceName := "data.ec_deployments.tagfilter"
 	depCfg := "testdata/datasource_tags.tf"
-	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	cfg := fixtureAccTagsDataSource(t, depCfg, randomName, getRegion(), defaultTemplate)
+	testID := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	randomName := prefix + testID
+	cfg := fixtureAccTagsDataSource(t, depCfg, randomName, getRegion(), defaultTemplate, testID)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -46,16 +50,28 @@ func TestAccDatasource_basic_tags(t *testing.T) {
 			{
 				Config: cfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(datasourceName, "tags.%", "2"),
+					// Check the "ec_deployment" datasource
+					resource.TestCheckResourceAttr(datasourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(datasourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(datasourceName, "tags.bar", "baz"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.test_id", testID),
+				),
+			},
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check the "ec_deployments" datasource, which filters on tags.
+					resource.TestCheckResourceAttrSet(filterDatasourceName, "return_count"),
+					resource.TestCheckResourceAttr(filterDatasourceName, "return_count", "1"),
+					resource.TestCheckResourceAttr(filterDatasourceName, "deployments.#", "1"),
+					resource.TestCheckResourceAttrSet(filterDatasourceName, "deployments.0.deployment_id"),
 				),
 			},
 		},
 	})
 }
 
-func fixtureAccTagsDataSource(t *testing.T, fileName, name, region string, depTpl string) string {
+func fixtureAccTagsDataSource(t *testing.T, fileName, name, region string, depTpl string, testID string) string {
 	t.Helper()
 
 	deploymentTpl := setDefaultTemplate(region, depTpl)
@@ -64,6 +80,6 @@ func fixtureAccTagsDataSource(t *testing.T, fileName, name, region string, depTp
 		t.Fatal(err)
 	}
 	return fmt.Sprintf(string(b),
-		region, name, region, deploymentTpl,
+		region, name, region, deploymentTpl, testID, testID,
 	)
 }

--- a/ec/acc/testdata/datasource_tags.tf
+++ b/ec/acc/testdata/datasource_tags.tf
@@ -9,8 +9,9 @@ resource "ec_deployment" "tags" {
   version                = data.ec_stack.latest.version
   deployment_template_id = "%s"
   tags = {
-    "foo" = "bar"
-    "bar" = "baz"
+    "foo"     = "bar"
+    "bar"     = "baz"
+    "test_id" = "%s"
   }
 
   elasticsearch {
@@ -21,6 +22,12 @@ resource "ec_deployment" "tags" {
   }
 }
 
-data "ec_deployment" "tags" {
+data "ec_deployment" "tagdata" {
   id = ec_deployment.tags.id
+}
+
+data "ec_deployments" "tagfilter" {
+  tags = {
+    "test_id" = "%s"
+  }
 }

--- a/ec/ecdatasource/deploymentsdatasource/expanders.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders.go
@@ -65,17 +65,17 @@ func expandFilters(d *schema.ResourceData) (*models.SearchRequest, error) {
 	}
 
 	tags := d.Get("tags").(map[string]interface{})
-	if len(tags) >= 1 {
-		var shouldQueries []*models.QueryContainer
-		tagPath := "metadata.tags"
-		for key, value := range tags {
-			tagQuery := newNestedTagQuery(tagPath, key, value)
-			shouldQueries = append(shouldQueries, tagQuery)
-		}
+	var tagQueries []*models.QueryContainer
+	for key, value := range tags {
+		tagQueries = append(tagQueries,
+			newNestedTagQuery("metadata.tags", key, value),
+		)
+	}
+	if len(tagQueries) > 0 {
 		queries = append(queries, &models.QueryContainer{
 			Bool: &models.BoolQuery{
 				MinimumShouldMatch: int32(len(tags)),
-				Should:             shouldQueries,
+				Should:             tagQueries,
 			},
 		})
 	}

--- a/ec/ecdatasource/deploymentsdatasource/expanders.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders.go
@@ -68,7 +68,7 @@ func expandFilters(d *schema.ResourceData) (*models.SearchRequest, error) {
 	var tagQueries []*models.QueryContainer
 	for key, value := range tags {
 		tagQueries = append(tagQueries,
-			newNestedTagQuery("metadata.tags", key, value),
+			newNestedTagQuery(key, value),
 		)
 	}
 	if len(tagQueries) > 0 {
@@ -171,10 +171,10 @@ func newNestedTermQuery(path, term string, value interface{}) *models.QueryConta
 }
 
 // newNestedTagQuery returns a nested query for a metadata tag
-func newNestedTagQuery(path string, key interface{}, value interface{}) *models.QueryContainer {
+func newNestedTagQuery(key interface{}, value interface{}) *models.QueryContainer {
 	return &models.QueryContainer{
 		Nested: &models.NestedQuery{
-			Path: ec.String(path),
+			Path: ec.String("metadata.tags"),
 			Query: &models.QueryContainer{
 				Bool: &models.BoolQuery{
 					Filter: []*models.QueryContainer{

--- a/ec/ecdatasource/deploymentsdatasource/expanders_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders_test.go
@@ -82,17 +82,17 @@ func Test_expandFilters(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			jsonWant, err := json.Marshal(tt.want)
+			jsonWant, err := json.MarshalIndent(tt.want, "", "  ")
 			if err != nil {
 				t.Error("Unable to marshal wanted struct to JSON")
 			}
-			jsonGot, err := json.Marshal(got)
+
+			jsonGot, err := json.MarshalIndent(got, "", "  ")
 			if err != nil {
 				t.Error("Unable to marshal received struct to JSON")
 			}
 
-			assert.Equal(t, jsonWant, jsonGot)
-
+			assert.Equal(t, string(jsonWant), string(jsonGot))
 		})
 	}
 }

--- a/ec/ecdatasource/deploymentsdatasource/expanders_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders_test.go
@@ -101,6 +101,9 @@ func newSampleFilters() map[string]interface{} {
 	return map[string]interface{}{
 		"name_prefix": "test",
 		"healthy":     "true",
+		"tags": map[string]interface{}{
+			"foo": "bar",
+		},
 		"elasticsearch": []interface{}{
 			map[string]interface{}{
 				"version": "7.9.1",
@@ -134,6 +137,38 @@ func newTestQuery() []*models.QueryContainer {
 		{
 			Term: map[string]models.TermQuery{
 				"healthy": {Value: true},
+			},
+		},
+		{
+			Bool: &models.BoolQuery{
+				MinimumShouldMatch: int32(1),
+				Should: []*models.QueryContainer{
+					{
+						Nested: &models.NestedQuery{
+							Path: ec.String("metadata.tags"),
+							Query: &models.QueryContainer{
+								Bool: &models.BoolQuery{
+									Filter: []*models.QueryContainer{
+										{
+											Term: map[string]models.TermQuery{
+												"metadata.tags.key": {
+													Value: ec.String("foo"),
+												},
+											},
+										},
+										{
+											Term: map[string]models.TermQuery{
+												"metadata.tags.value": {
+													Value: ec.String("bar"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		{

--- a/ec/ecdatasource/deploymentsdatasource/expanders_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders_test.go
@@ -18,6 +18,7 @@
 package deploymentsdatasource
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -81,7 +82,17 @@ func Test_expandFilters(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			assert.Equal(t, tt.want, got)
+			jsonWant, err := json.Marshal(tt.want)
+			if err != nil {
+				panic(err)
+			}
+			jsonGot, err := json.Marshal(got)
+			if err != nil {
+				panic(err)
+			}
+
+			assert.Equal(t, jsonWant, jsonGot)
+
 		})
 	}
 }

--- a/ec/ecdatasource/deploymentsdatasource/expanders_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders_test.go
@@ -84,11 +84,11 @@ func Test_expandFilters(t *testing.T) {
 
 			jsonWant, err := json.Marshal(tt.want)
 			if err != nil {
-				panic(err)
+				t.Error("Unable to marshal wanted struct to JSON")
 			}
 			jsonGot, err := json.Marshal(got)
 			if err != nil {
-				panic(err)
+				t.Error("Unable to marshal received struct to JSON")
 			}
 
 			assert.Equal(t, jsonWant, jsonGot)

--- a/ec/ecdatasource/deploymentsdatasource/schema.go
+++ b/ec/ecdatasource/deploymentsdatasource/schema.go
@@ -33,6 +33,13 @@ func newSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"return_count": {
 			Type:     schema.TypeInt,
 			Computed: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

This PR attempts to allow filtering by "tags" when using the `ec_deployments` datasource.

For example:

```hcl
data "ec_deployments" "example" {

  elasticsearch {
    healthy = "true"
  }

  tags = {
      "foo" = "bar"
  }
}

output "test" {
  value = data.ec_deployments.example.deployments
}
```

```bash
> terraform output test                 
tolist([
  {
    "apm_resource_id" = "ba049aec4b0249818af25c7ef7543ba9"
    "deployment_id" = "10974c2d7136235d8fe88be9545a8d22"
    "elasticsearch_resource_id" = "fbeaf8097f1342dbb4cf25aea4310796"
    "enterprise_search_resource_id" = "dab52337b8414f57a4b5f40fb9c7ffb3"
    "kibana_resource_id" = "6f7a0a51fa584ace8be97845c50d6525"
  },
])
```
.... where `10974c2d7136235d8fe88be9545a8d22` is tagged with `{ "foo" = "bar"}` and is elasticsearch-healthy !


## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #182 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit test `Test_expandFilters` extended to include "tags".
- Acceptance test `TestAccDatasource_basic_tags` extended to include `ec_depoyments` datasource filtering on tags.

```
> make unit
-> Running unit tests for terraform-provider-ec...
?       github.com/elastic/terraform-provider-ec        [no test files]
ok      github.com/elastic/terraform-provider-ec/ec     0.800s  coverage: 71.4% of statements
ok      github.com/elastic/terraform-provider-ec/ec/acc 1.159s  coverage: 4.7% of statements
ok      github.com/elastic/terraform-provider-ec/ec/ecdatasource/deploymentdatasource   1.068s  coverage: 89.6% of statements
ok      github.com/elastic/terraform-provider-ec/ec/ecdatasource/deploymentsdatasource  1.039s  coverage: 78.3% of statements
ok      github.com/elastic/terraform-provider-ec/ec/ecdatasource/stackdatasource        0.721s  coverage: 72.9% of statements
ok      github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource       1.292s  coverage: 85.6% of statements
ok      github.com/elastic/terraform-provider-ec/ec/ecresource/extensionresource        0.788s  coverage: 78.4% of statements
ok      github.com/elastic/terraform-provider-ec/ec/ecresource/trafficfilterassocresource       0.770s  coverage: 66.7% of statements
ok      github.com/elastic/terraform-provider-ec/ec/ecresource/trafficfilterresource    0.705s  coverage: 72.9% of statements
ok      github.com/elastic/terraform-provider-ec/ec/internal/util       0.485s  coverage: 79.1% of statements
```

```
> make testacc TEST_NAME=TestAccDatasource_basic_tags
-> Running terraform acceptance tests...
=== RUN   TestAccDatasource_basic_tags
=== PAUSE TestAccDatasource_basic_tags
=== CONT  TestAccDatasource_basic_tags
--- PASS: TestAccDatasource_basic_tags (313.49s)
PASS
ok      github.com/elastic/terraform-provider-ec/ec/acc 314.426s
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
