### PR TITLE
feat: 429 add debug mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,3 +127,25 @@ $ make build
 ```
 
 You can also use the `make install` target if you wish. This target will install the binary and move it to your Terraform plugin location.
+
+### Debugging
+
+This provider supports debugger-based debugging as described in the related [Terraform SDK documentation](https://www.terraform.io/plugin/sdkv2/debugging#debugger-based-debugging). To build a provider with the necessary Go compiler flags run:
+
+```console
+$ make build GCFLAGS='-gcflags="all=-N -l"'
+```
+
+To run the provider and connect it to your debugger run:
+
+```console
+dlv --listen=:60324 --headless=true --api-version=2 --accept-multiclient exec ./bin/terraform-provider-ec -- --debug
+```
+
+Connect your debugger using port 60234 as target. The provider should output a line containing the following variable:
+
+```console
+TF_REATTACH_PROVIDERS='{"registry.terraform.io/elastic/ec":{"Protocol":"grpc","ProtocolVersion":5,"Pid":13197,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin977285207"}}}'
+```
+
+which you can export or use to prefix every Terraform command. If that variable is not printed as soon as you connect your debugger, pausing execution and restarting it might do the trick. 

--- a/build/Makefile.build
+++ b/build/Makefile.build
@@ -2,7 +2,6 @@ BINARY_LOCATION ?= bin/$(BINARY)
 PLUGIN_LOCATION ?= ~/.terraform.d/plugins
 OS = $(shell uname -s|tr '[:upper:]' '[:lower:]')
 ARCH = $(shell uname -m)
-GCFLAGS ?= ""  # For a delve debugging enabled executable use: make build GCFLAGS='-gcflags="all=-N -l"'
 STRIPPED_V ?= $(subst -dev,,$(VERSION))
 PLUGIN_0.13 = registry.terraform.io/elastic/ec/$(STRIPPED_V)/$(OS)_$(ARCH)/terraform-provider-ec_v$(STRIPPED_V)
 
@@ -20,7 +19,7 @@ generate: gen
 ## Builds the source code and saves the binary to bin/terraform-provider-ec.
 .PHONY: build
 build: gen
-	@ echo "-> Building binary in $(BINARY_LOCATION)..."
+	@ echo "-> Building binary with GCFLAGS=$(GCFLAGS) in $(BINARY_LOCATION)..."
 	@ go build $(GCFLAGS) -o $(BINARY_LOCATION) .
 
 ## Builds the source code and moves the binary to the user's terraform plugin location.

--- a/build/Makefile.build
+++ b/build/Makefile.build
@@ -2,6 +2,7 @@ BINARY_LOCATION ?= bin/$(BINARY)
 PLUGIN_LOCATION ?= ~/.terraform.d/plugins
 OS = $(shell uname -s|tr '[:upper:]' '[:lower:]')
 ARCH = $(shell uname -m)
+GCFLAGS ?= ""  # For a delve debugging enabled executable use: make build GCFLAGS='-gcflags="all=-N -l"'
 STRIPPED_V ?= $(subst -dev,,$(VERSION))
 PLUGIN_0.13 = registry.terraform.io/elastic/ec/$(STRIPPED_V)/$(OS)_$(ARCH)/terraform-provider-ec_v$(STRIPPED_V)
 
@@ -20,7 +21,7 @@ generate: gen
 .PHONY: build
 build: gen
 	@ echo "-> Building binary in $(BINARY_LOCATION)..."
-	@ go build -o $(BINARY_LOCATION) .
+	@ go build $(GCFLAGS) -o $(BINARY_LOCATION) .
 
 ## Builds the source code and moves the binary to the user's terraform plugin location.
 .PHONY: install

--- a/main.go
+++ b/main.go
@@ -18,14 +18,29 @@
 package main
 
 import (
+	"context"
+	"flag"
 	"github.com/elastic/terraform-provider-ec/ec"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"log"
 )
 
 //go:generate go run ./gen/gen.go
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: ec.Provider,
-	})
+	var debugMode bool
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{ProviderFunc: ec.Provider}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/elastic/ec", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ import (
 
 //go:generate go run ./gen/gen.go
 
+const ProviderAddr = "registry.terraform.io/elastic/ec"
+
 func main() {
 	var debugMode bool
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
@@ -35,7 +37,7 @@ func main() {
 	opts := &plugin.ServeOpts{ProviderFunc: ec.Provider}
 
 	if debugMode {
-		err := plugin.Debug(context.Background(), "registry.terraform.io/elastic/ec", opts)
+		err := plugin.Debug(context.Background(), ProviderAddr, opts)
 		if err != nil {
 			log.Fatal(err.Error())
 		}

--- a/main.go
+++ b/main.go
@@ -27,7 +27,8 @@ import (
 
 //go:generate go run ./gen/gen.go
 
-const ProviderAddr = "registry.terraform.io/elastic/ec"
+// ProviderName contains the full name for this terraform provider.
+const ProviderName = "registry.terraform.io/elastic/ec"
 
 func main() {
 	var debugMode bool
@@ -37,7 +38,7 @@ func main() {
 	opts := &plugin.ServeOpts{ProviderFunc: ec.Provider}
 
 	if debugMode {
-		err := plugin.Debug(context.Background(), ProviderAddr, opts)
+		err := plugin.Debug(context.Background(), ProviderName, opts)
 		if err != nil {
 			log.Fatal(err.Error())
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Add -debug option and related code to allow debugger-based debugging to use with a tool like delve to inspect what is happening in a provider as it is happening.

## Description
A detailed explanation is available in this section of the Terraform plugin sdk documentation:
[debugger-based-debugging](https://www.terraform.io/plugin/sdkv2/debugging#debugger-based-debugging)

## Related Issues
https://github.com/elastic/terraform-provider-ec/issues/429

## Motivation and Context
It allows investigating some issues easily. 

## How Has This Been Tested?
Issue investigation. See linked issue https://github.com/elastic/terraform-provider-ec/issues/429


## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
