### PR TITLE
docs: data tiers update

### DIFF
--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -241,11 +241,11 @@ The required `elasticsearch` block supports the following arguments:
 
 To set up multi-node Elasticsearch clusters, you can set the topology block multiple times. Each block must specify the `id` field referencing the data tier name. This is particularly relevant for Elasticsearch clusters with multiple data tiers or Machine lLearning.
 
--> To avoid infinite diff loops, topology blocks should be ordered alphabetically by the `topology.id` field. The order with the current data tiers at the time of this writing would be: "cold", "coordinating", "hot_content", "master", "warm".
+-> To avoid infinite diff loops, topology blocks should be ordered alphabetically by the `topology.id` field. The order with the current data tiers at the time of this writing would be: "cold", "coordinating", "frozen", "hot_content", "master", "ml", "warm".
 
 The optional `elasticsearch.topology` block supports the following arguments:
 
-* `id` - (Required) Unique topology identifier. It generally refers to an Elasticsearch data tier, such as `hot_content`, `warm`, `cold`, `coordinating` or `master`.
+* `id` - (Required) Unique topology identifier. It generally refers to an Elasticsearch data tier, such as `hot_content`, `warm`, `cold`, `coordinating`, `frozen`, `ml` or `master`.
 * `size` - (Optional) Amount in Gigabytes per topology element in the `"<size in GB>g"` notation. When omitted, it defaults to the deployment template value.
 * `size_resource` - (Optional) Type of resource to which the size is assigned. Defaults to `"memory"`.
 * `zone_count` - (Optional) Number of zones the instance type of the Elasticsearch cluster will span. This is used to set or unset HA on an Elasticsearch node type. When omitted, it defaults to the deployment template value.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Adds `frozen` and `ml` to the list of available data tiers for the `elasticsearch.topology` block.

## Related Issues
Closes: https://github.com/elastic/terraform-provider-ec/issues/317

## Motivation and Context
Stay up to date!

## How Has This Been Tested?
N/A

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
