### PR TITLE
examples: Set ES password output as sensitive

### DIFF
--- a/examples/deployment/outputs.tf
+++ b/examples/deployment/outputs.tf
@@ -19,5 +19,6 @@ output "elasticsearch_username" {
 }
 
 output "elasticsearch_password" {
-  value = ec_deployment.example_minimal.elasticsearch_password
+  value     = ec_deployment.example_minimal.elasticsearch_password
+  sensitive = true
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Sets the `elasticsearch_password` output in the `examples/deployment` as
a sensitive  output since it's marked as such in the provider schema.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
the `examples/deployment` example didn't work out of the box.
