### PR TITLE
go: Require 1.16 and remove deprecated io/ioutil

### DIFF
--- a/ec/acc/datasource_deployment_basic_test.go
+++ b/ec/acc/datasource_deployment_basic_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -122,7 +122,7 @@ func fixtureAccDeploymentDatasourceBasic(t *testing.T, fileName, name, secondNam
 	t.Helper()
 
 	deploymentTpl := setDefaultTemplate(region, depTpl)
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/datasource_stack_test.go
+++ b/ec/acc/datasource_stack_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -71,7 +71,7 @@ func TestAccDatasourceStack_regex(t *testing.T) {
 func fixtureAccStackDataSource(t *testing.T, fileName, region string) string {
 	t.Helper()
 
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/datasource_tags_test.go
+++ b/ec/acc/datasource_tags_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -75,7 +75,7 @@ func fixtureAccTagsDataSource(t *testing.T, fileName, name, region string, depTp
 	t.Helper()
 
 	deploymentTpl := setDefaultTemplate(region, depTpl)
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/deployment_basic_defaults_test.go
+++ b/ec/acc/deployment_basic_defaults_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -232,7 +232,7 @@ func fixtureAccDeploymentResourceBasicDefaults(t *testing.T, fileName, name, reg
 	t.Helper()
 
 	deploymentTpl := setDefaultTemplate(region, depTpl)
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/deployment_basic_test.go
+++ b/ec/acc/deployment_basic_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -140,7 +140,7 @@ func fixtureAccDeploymentResourceBasicWithApps(t *testing.T, fileName, name, reg
 		t.Fatal(err)
 	}
 
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func fixtureAccDeploymentResourceBasicWithTF(t *testing.T, fileName, name, regio
 	t.Helper()
 
 	deploymentTpl := setDefaultTemplate(region, depTpl)
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/deployment_ccs_test.go
+++ b/ec/acc/deployment_ccs_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -133,7 +133,7 @@ func fixtureAccDeploymentResourceBasicCcs(t *testing.T, fileName, name, region, 
 	ccsTpl := setDefaultTemplate(region, ccsTplName)
 	sourceTpl := setDefaultTemplate(region, sourceTplName)
 
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/deployment_extension_basic_test.go
+++ b/ec/acc/deployment_extension_basic_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -63,7 +63,7 @@ func TestAccDeploymentExtension_basic(t *testing.T) {
 func fixtureAccExtensionBasicWithTF(t *testing.T, tfFileName, extensionName, description string) string {
 	t.Helper()
 
-	b, err := ioutil.ReadFile(tfFileName)
+	b, err := os.ReadFile(tfFileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/deployment_extension_bundle_file_test.go
+++ b/ec/acc/deployment_extension_bundle_file_test.go
@@ -21,7 +21,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -82,7 +82,7 @@ func TestAccDeploymentExtension_bundleFile(t *testing.T) {
 func fixtureAccExtensionBundleWithTF(t *testing.T, tfFileName, bundleFilePath, extensionName, description string) string {
 	t.Helper()
 
-	b, err := ioutil.ReadFile(tfFileName)
+	b, err := os.ReadFile(tfFileName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func writeFile(t *testing.T, filePath, fileName, content string) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filePath, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(filePath, buf.Bytes(), 0644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -153,7 +153,7 @@ func downloadAndReadExtension(filename string, url string, size int64) (string, 
 		return "", err
 	}
 
-	b, _ := ioutil.ReadAll(resp.Body)
+	b, _ := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
 	r, err := zip.NewReader(bytes.NewReader(b), size)
@@ -167,7 +167,7 @@ func downloadAndReadExtension(filename string, url string, size int64) (string, 
 
 	for _, f := range r.File {
 		reader, _ := f.Open()
-		b, _ := ioutil.ReadAll(reader)
+		b, _ := io.ReadAll(reader)
 		func() { defer reader.Close() }()
 		if filename == f.Name {
 			return string(b), nil

--- a/ec/acc/deployment_extension_plugin_download_test.go
+++ b/ec/acc/deployment_extension_plugin_download_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -54,7 +54,7 @@ func TestAccDeploymentExtension_pluginDownload(t *testing.T) {
 func fixtureAccExtensionBundleDownloadWithTF(t *testing.T, tfFileName, extensionName, downloadURL string) string {
 	t.Helper()
 
-	b, err := ioutil.ReadFile(tfFileName)
+	b, err := os.ReadFile(tfFileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/deployment_hotwarm_test.go
+++ b/ec/acc/deployment_hotwarm_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -116,7 +116,7 @@ func fixtureAccDeploymentResourceBasic(t *testing.T, fileName, name, region, dep
 	t.Helper()
 	requiresAPIConn(t)
 
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/deployment_observability_test.go
+++ b/ec/acc/deployment_observability_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -87,7 +87,7 @@ func fixtureAccDeploymentResourceBasicObs(t *testing.T, fileName, name, region, 
 
 	deploymentTpl := setDefaultTemplate(region, depTpl)
 
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/deployment_traffic_filter_association_test.go
+++ b/ec/acc/deployment_traffic_filter_association_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -76,7 +76,7 @@ func fixtureAccDeploymentTrafficFilterResourceAssociationBasic(t *testing.T, fil
 	t.Helper()
 
 	deploymentTpl := setDefaultTemplate(region, depTpl)
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ec/acc/deployment_traffic_filter_test.go
+++ b/ec/acc/deployment_traffic_filter_test.go
@@ -19,7 +19,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -90,7 +90,7 @@ func TestAccDeploymentTrafficFilter_basic(t *testing.T) {
 
 func fixtureAccDeploymentTrafficFilterResourceBasic(t *testing.T, fileName, name, region string) string {
 	t.Helper()
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/terraform-provider-ec
 
-go 1.13
+go 1.16
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Requires the module to use Go 1.16.x and removes any usages of the
`io/ioutil` deprecated library.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
