### PR TITLE
scripts: Add changelog generator

### DIFF
--- a/.changelog/208.txt
+++ b/.changelog/208.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/ec_traffic_filter: Fixes bug where having a traffic filter with a multiple rules will cause an infinite diff due to ordering
+```

--- a/.changelog/209.txt
+++ b/.changelog/209.txt
@@ -1,0 +1,3 @@
+```release-note:documentation
+index: Fix timeout configuration option in example
+```

--- a/.changelog/216.txt
+++ b/.changelog/216.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+resource/ec_extension: Add a new resource `ec_extension` which allows users to mange custom Elasticsearch bundles and plugins
+```

--- a/.changelog/218.txt
+++ b/.changelog/218.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/ec_deployment: Add tags key / value map
+```

--- a/.changelog/235.txt
+++ b/.changelog/235.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+go/build: Fixes bug where the api user agent wasn't stripped of its `-dev` tag prior to releasing
+```

--- a/.changelog/238.txt
+++ b/.changelog/238.txt
@@ -1,0 +1,3 @@
+```release-note:documentation
+resource/ec_deployment: renames invalid `ignore_unavailable` to the actual `skip_unavailable` option name
+```

--- a/.changelog/241.txt
+++ b/.changelog/241.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+datasource/ec_deployments: Fixes bug where queries containing a hyphens wouldn't work as expected
+```

--- a/.changelog/242.txt
+++ b/.changelog/242.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+datasource/ec_deployment: Fixes bug where the datasource was persisting zero sized topology elements in the state
+```

--- a/.changelog/244.txt
+++ b/.changelog/244.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+datasource/ec_deployment: Adds the tag attribute to the `ec_deployment` datasource
+```

--- a/.changelog/248.txt
+++ b/.changelog/248.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+datasource/ec_deployments: Allows filtering deployments by their associated tags
+```

--- a/.changelog/253.txt
+++ b/.changelog/253.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+datasource/ec_deployment: Adds support for the newly added data tiers. A new **required** field `elasticsearch.toplogy.id` has been added, it needs to be set to all **explicit** Elasticsearch topology declarations. A `node_roles` computed field has been added to the schema and **cannot** be overridden by the user, versions `>=7.10.0` will be automatically migrated by the provider to use `node_roles` from the `node_type_*` settings, these will be removed from the state. When `node_type_*` fields are explicitly set in the terraform configuration they need to be unset manually by the user. Additionally, it removes the `elasticsearch.version` computed field.
+```

--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -1,0 +1,26 @@
+name: Generate CHANGELOG
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+jobs:
+  GenerateChangelog:
+    if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: make changelog
+      - run: |
+          if [[ $(git status --porcelain) ]]; then
+            MSG="Update CHANGELOG.md (Manual Trigger)"
+            if ${{github.event_name != 'workflow_dispatch'}}; then
+              MSG="Update CHANGELOG.md for #${{ github.event.pull_request.number }}"
+            fi
+            git config --local user.email elasticcloudclients@elastic.co
+            git config --local user.name elasticcloudclients
+            git add CHANGELOG.md
+            git commit -m "$MSG" 
+            git push
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # 0.1.0 (Unreleased)
 
+BREAKING CHANGES:
+
+* datasource/ec_deployment: Adds support for the newly added data tiers. A new **required** field `elasticsearch.toplogy.id` has been added, it needs to be set to all **explicit** Elasticsearch topology declarations. A `node_roles` computed field has been added to the schema and **cannot** be overridden by the user, versions `>=7.10.0` will be automatically migrated by the provider to use `node_roles` from the `node_type_*` settings, these will be removed from the state. When `node_type_*` fields are explicitly set in the terraform configuration they need to be unset manually by the user. Additionally, it removes the `elasticsearch.version` computed field. ([#253](https://github.com/elastic/terraform-provider-ec/issues/253))
+
+FEATURES:
+
+* **New Resource:** resource/ec_extension: Add a new resource `ec_extension` which allows users to mange custom Elasticsearch bundles and plugins ([#216](https://github.com/elastic/terraform-provider-ec/issues/216))
+
+ENHANCEMENTS:
+
+* datasource/ec_deployment: Adds the tag attribute to the `ec_deployment` datasource ([#244](https://github.com/elastic/terraform-provider-ec/issues/244))
+* datasource/ec_deployments: Allows filtering deployments by their associated tags ([#248](https://github.com/elastic/terraform-provider-ec/issues/248))
+* resource/ec_deployment: Add tags key / value map ([#218](https://github.com/elastic/terraform-provider-ec/issues/218))
+
+BUG FIXES:
+
+* datasource/ec_deployment: Fixes bug where the datasource was persisting zero sized topology elements in the state ([#242](https://github.com/elastic/terraform-provider-ec/issues/242))
+* datasource/ec_deployments: Fixes bug where queries containing a hyphens wouldn't work as expected ([#241](https://github.com/elastic/terraform-provider-ec/issues/241))
+* go/build: Fixes bug where the api user agent wasn't stripped of its `-dev` tag prior to releasing ([#235](https://github.com/elastic/terraform-provider-ec/issues/235))
+* resource/ec_traffic_filter: Fixes bug where having a traffic filter with a multiple rules will cause an infinite diff due to ordering ([#208](https://github.com/elastic/terraform-provider-ec/issues/208))
+
 # 0.1.0-beta (December 14, 2020)
 
 NOTES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-# 0.1.0-beta (Unreleased)
-
+# 0.1.0 (Unreleased)
 
 # 0.1.0-beta (December 14, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# 0.1.0-beta (Unreleased)
+
+
+# 0.1.0-beta (December 14, 2020)
+
+NOTES
+
+The Elastic Cloud Terraform provider allows you to provision Elastic Cloud deployments on any Elastic Cloud platform, whether it’s Elasticsearch Service or Elastic Cloud Enterprise.
+
+_This functionality is in beta and is subject to change. The design and code are less mature than official GA features and are being provided as-is with no warranties._
+
+FEATURES
+
+* **New Provider**: ec ([docs](https://registry.terraform.io/providers/elastic/ec/0.1.0-beta/docs))
+* **New Resource**: ec_deployment ([docs](https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/ec_deployment))
+* **New Resource**: ec_deployment_traffic_filter ([docs](https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/ec_deployment_traffic_filter))
+* **New Resource**: ec_deployment_traffic_filter_association ([docs](https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/ec_deployment_traffic_filter_association))
+* **New Data Source**: ec_deployment ([docs](https://registry.terraform.io/providers/elastic/ec/latest/docs/data-sources/ec_deployment))
+* **New Data Source**: ec_deployments ([docs](https://registry.terraform.io/providers/elastic/ec/latest/docs/data-sources/ec_deployments))
+* **New Data Source**: ec_stack ([docs](https://registry.terraform.io/providers/elastic/ec/latest/docs/data-sources/ec_stack))

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 export GO111MODULE ?= on
-export VERSION := 0.1.0-beta-dev
+export VERSION := 0.1.0-dev
 export BINARY := terraform-provider-ec
 export GOBIN = $(shell pwd)/bin
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.1.0-beta"
+      version = "0.1.0"
     }
   }
 }

--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -8,6 +8,7 @@ VERSION_GOLINT:=v0.0.0-20191125180803-fdd1cda4f05f
 VERSION_GOLICENSER:=v0.3.0
 VERSION_GOLANGCILINT:=v1.26.0
 VERSION_GORELEASER:=v0.149.0
+VERSION_GOCHANGELOG:=v0.0.0-20201005170154-56335215ce3a
 
 deps: $(GOBIN)/gobin $(GOBIN)/golint $(GOBIN)/go-licenser $(GOBIN)/golangci-lint
 
@@ -57,3 +58,11 @@ $(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER): | $(VERSION_DIR)
 $(GOBIN)/goreleaser: $(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER) | $(GOBIN)
 	@ echo "-> Installing goreleaser..."
 	@ curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh| sh -s -- -b $(GOBIN) $(VERSION_GORELEASER)
+
+$(VERSION_DIR)/.version-changelog-build-$(VERSION_GOCHANGELOG): | $(VERSION_DIR)
+	@ rm -f $(VERSION_DIR)/.version-changelog-build-*
+	@ echo $(VERSION_GOCHANGELOG) > $(VERSION_DIR)/.version-changelog-build-$(VERSION_GOCHANGELOG)
+
+$(GOBIN)/changelog-build: $(GOBIN)/gobin $(VERSION_DIR)/.version-changelog-build-$(VERSION_GOCHANGELOG) | $(GOBIN)
+	@ echo "-> Installing changelog-build..."
+	@ $(GOBIN)/gobin github.com/hashicorp/go-changelog/cmd/changelog-build@$(VERSION_GOCHANGELOG)

--- a/build/Makefile.release
+++ b/build/Makefile.release
@@ -33,3 +33,8 @@ release: $(GOBIN)/goreleaser
 release-no-publish: $(GOBIN)/goreleaser
 	@ $(MAKE) gen VERSION=$(subst -dev,,$(VERSION))
 	@ $(GOBIN)/goreleaser --rm-dist --skip-validate --skip-publish
+
+.PHONY: changelog
+changelog: $(GOBIN)/changelog-build
+	@ echo "-> Generating changelog..."
+	@ ./scripts/generate-changelog.sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.1.0-beta"
+      version = "0.1.0"
     }
   }
 }

--- a/ec/version.go
+++ b/ec/version.go
@@ -18,4 +18,4 @@
 package ec
 
 // Version contains the current terraform provider version.
-const Version = "0.1.0-beta-dev"
+const Version = "0.1.0-dev"

--- a/examples/deployment/deployment.tf
+++ b/examples/deployment/deployment.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.1.0-beta"
+      version = "0.1.0"
     }
   }
 }

--- a/examples/deployment_ccs/deployment.tf
+++ b/examples/deployment_ccs/deployment.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.1.0-beta"
+      version = "0.1.0"
     }
   }
 }

--- a/examples/deployment_ec2_instance/provider.tf
+++ b/examples/deployment_ec2_instance/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.1.0-beta"
+      version = "0.1.0"
     }
 
     aws = {

--- a/examples/deployment_with_init/provider.tf
+++ b/examples/deployment_with_init/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.1.0-beta"
+      version = "0.1.0"
     }
   }
 }

--- a/examples/extension_bundle/extension.tf
+++ b/examples/extension_bundle/extension.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.1.0-beta"
+      version = "0.1.0"
     }
   }
 }

--- a/scripts/changelog.tmpl
+++ b/scripts/changelog.tmpl
@@ -1,0 +1,41 @@
+
+{{- if index .NotesByType "breaking-change" }}
+BREAKING CHANGES:
+
+{{range index .NotesByType "breaking-change" -}}
+{{ template "note" .}}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.note }}
+NOTES:
+
+{{range .NotesByType.note -}}
+{{ template "note" .}}
+{{ end -}}
+{{- end -}}
+
+{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-data-source") (index .NotesByType "new-guide") }}
+{{- if $features }}
+FEATURES:
+
+{{range $features | sort -}}
+{{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.enhancement }}
+ENHANCEMENTS:
+
+{{range .NotesByType.enhancement | sort -}}
+{{ template "note" .}}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.bug }}
+BUG FIXES:
+
+{{range .NotesByType.bug | sort -}}
+{{ template "note" . }}
+{{ end -}}
+{{- end -}}

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -48,10 +48,15 @@ echo "${CHANGELOG}" >> ${CHANGELOG_TMP_FILE_NAME}
 echo >> ${CHANGELOG_TMP_FILE_NAME}
 echo "${PREVIOUS_CHANGELOG}" >> ${CHANGELOG_TMP_FILE_NAME}
 
+HAS_CHANGES=$(diff ${CHANGELOG_TMP_FILE_NAME} ${CHANGELOG_FILE_NAME})
+
 cp ${CHANGELOG_TMP_FILE_NAME} ${CHANGELOG_FILE_NAME}
 
 rm ${CHANGELOG_TMP_FILE_NAME}
 
-echo "Successfully generated changelog."
+if [ -z ${HAS_CHANGES} ]; then
+    echo "No new changelog entries."
+    exit 0
+fi
 
-exit 0
+echo "Successfully generated changelog."

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__parent="$(dirname "${__dir}")"
+
+CHANGELOG_FILE_NAME="CHANGELOG.md"
+CHANGELOG_TMP_FILE_NAME="CHANGELOG.tmp"
+TARGET_SHA=$(git rev-parse HEAD)
+PREVIOUS_RELEASE_TAG=$(git describe --abbrev=0 --match='v*.*.*' --tags)
+PREVIOUS_RELEASE_SHA=$(git rev-list -n 1 ${PREVIOUS_RELEASE_TAG})
+
+if [ ${TARGET_SHA} == ${PREVIOUS_RELEASE_SHA} ]; then
+  echo "Nothing to do"
+  exit 0
+fi
+
+PREVIOUS_CHANGELOG=$(sed -n -e "/# ${PREVIOUS_RELEASE_TAG#v}/,\$p" ${__parent}/${CHANGELOG_FILE_NAME})
+
+if [ -z "${PREVIOUS_CHANGELOG}" ]; then
+    echo "Unable to locate previous changelog contents."
+    exit 1
+fi
+
+if [ -z "${GOBIN}" ]; then
+    GOBIN=$(go env GOPATH)/bin
+fi
+
+CHANGELOG=$(${GOBIN}/changelog-build -this-release ${TARGET_SHA} \
+                      -last-release ${PREVIOUS_RELEASE_SHA} \
+                      -git-dir ${__parent} \
+                      -entries-dir .changelog \
+                      -changelog-template ${__dir}/changelog.tmpl \
+                      -note-template ${__dir}/release-note.tmpl \
+                      )
+
+if [ -z "$CHANGELOG" ]; then
+    echo "No changelog generated."
+    exit 0
+fi
+
+rm -f ${CHANGELOG_TMP_FILE_NAME}
+
+sed -n -e "1{/# /p;}" ${__parent}/${CHANGELOG_FILE_NAME} > ${CHANGELOG_TMP_FILE_NAME}
+echo "${CHANGELOG}" >> ${CHANGELOG_TMP_FILE_NAME}
+echo >> ${CHANGELOG_TMP_FILE_NAME}
+echo "${PREVIOUS_CHANGELOG}" >> ${CHANGELOG_TMP_FILE_NAME}
+
+cp ${CHANGELOG_TMP_FILE_NAME} ${CHANGELOG_FILE_NAME}
+
+rm ${CHANGELOG_TMP_FILE_NAME}
+
+echo "Successfully generated changelog."
+
+exit 0

--- a/scripts/release-note.tmpl
+++ b/scripts/release-note.tmpl
@@ -1,10 +1,10 @@
 {{- define "note" -}}
 {{- if eq "new-resource" .Type -}}
-* **New Resource:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
+* **New Resource:** {{.Body}} ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
 {{- else if eq "new-data-source" .Type -}}
-* **New Data Source:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
+* **New Data Source:** {{.Body}} ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
 {{- else if eq "new-guide" .Type -}}
-* **New Guide:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
+* **New Guide:** {{.Body}} ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
 {{- else -}}
 * {{.Body}} ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
 {{- end -}}

--- a/scripts/release-note.tmpl
+++ b/scripts/release-note.tmpl
@@ -1,0 +1,11 @@
+{{- define "note" -}}
+{{- if eq "new-resource" .Type -}}
+* **New Resource:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
+{{- else if eq "new-data-source" .Type -}}
+* **New Data Source:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
+{{- else if eq "new-guide" .Type -}}
+* **New Guide:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
+{{- else -}}
+* {{.Body}} ([#{{- .Issue -}}](https://github.com/elastic/terraform-provider-ec/issues/{{- .Issue -}}))
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a changelog generator inspired on the work Hashicorp has done for
some of their providers. The structure is as follows:

Each change (PR) worth having an entry in the changelog should add a new
file `#PR.txt` as part of the Pull request. Examples on the file format
can be found in the `.changelog` folder.

Also, adds a GitHub action that will run every time a PR is merged and
run `make changelog` and commit any changes should there be any new
entries to the changelog file.

Last, I've ran the changelog generation for the upcoming version and
bumped the current provider version to `v0.1.0`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Have the changelog automatically generated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running `make changelog`.
