### PR TITLE
scripts: Update provider blocks with version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.2.0"
+      version = "0.3.0"
     }
   }
 }

--- a/build/Makefile.version
+++ b/build/Makefile.version
@@ -1,13 +1,18 @@
 ### Manage repository versions
 
+CURRENT_VERSION=$$($(GOBIN)/versionbump list Makefile)
+
 ## Bump the major version for the Terraform Provider for Elastic Cloud.
 major: $(GOBIN)/versionbump
 	@ $(GOBIN)/versionbump -c major Makefile
+	@ ./scripts/update-provider-version.sh $(CURRENT_VERSION)
 
 ## Bump the minor o feature version for the Terraform Provider for Elastic Cloud.
 minor: $(GOBIN)/versionbump
 	@ $(GOBIN)/versionbump -c minor Makefile
+	@ ./scripts/update-provider-version.sh $(CURRENT_VERSION)
 
 ## Bump the patch o bugfix version for the Terraform Provider for Elastic Cloud.
 patch: $(GOBIN)/versionbump
 	@ $(GOBIN)/versionbump -c patch Makefile
+	@ ./scripts/update-provider-version.sh $(CURRENT_VERSION)

--- a/scripts/update-provider-version.sh
+++ b/scripts/update-provider-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#
+# This script takes in a single parameter with the current provider version
+# and updates all the files that contain a declaration of the 'ec' provider
+# to use the current version.
+#
+
+set -e
+
+echo "-> Updating the version field on references to the previous 'ec' provider declaration"
+
+declare -a UPDATE_FILES=("README.md")
+for f in $(grep -R 'ec = {' examples | cut -d : -f1); do
+    UPDATE_FILES+=("$f")
+done
+
+for f in "${UPDATE_FILES[@]}"; do
+    # Instead of using the -i flag which its implementation differs on macOS and
+    # Linux, save the output in the temporary folder and move the result over to
+    # the original file for better OS cross-compatibility.
+    FILE_NAME="$(basename $f)"
+    sed "s/ version = \".*\"/ version = \"${1}\"/" $f > /tmp/$FILE_NAME
+    mv /tmp/$FILE_NAME $f
+done
+
+echo "-> Updated all the ec provider declarations"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new script which will be called after each version bump, which
will update all the `terraform.ec.version` references to use the version
which was just bumped. This script will be called every time a new tag
is pushed and thus will maintain all the versions in sync.

This solves an issue where the version would be updated, but the main
`README.md` and the examples would still point to the version which was
just released.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Outdated readme and examples.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<details>
  <summary>Testing instructions</summary>
  
  ### Check out the PR

```
$ echo 'diff --git a/Makefile b/Makefile
index 45c0e42..9860a66 100644
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 export GO111MODULE ?= on
-export VERSION := 0.3.0-dev
+export VERSION := 0.2.1-dev
 export BINARY := terraform-provider-ec
 export GOBIN = $(shell pwd)/bin
 
diff --git a/examples/deployment/deployment.tf b/examples/deployment/deployment.tf
index 7c6d743..23ffab8 100644
--- a/examples/deployment/deployment.tf
+++ b/examples/deployment/deployment.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.3.0"
+      version = "0.2.1"
     }
   }
 }
diff --git a/examples/deployment_ccs/deployment.tf b/examples/deployment_ccs/deployment.tf
index a1c4c92..2e067d6 100644
--- a/examples/deployment_ccs/deployment.tf
+++ b/examples/deployment_ccs/deployment.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.3.0"
+      version = "0.2.1"
     }
   }
 }
diff --git a/examples/deployment_ec2_instance/provider.tf b/examples/deployment_ec2_instance/provider.tf
index e25946a..0fa8030 100644
--- a/examples/deployment_ec2_instance/provider.tf
+++ b/examples/deployment_ec2_instance/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.3.0"
+      version = "0.2.1"
     }
 
     aws = {
diff --git a/examples/deployment_with_init/provider.tf b/examples/deployment_with_init/provider.tf
index 3df910c..1bb321a 100644
--- a/examples/deployment_with_init/provider.tf
+++ b/examples/deployment_with_init/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.3.0"
+      version = "0.2.1"
     }
   }
 }
diff --git a/examples/extension_bundle/extension.tf b/examples/extension_bundle/extension.tf
index 26e8d9e..26eafb3 100644
--- a/examples/extension_bundle/extension.tf
+++ b/examples/extension_bundle/extension.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.3.0"
+      version = "0.2.1"
     }
   }
 }

' | git apply -

```

  ### Run `make minor`
```console
$ make minor
-> Updating the version field on references to the previous 'ec' provider declaration
-> Updated all the ec provider declarations
```

  ### Run `git diff`

You should see no diff.

</details>

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
- [x] Documentation