### PR TITLE
ds/ec_deployments: Add `name` and `alias` fields

### DIFF
--- a/.changelog/362.txt
+++ b/.changelog/362.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+datasource/ec_deployments: Adds to new fields, `deployments.#.name` and `deployments.#.alias` to the data source.
+```

--- a/docs/data-sources/ec_deployments.md
+++ b/docs/data-sources/ec_deployments.md
@@ -70,6 +70,8 @@ These will not be available for interpolation.
 
 * `deployments` - List of deployments which match the specified query.
   * `deployments.#.deployment_id` - The deployment unique ID.
+  * `deployments.#.alias` - Deployment alias.
+  * `deployments.#.name` - The name of the deployment.
   * `deployments.#.elasticsearch_resource_id` - The Elasticsearch resource unique ID.
   * `deployments.#.kibana_resource_id` - The Kibana resource unique ID.
   * `deployments.#.apm_resource_id` - The APM resource unique ID.

--- a/ec/acc/datasource_deployment_basic_test.go
+++ b/ec/acc/datasource_deployment_basic_test.go
@@ -109,6 +109,10 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(depsDatasourceName, "name_prefix", namePrefix),
 					resource.TestCheckResourceAttrPair(depsDatasourceName, "deployment_template_id", resourceName, "deployment_template_id"),
 
+					// Verify Name and Alias is present
+					resource.TestCheckResourceAttrPair(depsDatasourceName, "deployments.0.name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(depsDatasourceName, "deployments.0.alias", resourceName, "alias"),
+
 					// Query results
 					resource.TestCheckResourceAttrPair(depsDatasourceName, "deployments.0.elasticsearch_resource_id", resourceName, "elasticsearch.0.resource_id"),
 					resource.TestCheckResourceAttrPair(depsDatasourceName, "deployments.0.kibana_resource_id", resourceName, "kibana.0.resource_id"),

--- a/ec/ecdatasource/deploymentdatasource/datasource.go
+++ b/ec/ecdatasource/deploymentdatasource/datasource.go
@@ -83,14 +83,11 @@ func modelToState(d *schema.ResourceData, res *models.DeploymentGetResponse) err
 		return err
 	}
 
-	if res.Alias != "" {
-		if err := d.Set("alias", res.Alias); err != nil {
-			return err
-		}
+	if err := d.Set("alias", res.Alias); err != nil {
+		return err
 	}
 
 	es := res.Resources.Elasticsearch[0]
-
 	if es.Region != nil {
 		if err := d.Set("region", *es.Region); err != nil {
 			return err

--- a/ec/ecdatasource/deploymentsdatasource/datasource.go
+++ b/ec/ecdatasource/deploymentsdatasource/datasource.go
@@ -82,6 +82,11 @@ func modelToState(d *schema.ResourceData, res *models.DeploymentsSearchResponse)
 		var m = make(map[string]interface{})
 
 		m["deployment_id"] = *deployment.ID
+		m["alias"] = deployment.Alias
+
+		if deployment.Name != nil {
+			m["name"] = deployment.Name
+		}
 
 		if len(deployment.Resources.Elasticsearch) > 0 {
 			m["elasticsearch_resource_id"] = *deployment.Resources.Elasticsearch[0].ID

--- a/ec/ecdatasource/deploymentsdatasource/datasource_test.go
+++ b/ec/ecdatasource/deploymentsdatasource/datasource_test.go
@@ -36,8 +36,23 @@ func Test_modelToState(t *testing.T) {
 	_ = deploymentsSchemaArg.Set("deployment_template_id", "azure-compute-optimized")
 
 	wantDeployments := util.NewResourceData(t, util.ResDataParams{
-		ID:     "myID",
-		State:  newSampleDeployments(),
+		ID: "myID",
+		State: map[string]interface{}{
+			"id":                     "myID",
+			"name_prefix":            "test",
+			"return_count":           1,
+			"deployment_template_id": "azure-compute-optimized",
+			"healthy":                "true",
+			"deployments": []interface{}{map[string]interface{}{
+				"name":                          "test-hello",
+				"alias":                         "dev",
+				"apm_resource_id":               "9884c76ae1cd4521a0d9918a454a700d",
+				"deployment_id":                 "a8f22a9b9e684a7f94a89df74aa14331",
+				"elasticsearch_resource_id":     "a98dd0dac15a48d5b3953384c7e571b9",
+				"enterprise_search_resource_id": "f17e4d8a61b14c12b020d85b723357ba",
+				"kibana_resource_id":            "c75297d672b54da68faecededf372f87",
+			}},
+		},
 		Schema: newSchema(),
 	})
 
@@ -48,6 +63,7 @@ func Test_modelToState(t *testing.T) {
 				Healthy: ec.Bool(true),
 				ID:      ec.String("a8f22a9b9e684a7f94a89df74aa14331"),
 				Name:    ec.String("test-hello"),
+				Alias:   "dev",
 				Resources: &models.DeploymentResources{
 					Elasticsearch: []*models.ElasticsearchResourceInfo{
 						{
@@ -87,8 +103,23 @@ func Test_modelToState(t *testing.T) {
 	_ = deploymentsSchemaArgNoID.Set("deployment_template_id", "azure-compute-optimized")
 
 	wantDeploymentsNoID := util.NewResourceData(t, util.ResDataParams{
-		ID:     "1648957651",
-		State:  newSampleDeployments(),
+		ID: "3138173215",
+		State: map[string]interface{}{
+			"id":                     "myID",
+			"name_prefix":            "test",
+			"return_count":           1,
+			"deployment_template_id": "azure-compute-optimized",
+			"healthy":                "true",
+			"deployments": []interface{}{map[string]interface{}{
+				"name":                          "test-hello",
+				"alias":                         "dev",
+				"apm_resource_id":               "9884c76ae1cd4521a0d9918a454a700d",
+				"deployment_id":                 "a8f22a9b9e684a7f94a89df74aa14331",
+				"elasticsearch_resource_id":     "a98dd0dac15a48d5b3953384c7e571b9",
+				"enterprise_search_resource_id": "f17e4d8a61b14c12b020d85b723357ba",
+				"kibana_resource_id":            "c75297d672b54da68faecededf372f87",
+			}},
+		},
 		Schema: newSchema(),
 	})
 
@@ -130,22 +161,5 @@ func Test_modelToState(t *testing.T) {
 
 			assert.Equal(t, tt.want.State().Attributes, tt.args.d.State().Attributes)
 		})
-	}
-}
-
-func newSampleDeployments() map[string]interface{} {
-	return map[string]interface{}{
-		"id":                     "myID",
-		"name_prefix":            "test",
-		"return_count":           1,
-		"deployment_template_id": "azure-compute-optimized",
-		"healthy":                "true",
-		"deployments": []interface{}{map[string]interface{}{
-			"apm_resource_id":               "9884c76ae1cd4521a0d9918a454a700d",
-			"deployment_id":                 "a8f22a9b9e684a7f94a89df74aa14331",
-			"elasticsearch_resource_id":     "a98dd0dac15a48d5b3953384c7e571b9",
-			"enterprise_search_resource_id": "f17e4d8a61b14c12b020d85b723357ba",
-			"kibana_resource_id":            "c75297d672b54da68faecededf372f87",
-		}},
 	}
 }

--- a/ec/ecdatasource/deploymentsdatasource/schema.go
+++ b/ec/ecdatasource/deploymentsdatasource/schema.go
@@ -92,6 +92,14 @@ func newDeploymentList() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"elasticsearch_resource_id": {
 				Type:     schema.TypeString,
 				Computed: true,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds two new fields, `deployments.#.name` and `deployments.#.alias` to
the `ec_deployments` datasource.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Part of #357

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and Acceptance tested.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)