### PR TITLE
github actions: skip changelog_generation on PRs

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 jobs:
   GenerateChangelog:
+    if: contains(github.ref, '/pull/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a conditional to skip running the changelog_generation job when the
push event occurs on a PR reference.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevents the job from running since it fails.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
