### PR TITLE
ec_deployments: Add size parameter to data source 

### DIFF
--- a/.changelog/300.txt
+++ b/.changelog/300.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+datasource/ec_deployment: Add a new size parameter to allow modifying the default size of `10` in the number of deployments returned by the search request.
+```

--- a/docs/data-sources/ec_deployments.md
+++ b/docs/data-sources/ec_deployments.md
@@ -15,6 +15,8 @@ data "ec_deployments" "example" {
   name_prefix            = "test"
   deployment_template_id = "azure-compute-optimized"
 
+  size = 200
+
   tags = {
     "foo" = "bar"
   }
@@ -41,6 +43,7 @@ data "ec_deployments" "example" {
 
 * `name_prefix` - Prefix that one or several deployment names have in common.
 * `deployment_template_id` - ID of the deployment template used to create the deployment.
+* `size` - The maximum number of deployments to return. Defaults to `100`.
 * `tags` - Key value map of arbitrary string tags for the deployment.
 * `healthy` - Overall health status of the deployment.
 * `elasticsearch` - Filter by Elasticsearch resource kind status or configuration.

--- a/ec/ecdatasource/deploymentsdatasource/expanders.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders.go
@@ -91,7 +91,9 @@ func expandFilters(d *schema.ResourceData) (*models.SearchRequest, error) {
 		queries = append(queries, req...)
 	}
 
-	var searchReq models.SearchRequest
+	searchReq := models.SearchRequest{
+		Size: int32(d.Get("size").(int)),
+	}
 
 	if len(queries) > 0 {
 		searchReq.Query = &models.QueryContainer{

--- a/ec/ecdatasource/deploymentsdatasource/expanders_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders_test.go
@@ -54,6 +54,56 @@ func Test_expandFilters(t *testing.T) {
 			name: "parses the data source",
 			args: args{d: deploymentsDS},
 			want: &models.SearchRequest{
+				Size: 100,
+				Query: &models.QueryContainer{
+					Bool: &models.BoolQuery{
+						Filter: []*models.QueryContainer{
+							{
+								Bool: &models.BoolQuery{
+									Must: newTestQuery(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "parses the data source with a different size",
+			args: args{d: util.NewResourceData(t, util.ResDataParams{
+				ID:     "myID",
+				Schema: newSchema(),
+				State: map[string]interface{}{
+					"name_prefix": "test",
+					"healthy":     "true",
+					"size":        200,
+					"tags": map[string]interface{}{
+						"foo": "bar",
+					},
+					"elasticsearch": []interface{}{
+						map[string]interface{}{
+							"version": "7.9.1",
+						},
+					},
+					"kibana": []interface{}{
+						map[string]interface{}{
+							"status": "started",
+						},
+					},
+					"apm": []interface{}{
+						map[string]interface{}{
+							"healthy": "true",
+						},
+					},
+					"enterprise_search": []interface{}{
+						map[string]interface{}{
+							"healthy": "false",
+						},
+					},
+				},
+			})},
+			want: &models.SearchRequest{
+				Size: 200,
 				Query: &models.QueryContainer{
 					Bool: &models.BoolQuery{
 						Filter: []*models.QueryContainer{

--- a/ec/ecdatasource/deploymentsdatasource/schema.go
+++ b/ec/ecdatasource/deploymentsdatasource/schema.go
@@ -40,6 +40,13 @@ func newSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
+		"size": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  100,
+		},
+
+		// Computed
 		"return_count": {
 			Type:     schema.TypeInt,
 			Computed: true,

--- a/examples/deployment/deployment.tf
+++ b/examples/deployment/deployment.tf
@@ -22,7 +22,8 @@ data "ec_stack" "latest" {
 # Create an Elastic Cloud deployment
 resource "ec_deployment" "example_minimal" {
   # Optional name.
-  name = "my_example_deployment"
+  name  = "my_example_deployment"
+  alias = "some"
 
   # Mandatory fields
   region                 = "us-east-1"

--- a/examples/deployment/deployment.tf
+++ b/examples/deployment/deployment.tf
@@ -22,8 +22,7 @@ data "ec_stack" "latest" {
 # Create an Elastic Cloud deployment
 resource "ec_deployment" "example_minimal" {
   # Optional name.
-  name  = "my_example_deployment"
-  alias = "some"
+  name = "my_example_deployment"
 
   # Mandatory fields
   region                 = "us-east-1"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new `size` integer parameter to the `ec_deployments` data source
which allows users to specify a maximum number of deployments to be
returned. The API defaults to 10 and the provider defaults to `100`.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #294 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
