### PR TITLE
ec_deployment: Persist lowest resource `version`

### DIFF
--- a/.changelog/371.txt
+++ b/.changelog/371.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/ec_deployment: Fix a bug affecting partial version upgrades, where some resources upgraded but others did not, leaving the `version` argument set to the configured value as if the upgrade was successful. The upgrade could not be retried and it was unable to detect drift.
+```

--- a/.changelog/371.txt
+++ b/.changelog/371.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/ec_deployment: Fix a bug affecting partial version upgrades, where some resources upgraded but others did not, leaving the `version` argument set to the configured value as if the upgrade was successful. The upgrade could not be retried and it was unable to detect drift.
+resource/ec_deployment: Fixed a bug that affects partial version upgrades. During an upgrade only a subset of resources would upgrade successfully, but the `version` argument value updated as if all resources were upgraded. Attempts to retry the upgrade would fail since the version difference was not detected.
 ```

--- a/ec/acc/deployment_failed_upgrade_retry_test.go
+++ b/ec/acc/deployment_failed_upgrade_retry_test.go
@@ -1,0 +1,151 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDeployment_failed_upgrade_retry(t *testing.T) {
+	var esCreds creds
+	resName := "ec_deployment.upgrade_retry"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fixtureDeploymentDefaults(t, "testdata/deployment_upgrade_retry_1.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					readEsCredentials(t, &esCreds),
+					checkMajorMinorVersion(t, resName, 7, 10),
+				),
+			},
+			{
+				// Creates an Elasticsearch index that will make the kibana upgrade fail.
+				PreConfig:   createIndex(t, &esCreds, ".kibana_2"),
+				Config:      fixtureDeploymentDefaults(t, "testdata/deployment_upgrade_retry_2.tf"),
+				ExpectError: regexp.MustCompile(`\[kibana\].*Plan change failed.*`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkMajorMinorVersion(t, resName, 7, 10),
+				),
+			},
+			{
+				// Deletes the Elasticsearch index so that the upgrade succeeds.
+				PreConfig: deleteIndex(t, &esCreds, ".kibana_2"),
+				Config:    fixtureDeploymentDefaults(t, "testdata/deployment_upgrade_retry_2.tf"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkMajorMinorVersion(t, resName, 7, 11),
+				),
+			},
+		},
+	})
+}
+
+func createIndex(t *testing.T, esCreds *creds, indexName string) func() {
+	t.Helper()
+	return func() {
+		indexURL := fmt.Sprintf(
+			esCreds.URL+"/%s", indexName,
+		)
+		req, err := http.NewRequest("PUT", indexURL, nil)
+		if err != nil {
+			t.Fatal(fmt.Errorf("failed creating snapshot request: %w", err))
+			return
+		}
+		req.SetBasicAuth(esCreds.User, esCreds.Pass)
+
+		t.Log("PUT", indexURL)
+
+		// Create a new client with no timeout, just wait for the call to return.
+		client := &http.Client{Timeout: 0}
+		res, err := client.Do(req)
+		if err != nil {
+			t.Fatal(fmt.Errorf("failed creating index %s request: %w", indexName, err))
+			return
+		}
+		if res.StatusCode != 200 {
+			t.Fatal("index create statuscode != 200")
+			return
+		}
+		t.Logf("Index %s created", indexName)
+	}
+}
+
+func deleteIndex(t *testing.T, esCreds *creds, indexName string) func() {
+	t.Helper()
+	return func() {
+		indexURL := fmt.Sprintf(
+			esCreds.URL+"/%s", indexName,
+		)
+		req, err := http.NewRequest("DELETE", indexURL, nil)
+		if err != nil {
+			t.Fatal(fmt.Errorf("failed creating snapshot request: %w", err))
+			return
+		}
+		req.SetBasicAuth(esCreds.User, esCreds.Pass)
+
+		t.Log("DELETE", indexURL)
+
+		// Create a new client with no timeout, just wait for the call to return.
+		client := &http.Client{Timeout: 0}
+		res, err := client.Do(req)
+		if err != nil {
+			t.Fatal(fmt.Errorf("failed creating index %s request: %w", indexName, err))
+			return
+		}
+		if res.StatusCode != 200 {
+			t.Fatal("index delete statuscode != 200")
+			return
+		}
+		t.Logf("Index %s deleted", indexName)
+	}
+}
+
+func checkMajorMinorVersion(t *testing.T, resName string, major, minor uint64) resource.TestCheckFunc {
+	t.Helper()
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "ec_deployment" {
+				continue
+			}
+			m := rs.Primary.Attributes
+
+			v, err := semver.Parse(m["version"])
+			if err != nil {
+				return fmt.Errorf("failed parsing deployment semver version %s: %w", m["version"], err)
+			}
+
+			if v.Major != major || v.Minor != minor {
+				return fmt.Errorf(
+					"found version %d.%d != expected version %d.%d",
+					v.Major, v.Minor,
+					major, minor,
+				)
+			}
+		}
+		return nil
+	}
+}

--- a/ec/acc/testdata/deployment_upgrade_retry_1.tf
+++ b/ec/acc/testdata/deployment_upgrade_retry_1.tf
@@ -1,0 +1,26 @@
+locals {
+  region              = "%s"
+  deployment_template = "%s"
+}
+
+data "ec_stack" "latest" {
+  version_regex = "7.10.?"
+  region        = local.region
+}
+
+resource "ec_deployment" "upgrade_retry" {
+  name                   = "terraform_acc_upgrade_retry"
+  region                 = local.region
+  version                = data.ec_stack.latest.version
+  deployment_template_id = local.deployment_template
+
+  elasticsearch {
+    topology {
+      id         = "hot_content"
+      size       = "1g"
+      zone_count = 1
+    }
+  }
+
+  kibana {}
+}

--- a/ec/acc/testdata/deployment_upgrade_retry_2.tf
+++ b/ec/acc/testdata/deployment_upgrade_retry_2.tf
@@ -1,0 +1,26 @@
+locals {
+  region              = "%s"
+  deployment_template = "%s"
+}
+
+data "ec_stack" "latest" {
+  version_regex = "7.11.?"
+  region        = local.region
+}
+
+resource "ec_deployment" "upgrade_retry" {
+  name                   = "terraform_acc_upgrade_retry"
+  region                 = local.region
+  version                = data.ec_stack.latest.version
+  deployment_template_id = local.deployment_template
+
+  elasticsearch {
+    topology {
+      id         = "hot_content"
+      size       = "1g"
+      zone_count = 1
+    }
+  }
+
+  kibana {}
+}

--- a/ec/ecresource/deploymentresource/flatteners.go
+++ b/ec/ecresource/deploymentresource/flatteners.go
@@ -203,7 +203,7 @@ func getLowestVersion(res *models.DeploymentResources) (string, error) {
 	for _, r := range res.Elasticsearch {
 		if !util.IsCurrentEsPlanEmpty(r) {
 			v := r.Info.PlanInfo.Current.Plan.Elasticsearch.Version
-			if err := swapLowerVersion(&version, v); err != nil {
+			if err := swapLowerVersion(&version, v); err != nil && !isEsResourceStopped(r) {
 				return "", fmt.Errorf("elasticsearch version '%s' is not semver compliant: %w", v, err)
 			}
 		}
@@ -212,7 +212,7 @@ func getLowestVersion(res *models.DeploymentResources) (string, error) {
 	for _, r := range res.Kibana {
 		if !util.IsCurrentKibanaPlanEmpty(r) {
 			v := r.Info.PlanInfo.Current.Plan.Kibana.Version
-			if err := swapLowerVersion(&version, v); err != nil {
+			if err := swapLowerVersion(&version, v); err != nil && !isKibanaResourceStopped(r) {
 				return version.String(), fmt.Errorf("kibana version '%s' is not semver compliant: %w", v, err)
 			}
 		}
@@ -221,7 +221,7 @@ func getLowestVersion(res *models.DeploymentResources) (string, error) {
 	for _, r := range res.Apm {
 		if !util.IsCurrentApmPlanEmpty(r) {
 			v := r.Info.PlanInfo.Current.Plan.Apm.Version
-			if err := swapLowerVersion(&version, v); err != nil {
+			if err := swapLowerVersion(&version, v); err != nil && !isApmResourceStopped(r) {
 				return version.String(), fmt.Errorf("apm version '%s' is not semver compliant: %w", v, err)
 			}
 		}
@@ -230,7 +230,7 @@ func getLowestVersion(res *models.DeploymentResources) (string, error) {
 	for _, r := range res.EnterpriseSearch {
 		if !util.IsCurrentEssPlanEmpty(r) {
 			v := r.Info.PlanInfo.Current.Plan.EnterpriseSearch.Version
-			if err := swapLowerVersion(&version, v); err != nil {
+			if err := swapLowerVersion(&version, v); err != nil && !isEssResourceStopped(r) {
 				return version.String(), fmt.Errorf("enterprise search version '%s' is not semver compliant: %w", v, err)
 			}
 		}

--- a/ec/ecresource/deploymentresource/flatteners.go
+++ b/ec/ecresource/deploymentresource/flatteners.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -58,7 +59,18 @@ func modelToState(d *schema.ResourceData, res *models.DeploymentGetResponse, rem
 			return err
 		}
 
-		if err := d.Set("version", getVersion(res.Resources)); err != nil {
+		// We're reconciling the version and storing the lowest version of any
+		// of the deployment resources. This ensures that if an upgrade fails,
+		// the state version will be lower than the desired version, making
+		// retries possible. Once more resource types are added, the function
+		// needs to be modified to check those as well.
+		version, err := getLowestVersion(res.Resources)
+		if err != nil {
+			// This code path is highly unlikely, but we're bubbling up the
+			// error in case one of the versions isn't parseable by semver.
+			return fmt.Errorf("failed reading deployment: %w", err)
+		}
+		if err := d.Set("version", version); err != nil {
 			return err
 		}
 
@@ -185,14 +197,58 @@ func getRegion(res *models.DeploymentResources) (region string) {
 	return region
 }
 
-func getVersion(res *models.DeploymentResources) (version string) {
+func getLowestVersion(res *models.DeploymentResources) (string, error) {
+	// We're starting off with a very high version so that it gets replaced.
+	version := semver.MustParse(`99.99.99`)
 	for _, r := range res.Elasticsearch {
 		if !util.IsCurrentEsPlanEmpty(r) {
-			return r.Info.PlanInfo.Current.Plan.Elasticsearch.Version
+			v := r.Info.PlanInfo.Current.Plan.Elasticsearch.Version
+			if err := swapLowerVersion(&version, v); err != nil {
+				return "", fmt.Errorf("elasticsearch version '%s' is not semver compliant: %w", v, err)
+			}
 		}
 	}
 
-	return version
+	for _, r := range res.Kibana {
+		if !util.IsCurrentKibanaPlanEmpty(r) {
+			v := r.Info.PlanInfo.Current.Plan.Kibana.Version
+			if err := swapLowerVersion(&version, v); err != nil {
+				return version.String(), fmt.Errorf("kibana version '%s' is not semver compliant: %w", v, err)
+			}
+		}
+	}
+
+	for _, r := range res.Apm {
+		if !util.IsCurrentApmPlanEmpty(r) {
+			v := r.Info.PlanInfo.Current.Plan.Apm.Version
+			if err := swapLowerVersion(&version, v); err != nil {
+				return version.String(), fmt.Errorf("apm version '%s' is not semver compliant: %w", v, err)
+			}
+		}
+	}
+
+	for _, r := range res.EnterpriseSearch {
+		if !util.IsCurrentEssPlanEmpty(r) {
+			v := r.Info.PlanInfo.Current.Plan.EnterpriseSearch.Version
+			if err := swapLowerVersion(&version, v); err != nil {
+				return version.String(), fmt.Errorf("enterprise search version '%s' is not semver compliant: %w", v, err)
+			}
+		}
+	}
+
+	return version.String(), nil
+}
+
+func swapLowerVersion(version *semver.Version, comp string) error {
+	v, err := semver.Parse(comp)
+	if err != nil {
+		return err
+	}
+
+	if v.LT(*version) {
+		*version = v
+	}
+	return nil
 }
 
 func hasRunningResources(res *models.DeploymentGetResponse) bool {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Reconciles the top level `ec_deployment.version` field to the lesser of
all of the resource versions. Cases where the version is updated and one
or more of the resources did not succeed to upgrade, were not detected
since the `version` field was not reconciled during the Read stage and
was set to the value the terraform configuration was set to without the
ability to detect drift.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Failed upgrades could not be retried through the provider.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and acceptance tested.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
