### PR TITLE
ec_deployment: Fix bug where alias is ignored

### DIFF
--- a/ec/ecresource/deploymentresource/expanders.go
+++ b/ec/ecresource/deploymentresource/expanders.go
@@ -118,6 +118,7 @@ func createResourceToModel(d *schema.ResourceData, client *api.API) (*models.Dep
 func updateResourceToModel(d *schema.ResourceData, client *api.API) (*models.DeploymentUpdateRequest, error) {
 	var result = models.DeploymentUpdateRequest{
 		Name:         d.Get("name").(string),
+		Alias:        d.Get("alias").(string),
 		PruneOrphans: ec.Bool(true),
 		Resources:    &models.DeploymentUpdateResources{},
 		Settings:     &models.DeploymentUpdateSettings{},

--- a/ec/ecresource/deploymentresource/expanders_test.go
+++ b/ec/ecresource/deploymentresource/expanders_test.go
@@ -3013,6 +3013,7 @@ func Test_updateResourceToModel(t *testing.T) {
 			},
 			want: &models.DeploymentUpdateRequest{
 				Name:         "my_deployment_name",
+				Alias:        "my-deployment",
 				PruneOrphans: ec.Bool(true),
 				Settings: &models.DeploymentUpdateSettings{
 					Observability: &models.DeploymentObservabilitySettings{
@@ -3164,6 +3165,7 @@ func Test_updateResourceToModel(t *testing.T) {
 			},
 			want: &models.DeploymentUpdateRequest{
 				Name:         "my_deployment_name",
+				Alias:        "my-deployment",
 				PruneOrphans: ec.Bool(true),
 				Settings:     &models.DeploymentUpdateSettings{},
 				Metadata: &models.DeploymentUpdateMetadata{
@@ -3287,6 +3289,7 @@ func Test_updateResourceToModel(t *testing.T) {
 			},
 			want: &models.DeploymentUpdateRequest{
 				Name:         "my_deployment_name",
+				Alias:        "my-deployment",
 				PruneOrphans: ec.Bool(true),
 				Settings:     &models.DeploymentUpdateSettings{},
 				Metadata: &models.DeploymentUpdateMetadata{
@@ -3521,6 +3524,7 @@ func Test_updateResourceToModel(t *testing.T) {
 			},
 			want: &models.DeploymentUpdateRequest{
 				Name:         "my_deployment_name",
+				Alias:        "my-deployment",
 				PruneOrphans: ec.Bool(true),
 				Settings: &models.DeploymentUpdateSettings{
 					Observability: &models.DeploymentObservabilitySettings{},


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes a bug where the deployment alias field is ignored in the update
requests.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #338 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
