### PR TITLE
github action: Turn changelog generation back on

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -1,10 +1,12 @@
 name: Generate CHANGELOG
 on:
   push:
+    branches:
+      - master
+      - '[0-9].[0-9]+.[0-9]+'
   workflow_dispatch:
 jobs:
   GenerateChangelog:
-    if: contains(github.ref, '/pull/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
The change introduced in #366 turned off changelog generation for all
the runs, this attempts to turn the changelog generation back on,
since the intention was to only disable them for pull requests.
