### PR TITLE
ec_deployment: retry deallocation error on destroy

### DIFF
--- a/ec/ecresource/deploymentresource/delete.go
+++ b/ec/ecresource/deploymentresource/delete.go
@@ -89,9 +89,13 @@ func shouldRetryShutdown(err error, retries, maxRetries int) bool {
 	const timeout = "Timeout exceeded"
 	needsRetry := retries < maxRetries
 
-	var isTimeout bool
+	var isTimeout, isFailDeallocate bool
 	if err != nil {
 		isTimeout = strings.Contains(err.Error(), timeout)
+		isFailDeallocate = strings.Contains(
+			err.Error(), "Some instances were not stopped",
+		)
 	}
-	return isTimeout && needsRetry
+	return (needsRetry && isTimeout) ||
+		(needsRetry && isFailDeallocate)
 }

--- a/ec/ecresource/deploymentresource/delete_test.go
+++ b/ec/ecresource/deploymentresource/delete_test.go
@@ -173,9 +173,31 @@ func Test_shouldRetryShutdown(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "returns true when error contains a deallocation failure string",
+			args: args{
+				err: multierror.NewPrefixed("aa",
+					errors.New(`deployment [8f3c85f97536163ad117a6d37b377120] - [elasticsearch][39dd873845bc43f9b3b21b87fe1a3c99]: caught error: "Plan change failed: Some instances were not stopped`),
+				),
+				retries:    1,
+				maxRetries: 10,
+			},
+			want: true,
+		},
+		{
 			name: "returns false when error contains timeout string but exceeds max timeouts",
 			args: args{
 				err:        errors.New("Timeout exceeded"),
+				retries:    10,
+				maxRetries: 10,
+			},
+			want: false,
+		},
+		{
+			name: "returns false when error contains a deallocation failure string",
+			args: args{
+				err: multierror.NewPrefixed("aa",
+					errors.New(`deployment [8f3c85f97536163ad117a6d37b377120] - [elasticsearch][39dd873845bc43f9b3b21b87fe1a3c99]: caught error: "Plan change failed: Some instances were not stopped`),
+				),
 				retries:    10,
 				maxRetries: 10,
 			},


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the string `Some instances were not stopped` that happens quite
frequently as a retryable error on the destroy step. Should improve the
test pass rate and reduce transient errors. It's still bound by a max
of 3 retries.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running the acceptance tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
