### PR TITLE
ec_deployment: Fix bug on upgrade with node_roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 0.3.0 (Unreleased)
 
+# 0.2.1 (Jun 17, 2021)
+
+BUG FIXES:
+
+* resource/ec_deployment: Fixes a bug which made ec_deployment version upgrades return an API error stating: `node_roles must be provided for all elasticsearch topology elements or for none of them`. ([#329](https://github.com/elastic/terraform-provider-ec/issues/329))
+
 # 0.2.0 (Jun 15, 2021)
 
 FEATURES:

--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -6,7 +6,7 @@ TEST_COUNT ?= 1
 TESTUNITARGS ?= -timeout 10s -p 4 -race -cover -coverprofile=reports/c.out
 TEST_ACC ?= github.com/elastic/terraform-provider-ec/ec/acc
 TEST_NAME ?= TestAcc
-TEST_ACC_PARALLEL = 4
+TEST_ACC_PARALLEL = 6
 
 REPORT_PATH ?= ./reports
 

--- a/ec/acc/deployment_post_node_role_upgrade_test.go
+++ b/ec/acc/deployment_post_node_role_upgrade_test.go
@@ -1,0 +1,86 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDeployment_post_node_roles(t *testing.T) {
+	resName := "ec_deployment.post_nr_upgrade"
+	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	startCfg := "testdata/deployment_post_node_roles_upgrade_1.tf"
+	upgradeVersionCfg := "testdata/deployment_post_node_roles_upgrade_2.tf"
+
+	cfgF := func(cfg string) string {
+		return fixtureAccDeploymentResourceBasic(
+			t, cfg, randomName, getRegion(), defaultTemplate,
+		)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfgF(startCfg),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size", "1g"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.node_roles.#"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.id", "hot_content"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "1"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "0"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+				),
+			},
+			{
+				Config: cfgF(upgradeVersionCfg),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size", "1g"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.node_roles.#"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.id", "hot_content"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "1"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "0"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/ec/acc/testdata/deployment_post_node_roles_upgrade_1.tf
+++ b/ec/acc/testdata/deployment_post_node_roles_upgrade_1.tf
@@ -1,12 +1,12 @@
-data "ec_stack" "pre_node_roles" {
-  version_regex = "7.??.?"
+data "ec_stack" "post_node_roles_upgrade" {
+  version_regex = "7.12.?"
   region        = "%s"
 }
 
-resource "ec_deployment" "pre_nr" {
+resource "ec_deployment" "post_nr_upgrade" {
   name                   = "%s"
   region                 = "%s"
-  version                = data.ec_stack.pre_node_roles.version
+  version                = data.ec_stack.post_node_roles_upgrade.version
   deployment_template_id = "%s"
 
   elasticsearch {

--- a/ec/acc/testdata/deployment_post_node_roles_upgrade_2.tf
+++ b/ec/acc/testdata/deployment_post_node_roles_upgrade_2.tf
@@ -1,12 +1,12 @@
-data "ec_stack" "pre_node_roles" {
+data "ec_stack" "post_node_roles_upgrade" {
   version_regex = "7.??.?"
   region        = "%s"
 }
 
-resource "ec_deployment" "pre_nr" {
+resource "ec_deployment" "post_nr_upgrade" {
   name                   = "%s"
   region                 = "%s"
-  version                = data.ec_stack.pre_node_roles.version
+  version                = data.ec_stack.post_node_roles_upgrade.version
   deployment_template_id = "%s"
 
   elasticsearch {

--- a/ec/acc/testdata/deployment_pre_node_roles_migration_3.tf
+++ b/ec/acc/testdata/deployment_pre_node_roles_migration_3.tf
@@ -1,5 +1,5 @@
 data "ec_stack" "pre_node_roles" {
-  version_regex = "7.11.?"
+  version_regex = "7.??.?"
   region        = "%s"
 }
 

--- a/ec/ecresource/deploymentresource/expanders_test.go
+++ b/ec/ecresource/deploymentresource/expanders_test.go
@@ -3777,7 +3777,7 @@ func Test_updateResourceToModel(t *testing.T) {
 			},
 		},
 		{
-			name: "does not migrate node_type to node_role on version upgrade",
+			name: "does not migrate node_type to node_role on version upgrade that's lower than 7.10.0",
 			args: args{
 				d: util.NewResourceData(t, util.ResDataParams{
 					ID: mock.ValidClusterID,
@@ -3785,7 +3785,7 @@ func Test_updateResourceToModel(t *testing.T) {
 						"name":                   "my_deployment_name",
 						"deployment_template_id": "aws-io-optimized-v2",
 						"region":                 "us-east-1",
-						"version":                "7.10.1",
+						"version":                "7.9.1",
 						"elasticsearch": []interface{}{map[string]interface{}{
 							"topology": []interface{}{map[string]interface{}{
 								"id":               "hot_content",
@@ -3867,6 +3867,104 @@ func Test_updateResourceToModel(t *testing.T) {
 									Resource: ec.String("memory"),
 								},
 							}},
+						},
+					}),
+				},
+			},
+		},
+		{
+			name: "does not migrate node_type to node_role on version upgrade that's higher than 7.10.0",
+			args: args{
+				d: util.NewResourceData(t, util.ResDataParams{
+					ID: mock.ValidClusterID,
+					State: map[string]interface{}{
+						"name":                   "my_deployment_name",
+						"deployment_template_id": "aws-io-optimized-v2",
+						"region":                 "us-east-1",
+						"version":                "7.10.1",
+						"elasticsearch": []interface{}{map[string]interface{}{
+							"topology": []interface{}{map[string]interface{}{
+								"id":               "hot_content",
+								"size":             "16g",
+								"node_type_data":   "true",
+								"node_type_ingest": "true",
+								"node_type_master": "true",
+								"node_type_ml":     "false",
+							}},
+						}},
+					},
+					Change: map[string]interface{}{
+						"name":                   "my_deployment_name",
+						"deployment_template_id": "aws-io-optimized-v2",
+						"region":                 "us-east-1",
+						"version":                "7.11.1",
+						"elasticsearch": []interface{}{map[string]interface{}{
+							"topology": []interface{}{map[string]interface{}{
+								"id":               "hot_content",
+								"size":             "16g",
+								"node_type_data":   "true",
+								"node_type_ingest": "true",
+								"node_type_master": "true",
+								"node_type_ml":     "false",
+							}},
+						}},
+					},
+					Schema: newSchema(),
+				}),
+				client: api.NewMock(mock.New200Response(ioOptimizedTpl())),
+			},
+			want: &models.DeploymentUpdateRequest{
+				Name:         "my_deployment_name",
+				PruneOrphans: ec.Bool(true),
+				Settings:     &models.DeploymentUpdateSettings{},
+				Metadata: &models.DeploymentUpdateMetadata{
+					Tags: []*models.MetadataItem{},
+				},
+				Resources: &models.DeploymentUpdateResources{
+					Elasticsearch: enrichWithEmptyTopologies(readerToESPayload(t, ioOptimizedTpl(), false), &models.ElasticsearchPayload{
+						Region: ec.String("us-east-1"),
+						RefID:  ec.String("main-elasticsearch"),
+						Settings: &models.ElasticsearchClusterSettings{
+							DedicatedMastersThreshold: 6,
+						},
+						Plan: &models.ElasticsearchClusterPlan{
+							AutoscalingEnabled: ec.Bool(false),
+							Elasticsearch: &models.ElasticsearchConfiguration{
+								Version: "7.11.1",
+							},
+							DeploymentTemplate: &models.DeploymentTemplateReference{
+								ID: ec.String("aws-io-optimized-v2"),
+							},
+							ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+								{
+									ID: "hot_content",
+									Elasticsearch: &models.ElasticsearchConfiguration{
+										NodeAttributes: map[string]string{"data": "hot"},
+									},
+									ZoneCount:               2,
+									InstanceConfigurationID: "aws.data.highio.i3",
+									Size: &models.TopologySize{
+										Resource: ec.String("memory"),
+										Value:    ec.Int32(16384),
+									},
+									NodeType: &models.ElasticsearchNodeType{
+										Data:   ec.Bool(true),
+										Ingest: ec.Bool(true),
+										Master: ec.Bool(true),
+										Ml:     ec.Bool(false),
+									},
+									TopologyElementControl: &models.TopologyElementControl{
+										Min: &models.TopologySize{
+											Resource: ec.String("memory"),
+											Value:    ec.Int32(1024),
+										},
+									},
+									AutoscalingMax: &models.TopologySize{
+										Value:    ec.Int32(118784),
+										Resource: ec.String("memory"),
+									},
+								},
+							},
 						},
 					}),
 				},


### PR DESCRIPTION
## Description

**PORT TO MASTER**

Fixes a bug that prevents deployments from upgrading when they're using
the `node_roles` field in the state.

The reason was that since the "version" field was changing, the template
field that was being chosen was `node_type_*` instead of `node_roles`.

Adds an integration test covering this scenario which was  missing, this
being the main reason why we shipped this bug with `0.2.0`.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
#329 

