### PR TITLE
changelog: Add GITHUB_TOKEN to git commit step

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -12,7 +12,9 @@ jobs:
         with:
           fetch-depth: 0
       - run: make changelog
-      - run: |
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
           if [[ $(git status --porcelain) ]]; then
             MSG="Update CHANGELOG.md (Manual Trigger)"
             if ${{github.event_name != 'workflow_dispatch'}}; then


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the missing GITHUB_TOKEN env to the step that runs `git commit` and git push.
