### PR TITLE
fix: 407 sigsegv when modifying topologies config

### DIFF
--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -248,6 +248,9 @@ func expandEsTopology(raw interface{}, topologies []*models.ElasticsearchCluster
 		}
 
 		if cfg, ok := topology["config"]; ok {
+			if elem.Elasticsearch == nil {
+				elem.Elasticsearch = &models.ElasticsearchConfiguration{}
+			}
 			if err := expandEsConfig(cfg, elem.Elasticsearch); err != nil {
 				return nil, err
 			}

--- a/ec/version.go
+++ b/ec/version.go
@@ -18,4 +18,4 @@
 package ec
 
 // Version contains the current terraform provider version.
-const Version = "0.3.0-dev"
+const Version = "0.4.0-dev"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Fixes SIGSEGV error triggered by nil pointer dereferenced under certain conditions. Some of these conditions are listed in [407](https://github.com/elastic/terraform-provider-ec/issues/407).

## Description
After importing an ec_deployment resource with configuration blocks inside topology blocks for elasticsearch, such as user_settings_yaml inside a master topology configuration block, into Terraform, every change to that configuration will trigger a SIGSEGV as a nil pointer is dereferenced. This change fixes the issue by initialising that pointer when needed. 

## Related Issues
https://github.com/elastic/terraform-provider-ec/issues/407

## Motivation and Context
Modifying some ec_deployment resources after importing them into Terraform fails with a SIGSEGV (see issue above).

## How Has This Been Tested?
Added unit test. 

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing unit tests passed
- [] All new and existing tests passed
