### PR TITLE
acceptance: Increase timeout on API calls

### DIFF
--- a/ec/acc/acc_prereq.go
+++ b/ec/acc/acc_prereq.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/auth"
@@ -118,6 +119,7 @@ func newAPI() (*api.API, error) {
 		Host:          host,
 		SkipTLSVerify: insecure,
 		Retries:       ec.DefaultHTTPRetries,
+		Timeout:       5 * time.Minute,
 	})
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Increases the timeout value to 5 minutes on acceptance tests to
hopefully give enough time for the destroy actions to finish.

## Motivation and Context
Make the tests pass again 😩 

## How Has This Been Tested?
We'll see what happens when Jenkins runs

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
