### PR TITLE
ec_deployment: Fix panic on null user_settings_*

### DIFF
--- a/ec/acc/deployment_emptyconf_test.go
+++ b/ec/acc/deployment_emptyconf_test.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDeployment_emptyconfig(t *testing.T) {
+	resName := "ec_deployment.emptyconfig"
+	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	startCfg := "testdata/deployment_emptyconfig.tf"
+
+	cfgF := func(cfg string) string {
+		return fixtureAccDeploymentResourceBasic(
+			t, cfg, randomName, getRegion(), defaultTemplate,
+		)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfgF(startCfg),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.config.#", "1"),
+				),
+			},
+		},
+	})
+}

--- a/ec/acc/testdata/deployment_emptyconfig.tf
+++ b/ec/acc/testdata/deployment_emptyconfig.tf
@@ -1,0 +1,22 @@
+data "ec_stack" "emptyconfig" {
+  version_regex = "latest"
+  region        = "%s"
+}
+
+resource "ec_deployment" "emptyconfig" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.emptyconfig.version
+  deployment_template_id = "%s"
+
+  elasticsearch {
+    config {
+      user_settings_yaml = null
+    }
+    topology {
+      id         = "hot_content"
+      size       = "1g"
+      zone_count = 1
+    }
+  }
+}

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -253,7 +253,10 @@ func expandEsTopology(raw interface{}, topologies []*models.ElasticsearchCluster
 
 func expandEsConfig(raw interface{}, esCfg *models.ElasticsearchConfiguration) error {
 	for _, rawCfg := range raw.([]interface{}) {
-		var cfg = rawCfg.(map[string]interface{})
+		cfg, ok := rawCfg.(map[string]interface{})
+		if !ok {
+			continue
+		}
 		if settings, ok := cfg["user_settings_json"]; ok && settings != nil {
 			if s, ok := settings.(string); ok && s != "" {
 				if err := json.Unmarshal([]byte(s), &esCfg.UserSettingsJSON); err != nil {

--- a/ec/ecresource/deploymentresource/elasticsearch_flatteners.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_flatteners.go
@@ -202,7 +202,7 @@ func flattenEsTopology(plan *models.ElasticsearchClusterPlan) ([]interface{}, er
 func flattenEsConfig(cfg *models.ElasticsearchConfiguration) []interface{} {
 	var m = make(map[string]interface{})
 	if cfg == nil {
-		return nil
+		return []interface{}{m}
 	}
 
 	if len(cfg.EnabledBuiltInPlugins) > 0 {
@@ -229,10 +229,6 @@ func flattenEsConfig(cfg *models.ElasticsearchConfiguration) []interface{} {
 		if b, _ := json.Marshal(o); len(b) > 0 && !bytes.Equal([]byte("{}"), b) {
 			m["user_settings_override_json"] = string(b)
 		}
-	}
-
-	if len(m) == 0 {
-		return nil
 	}
 
 	return []interface{}{m}

--- a/ec/ecresource/deploymentresource/elasticsearch_flatteners_test.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_flatteners_test.go
@@ -155,6 +155,7 @@ func Test_flattenEsResource(t *testing.T) {
 					"cloud_id":       "some CLOUD ID",
 					"http_endpoint":  "http://somecluster.cloud.elastic.co:9200",
 					"https_endpoint": "https://somecluster.cloud.elastic.co:9243",
+					"config":         []interface{}{map[string]interface{}{}},
 					"topology": []interface{}{
 						map[string]interface{}{
 							"id":                        "hot_content",
@@ -312,6 +313,7 @@ func Test_flattenEsResource(t *testing.T) {
 				"region":         "some-region",
 				"http_endpoint":  "http://othercluster.cloud.elastic.co:9200",
 				"https_endpoint": "https://othercluster.cloud.elastic.co:9243",
+				"config":         []interface{}{map[string]interface{}{}},
 				"remote_cluster": []interface{}{
 					map[string]interface{}{
 						"alias":            "alias",

--- a/ec/ecresource/deploymentresource/flatteners_test.go
+++ b/ec/ecresource/deploymentresource/flatteners_test.go
@@ -75,6 +75,7 @@ func Test_modelToState(t *testing.T) {
 				"ref_id":         "main-elasticsearch",
 				"region":         "azure-eastus2",
 				"resource_id":    "1238f19957874af69306787dca662154",
+				"config":         []interface{}{map[string]interface{}{}},
 				"topology": []interface{}{map[string]interface{}{
 					"id":                        "hot_content",
 					"instance_configuration_id": "azure.data.highio.l32sv2",
@@ -141,6 +142,7 @@ func Test_modelToState(t *testing.T) {
 				"ref_id":         "main-elasticsearch",
 				"region":         "aws-eu-central-1",
 				"resource_id":    "1239f7ee7196439ba2d105319ac5eba7",
+				"config":         []interface{}{map[string]interface{}{}},
 				"topology": []interface{}{map[string]interface{}{
 					"id":                        "hot_content",
 					"instance_configuration_id": "aws.data.highio.i3",
@@ -215,6 +217,7 @@ func Test_modelToState(t *testing.T) {
 				"ref_id":         "main-elasticsearch",
 				"region":         "aws-eu-central-1",
 				"resource_id":    "1239f7ee7196439ba2d105319ac5eba7",
+				"config":         []interface{}{map[string]interface{}{}},
 				"topology": []interface{}{map[string]interface{}{
 					"id":                        "hot_content",
 					"instance_configuration_id": "aws.data.highio.i3",
@@ -281,6 +284,7 @@ func Test_modelToState(t *testing.T) {
 				"ref_id":         "main-elasticsearch",
 				"region":         "gcp-asia-east1",
 				"resource_id":    "123695e76d914005bf90b717e668ad4b",
+				"config":         []interface{}{map[string]interface{}{}},
 				"topology": []interface{}{map[string]interface{}{
 					"id":                        "hot_content",
 					"instance_configuration_id": "gcp.data.highio.1",
@@ -350,6 +354,7 @@ func Test_modelToState(t *testing.T) {
 				"ref_id":         "main-elasticsearch",
 				"region":         "gcp-us-central1",
 				"resource_id":    "123e837db6ee4391bb74887be35a7a91",
+				"config":         []interface{}{map[string]interface{}{}},
 				"topology": []interface{}{
 					map[string]interface{}{
 						"id":                        "hot_content",
@@ -427,6 +432,7 @@ func Test_modelToState(t *testing.T) {
 				"ref_id":         "main-elasticsearch",
 				"region":         "gcp-asia-east1",
 				"resource_id":    "123695e76d914005bf90b717e668ad4b",
+				"config":         []interface{}{map[string]interface{}{}},
 				"topology": []interface{}{
 					map[string]interface{}{
 						"id":                        "hot_content",
@@ -518,6 +524,7 @@ func Test_modelToState(t *testing.T) {
 				"ref_id":         "main-elasticsearch",
 				"region":         "gcp-us-central1",
 				"resource_id":    "123e837db6ee4391bb74887be35a7a91",
+				"config":         []interface{}{map[string]interface{}{}},
 				"topology": []interface{}{
 					map[string]interface{}{
 						"id":                        "hot_content",
@@ -586,6 +593,7 @@ func Test_modelToState(t *testing.T) {
 				"ref_id":         "main-elasticsearch",
 				"region":         "eu-west-1",
 				"resource_id":    "1230b3ae633b4f51a432d50971f7f1c1",
+				"config":         []interface{}{map[string]interface{}{}},
 				"remote_cluster": []interface{}{
 					map[string]interface{}{
 						"alias":            "alias",
@@ -887,6 +895,7 @@ func Test_modelToState(t *testing.T) {
 					"elasticsearch": []interface{}{map[string]interface{}{
 						"autoscale": "false",
 						"cloud_id":  "up2d:someCloudID",
+						"config":    []interface{}{map[string]interface{}{}},
 						"extension": []interface{}{
 							map[string]interface{}{
 								"name":    "custom-bundle",
@@ -1027,6 +1036,7 @@ func Test_modelToState(t *testing.T) {
 					"region":                 "aws-eu-central-1",
 					"version":                "7.13.1",
 					"elasticsearch": []interface{}{map[string]interface{}{
+						"config": []interface{}{map[string]interface{}{}},
 						"region": "aws-eu-central-1",
 						"ref_id": "main-elasticsearch",
 						"topology": []interface{}{map[string]interface{}{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes a panic when any `elasticsearch.config.user_settings_*` are set to
`null`.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #345

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and acceptance tested.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)