### PR TITLE
ec_deployments: Use API sorting by deployment ID

### DIFF
--- a/.changelog/322.txt
+++ b/.changelog/322.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+datasource/ec_deployments: Properly sorts the datasource results by ID.
+```

--- a/ec/ecdatasource/deploymentsdatasource/expanders.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders.go
@@ -93,6 +93,7 @@ func expandFilters(d *schema.ResourceData) (*models.SearchRequest, error) {
 
 	searchReq := models.SearchRequest{
 		Size: int32(d.Get("size").(int)),
+		Sort: []interface{}{"id"},
 	}
 
 	if len(queries) > 0 {

--- a/ec/ecdatasource/deploymentsdatasource/expanders_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/expanders_test.go
@@ -55,6 +55,7 @@ func Test_expandFilters(t *testing.T) {
 			args: args{d: deploymentsDS},
 			want: &models.SearchRequest{
 				Size: 100,
+				Sort: []interface{}{"id"},
 				Query: &models.QueryContainer{
 					Bool: &models.BoolQuery{
 						Filter: []*models.QueryContainer{
@@ -104,6 +105,7 @@ func Test_expandFilters(t *testing.T) {
 			})},
 			want: &models.SearchRequest{
 				Size: 200,
+				Sort: []interface{}{"id"},
 				Query: &models.QueryContainer{
 					Bool: &models.BoolQuery{
 						Filter: []*models.QueryContainer{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Uses the `Sort` field of the Search body request to always sort the
resulting deployments by ID, since they were not, now it should ALWAYS
return the same result order as long as the deployment array doesn't
change.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

Closes #320

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
