### PR TITLE
ec_deployment: Set snapshot restore strategy to `partial` on Update

### DIFF
--- a/.changelog/309.txt
+++ b/.changelog/309.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/ec_deployment: Fixes a bug which made restoring a snapshot to an existing deployment fail.
+```

--- a/ec/acc/deployment_fixture_test.go
+++ b/ec/acc/deployment_fixture_test.go
@@ -1,0 +1,40 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// fixtureDeploymentDefaults takes the default region and default deployment template
+// It assumes that the template order is region = %s and deployment_template = %s
+func fixtureDeploymentDefaults(t *testing.T, fileName string) string {
+	t.Helper()
+	requiresAPIConn(t)
+
+	region := getRegion()
+	deploymentTpl := setDefaultTemplate(region, defaultTemplate)
+
+	b, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf(string(b), region, deploymentTpl)
+}

--- a/ec/acc/deployment_snapshot_test.go
+++ b/ec/acc/deployment_snapshot_test.go
@@ -1,0 +1,119 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// creds is used as a container to pass around ES credentials.
+type creds struct {
+	User string
+	Pass string
+	URL  string
+}
+
+func TestAccDeployment_snapshot_restore(t *testing.T) {
+	var esCreds creds
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fixtureDeploymentDefaults(t, "testdata/deployment_snapshot_1.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					readEsCredentials(t, &esCreds),
+				),
+			},
+			{
+				// Creates a deployment restoring from snapshot. For some reason,
+				// this can take quite a long time. It will have an impact on the
+				// total run time of the acceptance tests.
+				PreConfig: triggerSnapshot(t, &esCreds),
+				Config:    fixtureDeploymentDefaults(t, "testdata/deployment_snapshot_2.tf"),
+				// Since the `snapshot_source` block is never persisted, it'll
+				// always have a non-empty plan after applying.
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// Triggers a new snapshot and restores the last snapshot to the
+				// running Elasticsearch cluster. This ensures that the snapshot
+				// is restored and the plan returns with no error.
+				PreConfig: triggerSnapshot(t, &esCreds),
+				Config:    fixtureDeploymentDefaults(t, "testdata/deployment_snapshot_2.tf"),
+				// Since the `snapshot_source` block is never persisted, it'll
+				// always have a non-empty plan after applying.
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func readEsCredentials(t *testing.T, esCreds *creds) resource.TestCheckFunc {
+	t.Helper()
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "ec_deployment" {
+				continue
+			}
+
+			esCreds.URL = rs.Primary.Attributes["elasticsearch.0.https_endpoint"]
+			esCreds.User = rs.Primary.Attributes["elasticsearch_username"]
+			esCreds.Pass = rs.Primary.Attributes["elasticsearch_password"]
+		}
+		return nil
+	}
+}
+
+func triggerSnapshot(t *testing.T, esCreds *creds) func() {
+	t.Helper()
+	return func() {
+		snapshotURL := fmt.Sprintf(
+			esCreds.URL+"/_snapshot/found-snapshots/snap_%d?wait_for_completion=true",
+			time.Now().Unix(),
+		)
+		req, err := http.NewRequest("PUT", snapshotURL, nil)
+		if err != nil {
+			t.Fatal(fmt.Errorf("failed creating snapshot request: %w", err))
+			return
+		}
+		req.SetBasicAuth(esCreds.User, esCreds.Pass)
+
+		t.Log("PUT", snapshotURL)
+
+		// Create a new client with no timeout, just wait for the call to return.
+		client := &http.Client{Timeout: 0}
+		res, err := client.Do(req)
+		if err != nil {
+			t.Fatal(fmt.Errorf("failed performing snapshot request: %w", err))
+			return
+		}
+		if res.StatusCode != 200 {
+			t.Fatal("snapshot create statuscode != 200")
+			return
+		}
+		t.Log("Snapshot created")
+	}
+}

--- a/ec/acc/testdata/deployment_snapshot_1.tf
+++ b/ec/acc/testdata/deployment_snapshot_1.tf
@@ -1,0 +1,23 @@
+locals {
+  region              = "%s"
+  deployment_template = "%s"
+}
+
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = local.region
+}
+
+resource "ec_deployment" "snapshot_source" {
+  name                   = "terraform_acc_snapshot_source"
+  region                 = local.region
+  version                = data.ec_stack.latest.version
+  deployment_template_id = local.deployment_template
+
+  elasticsearch {
+    topology {
+      id   = "hot_content"
+      size = "1g"
+    }
+  }
+}

--- a/ec/acc/testdata/deployment_snapshot_2.tf
+++ b/ec/acc/testdata/deployment_snapshot_2.tf
@@ -1,0 +1,41 @@
+locals {
+  region              = "%s"
+  deployment_template = "%s"
+}
+
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = local.region
+}
+
+resource "ec_deployment" "snapshot_source" {
+  name                   = "terraform_acc_snapshot_source"
+  region                 = local.region
+  version                = data.ec_stack.latest.version
+  deployment_template_id = local.deployment_template
+
+  elasticsearch {
+    topology {
+      id   = "hot_content"
+      size = "1g"
+    }
+  }
+}
+
+resource "ec_deployment" "snapshot_target" {
+  name                   = "terraform_acc_snapshot_target"
+  region                 = local.region
+  version                = data.ec_stack.latest.version
+  deployment_template_id = local.deployment_template
+
+  elasticsearch {
+    snapshot_source {
+      source_elasticsearch_cluster_id = ec_deployment.snapshot_source.elasticsearch.0.resource_id
+    }
+
+    topology {
+      id   = "hot_content"
+      size = "1g"
+    }
+  }
+}

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -279,7 +279,6 @@ func expandSnapshotSource(raw interface{}, restore *models.RestoreSnapshotConfig
 		if snapshotName, ok := rs["snapshot_name"]; ok {
 			restore.SnapshotName = ec.String(snapshotName.(string))
 		}
-
 	}
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes a bug where the strategy field wasn't set on either of the create
or update operations and it made restoring a snapshot on an existing
deployment impossible since when `transient.snapshot_restore.strategy`
isn't set, the API will make it default to "full", which isn't a valid
restoration strategy for snapshots when a deployment has already been
created and it's running, for the operation to succeed, "partial" must
be used.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #249

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual, unit and acceptance tested.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)