### PR TITLE
ec_deployment: Retry destroy on Timeout Exceeded

### DIFF
--- a/.changelog/308.txt
+++ b/.changelog/308.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/ec_deployment: Retries the Shutdown API call on the destroy operation up to 3 times when the transient "Timeout Exceeded" error returned from the Elastic Cloud API.
+```

--- a/ec/ecresource/deploymentresource/delete_test.go
+++ b/ec/ecresource/deploymentresource/delete_test.go
@@ -55,7 +55,6 @@ func Test_deleteResource(t *testing.T) {
 	wantTC404.SetId("")
 
 	type args struct {
-		ctx  context.Context
 		d    *schema.ResourceData
 		meta interface{}
 	}
@@ -95,7 +94,7 @@ func Test_deleteResource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := deleteResource(tt.args.ctx, tt.args.d, tt.args.meta)
+			got := deleteResource(context.Background(), tt.args.d, tt.args.meta)
 			assert.Equal(t, tt.want, got)
 			var want interface{}
 			if tt.wantRD != nil {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds retries when the plan tracking message of a deployment shutdown
contains the Timeout Exceeded message, with a maximum of 3 retries.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
No more failures on flakey `Timeout Exceeded`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Acceptance tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Enhancement