### PR TITLE
ec_deployment: Add `config.docker_image` argument

### DIFF
--- a/ec/acc/deployment_docker_image_override_test.go
+++ b/ec/acc/deployment_docker_image_override_test.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDeployment_docker_image_override(t *testing.T) {
+	resName := "ec_deployment.docker_image"
+	randomName := prefix + "docker_image_" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	cfgF := func(cfg string) string {
+		t.Helper()
+		requiresAPIConn(t)
+
+		b, err := os.ReadFile(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fmt.Sprintf(string(b),
+			randomName, "gcp-us-west2", setDefaultTemplate("gcp-us-west2", defaultTemplate),
+		)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfgF("testdata/deployment_docker_image_override.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.config.0.docker_image", "docker.elastic.co/cloud-ci/elasticsearch:7.15.0-SNAPSHOT"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.config.0.docker_image", "docker.elastic.co/cloud-ci/kibana:7.15.0-SNAPSHOT"),
+					resource.TestCheckResourceAttr(resName, "apm.0.config.0.docker_image", "docker.elastic.co/cloud-ci/apm:7.15.0-SNAPSHOT"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.0.config.0.docker_image", "docker.elastic.co/cloud-ci/enterprise-search:7.15.0-SNAPSHOT"),
+				),
+			},
+		},
+	})
+}

--- a/ec/acc/testdata/deployment_docker_image_override.tf
+++ b/ec/acc/testdata/deployment_docker_image_override.tf
@@ -1,5 +1,5 @@
 locals {
-  name = "%s"
+  name                = "%s"
   region              = "%s"
   deployment_template = "%s"
 }

--- a/ec/acc/testdata/deployment_docker_image_override.tf
+++ b/ec/acc/testdata/deployment_docker_image_override.tf
@@ -1,0 +1,49 @@
+locals {
+  name = "%s"
+  region              = "%s"
+  deployment_template = "%s"
+}
+
+data "ec_stack" "latest" {
+  version_regex = "7.15.?"
+  region        = local.region
+}
+
+resource "ec_deployment" "docker_image" {
+  name                   = local.name
+  region                 = local.region
+  version                = data.ec_stack.latest.version
+  deployment_template_id = local.deployment_template
+
+  elasticsearch {
+    config {
+      docker_image = "docker.elastic.co/cloud-ci/elasticsearch:7.15.0-SNAPSHOT"
+    }
+    topology {
+      id         = "hot_content"
+      size       = "1g"
+      zone_count = 1
+    }
+  }
+
+  kibana {
+    config {
+      docker_image = "docker.elastic.co/cloud-ci/kibana:7.15.0-SNAPSHOT"
+    }
+  }
+
+  apm {
+    config {
+      docker_image = "docker.elastic.co/cloud-ci/apm:7.15.0-SNAPSHOT"
+    }
+  }
+
+  enterprise_search {
+    config {
+      docker_image = "docker.elastic.co/cloud-ci/enterprise-search:7.15.0-SNAPSHOT"
+    }
+    topology {
+      zone_count = 1
+    }
+  }
+}

--- a/ec/ecresource/deploymentresource/apm_expanders.go
+++ b/ec/ecresource/deploymentresource/apm_expanders.go
@@ -160,6 +160,10 @@ func expandApmConfig(raw interface{}, res *models.ApmConfiguration) error {
 		if settings, ok := cfg["user_settings_override_yaml"]; ok {
 			res.UserSettingsOverrideYaml = settings.(string)
 		}
+
+		if v, ok := cfg["docker_image"]; ok {
+			res.DockerImage = v.(string)
+		}
 	}
 
 	return nil

--- a/ec/ecresource/deploymentresource/apm_flatteners.go
+++ b/ec/ecresource/deploymentresource/apm_flatteners.go
@@ -121,6 +121,10 @@ func flattenApmConfig(cfg *models.ApmConfiguration) []interface{} {
 		}
 	}
 
+	if cfg.DockerImage != "" {
+		m["docker_image"] = cfg.DockerImage
+	}
+
 	for k, v := range flattenApmSystemConfig(cfg.SystemSettings) {
 		m[k] = v
 	}

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -291,6 +291,10 @@ func expandEsConfig(raw interface{}, esCfg *models.ElasticsearchConfiguration) e
 		if v, ok := cfg["plugins"]; ok {
 			esCfg.EnabledBuiltInPlugins = util.ItemsToString(v.(*schema.Set).List())
 		}
+
+		if v, ok := cfg["docker_image"]; ok {
+			esCfg.DockerImage = v.(string)
+		}
 	}
 
 	return nil

--- a/ec/ecresource/deploymentresource/elasticsearch_flatteners.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_flatteners.go
@@ -232,6 +232,10 @@ func flattenEsConfig(cfg *models.ElasticsearchConfiguration) []interface{} {
 		}
 	}
 
+	if cfg.DockerImage != "" {
+		m["docker_image"] = cfg.DockerImage
+	}
+
 	// If no settings are set, there's no need to store the empty values in the
 	// state and makes the state consistent with a clean import return.
 	if len(m) == 0 {

--- a/ec/ecresource/deploymentresource/enterprise_search_expanders.go
+++ b/ec/ecresource/deploymentresource/enterprise_search_expanders.go
@@ -164,6 +164,10 @@ func expandEssConfig(raw interface{}, res *models.EnterpriseSearchConfiguration)
 		if settings, ok := cfg["user_settings_override_yaml"]; ok {
 			res.UserSettingsOverrideYaml = settings.(string)
 		}
+
+		if v, ok := cfg["docker_image"]; ok {
+			res.DockerImage = v.(string)
+		}
 	}
 
 	return nil

--- a/ec/ecresource/deploymentresource/enterprise_search_flatteners.go
+++ b/ec/ecresource/deploymentresource/enterprise_search_flatteners.go
@@ -137,6 +137,10 @@ func flattenEssConfig(cfg *models.EnterpriseSearchConfiguration) []interface{} {
 		}
 	}
 
+	if cfg.DockerImage != "" {
+		m["docker_image"] = cfg.DockerImage
+	}
+
 	if len(m) == 0 {
 		return nil
 	}

--- a/ec/ecresource/deploymentresource/flatteners_test.go
+++ b/ec/ecresource/deploymentresource/flatteners_test.go
@@ -1133,6 +1133,198 @@ func Test_modelToState(t *testing.T) {
 			}),
 		},
 		{
+			name: "flattens an plan with config.docker_image set",
+			args: args{
+				d: newDeploymentRD(t, "123b7b540dfc967a7a649c18e2fce4ed", nil),
+				res: &models.DeploymentGetResponse{
+					ID:    ec.String("123b7b540dfc967a7a649c18e2fce4ed"),
+					Alias: "OH",
+					Name:  ec.String("up2d"),
+					Resources: &models.DeploymentResources{
+						Elasticsearch: []*models.ElasticsearchResourceInfo{{
+							RefID:  ec.String("main-elasticsearch"),
+							Region: ec.String("aws-eu-central-1"),
+							Info: &models.ElasticsearchClusterInfo{
+								Status: ec.String("running"),
+								PlanInfo: &models.ElasticsearchClusterPlansInfo{
+									Current: &models.ElasticsearchClusterPlanInfo{
+										Plan: &models.ElasticsearchClusterPlan{
+											DeploymentTemplate: &models.DeploymentTemplateReference{
+												ID: ec.String("aws-io-optimized-v2"),
+											},
+											Elasticsearch: &models.ElasticsearchConfiguration{
+												Version:     "7.14.1",
+												DockerImage: "docker.elastic.com/elasticsearch/cloud:7.14.1-hash",
+											},
+											ClusterTopology: []*models.ElasticsearchClusterTopologyElement{{
+												ID: "hot_content",
+												Size: &models.TopologySize{
+													Value:    ec.Int32(4096),
+													Resource: ec.String("memory"),
+												},
+												Elasticsearch: &models.ElasticsearchConfiguration{
+													UserSettingsYaml: "a.setting: true",
+												},
+												ZoneCount: 1,
+											}},
+										},
+									},
+								},
+								Settings: &models.ElasticsearchClusterSettings{},
+							},
+						}},
+						Apm: []*models.ApmResourceInfo{{
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+							RefID:                     ec.String("main-apm"),
+							Region:                    ec.String("aws-eu-central-1"),
+							Info: &models.ApmInfo{
+								Status: ec.String("running"),
+								PlanInfo: &models.ApmPlansInfo{Current: &models.ApmPlanInfo{
+									Plan: &models.ApmPlan{
+										Apm: &models.ApmConfiguration{
+											DockerImage: "docker.elastic.com/apm/cloud:7.14.1-hash",
+											SystemSettings: &models.ApmSystemSettings{
+												DebugEnabled: ec.Bool(false),
+											},
+										},
+										ClusterTopology: []*models.ApmTopologyElement{{
+											InstanceConfigurationID: "aws.apm.r5d",
+											Size: &models.TopologySize{
+												Resource: ec.String("memory"),
+												Value:    ec.Int32(512),
+											},
+											ZoneCount: 1,
+										}},
+									},
+								}},
+							},
+						}},
+						Kibana: []*models.KibanaResourceInfo{{
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+							RefID:                     ec.String("main-kibana"),
+							Region:                    ec.String("aws-eu-central-1"),
+							Info: &models.KibanaClusterInfo{
+								Status: ec.String("running"),
+								PlanInfo: &models.KibanaClusterPlansInfo{Current: &models.KibanaClusterPlanInfo{
+									Plan: &models.KibanaClusterPlan{
+										Kibana: &models.KibanaConfiguration{
+											DockerImage: "docker.elastic.com/kibana/cloud:7.14.1-hash",
+										},
+										ClusterTopology: []*models.KibanaClusterTopologyElement{{
+											InstanceConfigurationID: "aws.kibana.r5d",
+											Size: &models.TopologySize{
+												Resource: ec.String("memory"),
+												Value:    ec.Int32(1024),
+											},
+											ZoneCount: 1,
+										}},
+									},
+								}},
+							},
+						}},
+						EnterpriseSearch: []*models.EnterpriseSearchResourceInfo{{
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+							RefID:                     ec.String("main-enterprise_search"),
+							Region:                    ec.String("aws-eu-central-1"),
+							Info: &models.EnterpriseSearchInfo{
+								Status: ec.String("running"),
+								PlanInfo: &models.EnterpriseSearchPlansInfo{Current: &models.EnterpriseSearchPlanInfo{
+									Plan: &models.EnterpriseSearchPlan{
+										EnterpriseSearch: &models.EnterpriseSearchConfiguration{
+											DockerImage: "docker.elastic.com/enterprise_search/cloud:7.14.1-hash",
+										},
+										ClusterTopology: []*models.EnterpriseSearchTopologyElement{{
+											InstanceConfigurationID: "aws.enterprisesearch.m5d",
+											Size: &models.TopologySize{
+												Resource: ec.String("memory"),
+												Value:    ec.Int32(2048),
+											},
+											NodeType: &models.EnterpriseSearchNodeTypes{
+												Appserver: ec.Bool(true),
+												Connector: ec.Bool(true),
+												Worker:    ec.Bool(true),
+											},
+											ZoneCount: 2,
+										}},
+									},
+								}},
+							},
+						}},
+					},
+				},
+			},
+			want: util.NewResourceData(t, util.ResDataParams{
+				ID: "123b7b540dfc967a7a649c18e2fce4ed",
+				State: map[string]interface{}{
+					"alias":                  "OH",
+					"deployment_template_id": "aws-io-optimized-v2",
+					"id":                     "123b7b540dfc967a7a649c18e2fce4ed",
+					"name":                   "up2d",
+					"region":                 "aws-eu-central-1",
+					"version":                "7.14.1",
+					"elasticsearch": []interface{}{map[string]interface{}{
+						"region": "aws-eu-central-1",
+						"ref_id": "main-elasticsearch",
+						"config": []interface{}{map[string]interface{}{
+							"docker_image": "docker.elastic.com/elasticsearch/cloud:7.14.1-hash",
+						}},
+						"topology": []interface{}{map[string]interface{}{
+							"id":            "hot_content",
+							"size":          "4g",
+							"size_resource": "memory",
+							"zone_count":    1,
+							"config": []interface{}{map[string]interface{}{
+								"user_settings_yaml": "a.setting: true",
+							}},
+						}},
+					}},
+					"kibana": []interface{}{map[string]interface{}{
+						"region": "aws-eu-central-1",
+						"ref_id": "main-kibana",
+						"config": []interface{}{map[string]interface{}{
+							"docker_image": "docker.elastic.com/kibana/cloud:7.14.1-hash",
+						}},
+						"topology": []interface{}{map[string]interface{}{
+							"instance_configuration_id": "aws.kibana.r5d",
+							"size":                      "1g",
+							"size_resource":             "memory",
+							"zone_count":                1,
+						}},
+					}},
+					"apm": []interface{}{map[string]interface{}{
+						"region": "aws-eu-central-1",
+						"ref_id": "main-apm",
+						"config": []interface{}{map[string]interface{}{
+							"docker_image": "docker.elastic.com/apm/cloud:7.14.1-hash",
+						}},
+						"topology": []interface{}{map[string]interface{}{
+							"instance_configuration_id": "aws.apm.r5d",
+							"size":                      "0.5g",
+							"size_resource":             "memory",
+							"zone_count":                1,
+						}},
+					}},
+					"enterprise_search": []interface{}{map[string]interface{}{
+						"region": "aws-eu-central-1",
+						"ref_id": "main-enterprise_search",
+						"config": []interface{}{map[string]interface{}{
+							"docker_image": "docker.elastic.com/enterprise_search/cloud:7.14.1-hash",
+						}},
+						"topology": []interface{}{map[string]interface{}{
+							"instance_configuration_id": "aws.enterprisesearch.m5d",
+							"size":                      "2g",
+							"size_resource":             "memory",
+							"zone_count":                2,
+							"node_type_appserver":       "true",
+							"node_type_connector":       "true",
+							"node_type_worker":          "true",
+						}},
+					}},
+				},
+				Schema: newSchema(),
+			}),
+		},
+		{
 			name: "flattens an aws plan (io-optimized) with tags",
 			args: args{d: awsIOOptimizedTagsRD, res: awsIOOptimizedTagsRes},
 			want: wantAwsIOOptimizedDeploymentTags,

--- a/ec/ecresource/deploymentresource/kibana_expanders.go
+++ b/ec/ecresource/deploymentresource/kibana_expanders.go
@@ -149,6 +149,10 @@ func expandKibanaConfig(raw interface{}, res *models.KibanaConfiguration) error 
 		if settings, ok := cfg["user_settings_override_yaml"]; ok {
 			res.UserSettingsOverrideYaml = settings.(string)
 		}
+
+		if v, ok := cfg["docker_image"]; ok {
+			res.DockerImage = v.(string)
+		}
 	}
 
 	return nil

--- a/ec/ecresource/deploymentresource/kibana_flatteners.go
+++ b/ec/ecresource/deploymentresource/kibana_flatteners.go
@@ -122,6 +122,10 @@ func flattenKibanaConfig(cfg *models.KibanaConfiguration) []interface{} {
 		}
 	}
 
+	if cfg.DockerImage != "" {
+		m["docker_image"] = cfg.DockerImage
+	}
+
 	if len(m) == 0 {
 		return nil
 	}

--- a/ec/ecresource/deploymentresource/schema_apm.go
+++ b/ec/ecresource/deploymentresource/schema_apm.go
@@ -102,6 +102,11 @@ func apmConfig() *schema.Schema {
 		Description:      `Optionally define the Apm configuration options for the APM Server`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"docker_image": {
+					Type:        schema.TypeString,
+					Description: "Optionally override the docker image the APM nodes will use. Note that this field will only work for internal users only.",
+					Optional:    true,
+				},
 				// APM System Settings
 				"debug_enabled": {
 					Type:        schema.TypeBool,

--- a/ec/ecresource/deploymentresource/schema_elasticsearch.go
+++ b/ec/ecresource/deploymentresource/schema_elasticsearch.go
@@ -274,6 +274,12 @@ func elasticsearchConfig() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				// Settings
 
+				"docker_image": {
+					Type:        schema.TypeString,
+					Description: "Optionally override the docker image the Elasticsearch nodes will use. Note that this field will only work for internal users only.",
+					Optional:    true,
+				},
+
 				// Ignored settings are: [ user_bundles and user_plugins ].
 				// Adding support for them will allow users to specify
 				// "Extensions" as it is possible in the UI today.

--- a/ec/ecresource/deploymentresource/schema_enteprise_search.go
+++ b/ec/ecresource/deploymentresource/schema_enteprise_search.go
@@ -117,6 +117,11 @@ func enterpriseSearchConfig() *schema.Schema {
 		Description:      `Optionally define the Enterprise Search configuration options for the Enterprise Search Server`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"docker_image": {
+					Type:        schema.TypeString,
+					Description: "Optionally override the docker image the Enterprise Search nodes will use. Note that this field will only work for internal users only.",
+					Optional:    true,
+				},
 				"user_settings_json": {
 					Type:        schema.TypeString,
 					Description: `An arbitrary JSON object allowing (non-admin) cluster owners to set their parameters (only one of this and 'user_settings_yaml' is allowed), provided they are on the whitelist ('user_settings_whitelist') and not on the blacklist ('user_settings_blacklist'). (This field together with 'user_settings_override*' and 'system_settings' defines the total set of resource settings)`,

--- a/ec/ecresource/deploymentresource/schema_kibana.go
+++ b/ec/ecresource/deploymentresource/schema_kibana.go
@@ -99,6 +99,11 @@ func kibanaConfig() *schema.Schema {
 		Description:      `Optionally define the Kibana configuration options for the Kibana Server`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"docker_image": {
+					Type:        schema.TypeString,
+					Description: "Optionally override the docker image the Kibana nodes will use. Note that this field will only work for internal users only.",
+					Optional:    true,
+				},
 				"user_settings_json": {
 					Type:        schema.TypeString,
 					Description: `An arbitrary JSON object allowing (non-admin) cluster owners to set their parameters (only one of this and 'user_settings_yaml' is allowed), provided they are on the whitelist ('user_settings_whitelist') and not on the blacklist ('user_settings_blacklist'). (This field together with 'user_settings_override*' and 'system_settings' defines the total set of resource settings)`,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new `config.docker_image` argument to all resources which allows
Elastic Cloud internal users to override the docker image used.

**This is an internal only field, and attempting to set it to any value
when you're not part of the Elastic org, will result in an API error**.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better support for docker image overrides.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and acceptance tested 

## TODO:

- [x] Add acceptance tests using a durable docker image. (b7d915b)
- [x] Update documentation to reflect this field, pending on Cloud Writers.