### PR TITLE
Add info about Terraform operator scope to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _Model changes might be introduced between minors until version 1.0.0 is release
 
 The goal for a Terraform provider is to orchestrate lifecycle for deployments via common set of APIs across ESS, ESSP and ECE (see https://www.elastic.co/guide/en/cloud/current/ec-restful-api.html for API examples)
 
-Things which are out of scope for provider:
+Things which are currently out of scope for provider:
 - Configuring individual Elastic Stack components (Elasticsearch, Kibana, etc)
 - Configuring snapshots settings for deployment (since they are using Elasticsearch SLM for this now, see https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-lifecycle-management.html)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
This PR adds information about provider scope to the readme

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Close https://github.com/elastic/terraform-provider-ec/issues/387

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We often see issues/requests about features that are clearly out of the scope for the Terraform provider (mainly about managing individual Elastic Stack components through provider). This change hopefully should make it more clear.