### PR TITLE
ec_deployment: Handle account and external trust

### DIFF
--- a/.changelog/324.txt
+++ b/.changelog/324.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/ec_deployment: Handles account and external trust settings, fixing a bug where the default trust settings are unset and allowing users to set up their own trust settings for an Elasticsearch cluster.
+```

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -236,6 +236,8 @@ The required `elasticsearch` block supports the following arguments:
 * `snapshot_source` (Optional) Restores data from a snapshot of another deployment.
 * `extension` (Optional) Custom Elasticsearch bundles or plugins. Can be set multiple times.
 * `autoscale` (Optional) Enable or disable autoscaling. Defaults to the setting coming from the deployment template. Accepted values are `"true"` or `"false"`.
+* `trust_account` (Optional) The trust relationships with other ESS accounts.
+* `trust_external` (Optional) The trust relationship with external entities (remote environments, remote accounts...).
 
 ##### Topology
 
@@ -306,6 +308,24 @@ The optional `elasticsearch.extension` block, allows custom plugins or bundles t
 * `type` (Required) Extension type, only `bundle` or `plugin` are supported.
 * `version` (Required) Elasticsearch compatibility version. Bundles should specify major or minor versions with wildcards, such as `7.*` or `*` but **plugins must use full version notation down to the patch level**, such as `7.10.1` and wildcards are not allowed.
 * `url` (Required) Bundle or plugin URL, the extension URL can be obtained from the `ec_deployment_extension.<name>.url` attribute or the API and cannot be a random HTTP address that is hosted elsewhere.
+
+##### Trust Account
+
+~> **Note on Computed Account Trusts** If your account has the default trust setting set to `Trust all my deployments (includes future deployments)`, the `trust_account` will always contain 1 element that sets up that trust. If that element is manually removed, the trust default will be unset for the cluster.
+
+The optional `elasticsearch.trust_account` block, allows cross-account trust relationships to be set. It supports the following arguments:
+
+* `account_id` (Required) The account identifier to establish the new trust with.
+* `trust_all` (Optional) If true, all clusters in this account will by default be trusted and the `trust_allowlist` is ignored.
+* `trust_allowlist` (Optional) The list of clusters to trust. Only used when `trust_all` is `false`.
+
+##### Trust External
+
+The optional `elasticsearch.trust_external` block, allows external trust relationships to be set. It supports the following arguments:
+
+* `relationship_id` (Required) Identifier of the the trust relationship with external entities (remote environments, remote accounts...).
+* `trust_all` (Optional) If true, all clusters in this external entity will be trusted and the `trust_allowlist` is ignored.
+* `trust_allowlist` (Optional) The list of clusters to trust. Only used when `trust_all` is `false`.
 
 #### Kibana
 

--- a/ec/acc/deployment_basic_test.go
+++ b/ec/acc/deployment_basic_test.go
@@ -54,11 +54,15 @@ func TestAccDeployment_basic_tf(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "enterprise_search.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "0"),
+					// Ensure at least 1 account is trusted (self).
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.trust_account.#", "1"),
 				),
 			},
 			{
 				Config: cfgWithTrafficFilter,
 				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
+					// Ensure at least 1 account is trusted (self). It isn't deleted.
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.trust_account.#", "1"),
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "1"),
 				),
 			},

--- a/ec/ecresource/deploymentresource/import_test.go
+++ b/ec/ecresource/deploymentresource/import_test.go
@@ -119,6 +119,8 @@ func Test_importFunc(t *testing.T) {
 				"elasticsearch.0.remote_cluster.#":  "0",
 				"elasticsearch.0.resource_id":       "",
 				"elasticsearch.0.topology.#":        "0",
+				"elasticsearch.0.trust_account.#":   "0",
+				"elasticsearch.0.trust_external.#":  "0",
 			},
 		},
 		{
@@ -165,6 +167,8 @@ func Test_importFunc(t *testing.T) {
 				"elasticsearch.0.remote_cluster.#":  "0",
 				"elasticsearch.0.resource_id":       "",
 				"elasticsearch.0.topology.#":        "0",
+				"elasticsearch.0.trust_account.#":   "0",
+				"elasticsearch.0.trust_external.#":  "0",
 			},
 		},
 		{
@@ -211,6 +215,8 @@ func Test_importFunc(t *testing.T) {
 				"elasticsearch.0.remote_cluster.#":  "0",
 				"elasticsearch.0.resource_id":       "",
 				"elasticsearch.0.topology.#":        "0",
+				"elasticsearch.0.trust_account.#":   "0",
+				"elasticsearch.0.trust_external.#":  "0",
 			},
 		},
 	}

--- a/ec/ecresource/deploymentresource/schema_elasticsearch.go
+++ b/ec/ecresource/deploymentresource/schema_elasticsearch.go
@@ -89,6 +89,9 @@ func newElasticsearchResource() *schema.Resource {
 			"snapshot_source": newSnapshotSourceSettings(),
 
 			"extension": newExtensionSchema(),
+
+			"trust_account":  newTrustAccountSchema(),
+			"trust_external": newTrustExternalSchema(),
 		},
 	}
 }
@@ -381,4 +384,76 @@ func esExtensionHash(v interface{}) int {
 	buf.WriteString(m["url"].(string))
 	buf.WriteString(m["name"].(string))
 	return schema.HashString(buf.String())
+}
+
+func newTrustAccountSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Optional Elasticsearch account trust settings.",
+		Optional:    true,
+		Computed:    true,
+		Elem:        accountResource(),
+	}
+}
+
+func accountResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Description: "The ID of the Account.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"trust_all": {
+				Description: "If true, all clusters in this account will by default be trusted and the `trust_allowlist` is ignored.",
+				Type:        schema.TypeBool,
+				Required:    true,
+			},
+			"trust_allowlist": {
+				Description: "The list of clusters to trust. Only used when `trust_all` is false.",
+				Type:        schema.TypeSet,
+				Set:         schema.HashString,
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func newTrustExternalSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Optional Elasticsearch external trust settings.",
+		Optional:    true,
+		Computed:    true,
+		Elem:        externalResource(),
+	}
+}
+
+func externalResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"relationship_id": {
+				Description: "The ID of the external trust relationship.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"trust_all": {
+				Description: "If true, all clusters in this account will by default be trusted and the `trust_allowlist` is ignored.",
+				Type:        schema.TypeBool,
+				Required:    true,
+			},
+			"trust_allowlist": {
+				Description: "The list of clusters to trust. Only used when `trust_all` is false.",
+				Type:        schema.TypeSet,
+				Set:         schema.HashString,
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
 }

--- a/ec/ecresource/deploymentresource/testutil_func.go
+++ b/ec/ecresource/deploymentresource/testutil_func.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // parseDeploymentTemplate is a test helper which parse a file by path and
@@ -101,4 +102,10 @@ func readerToESPayload(t *testing.T, rc io.Reader, nr bool) *models.Elasticsearc
 		"",
 		nr,
 	)
+}
+
+func newDeploymentRD(t *testing.T, id string, raw map[string]interface{}) *schema.ResourceData {
+	rd := schema.TestResourceDataRaw(t, newSchema(), raw)
+	rd.SetId(id)
+	return rd
 }


### PR DESCRIPTION
## Description
This patch adds the necessary logic to handle both account and external
trust settings, allowing users to set up their own trust settings for
an Elasticsearch cluster.

It also fixes the unfortunate bug where the default account trust is
unset by the provider on any update operation.

## Related Issues
Closes #323.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)