### PR TITLE
acceptance: Skip Deployment_snapshot_restore test

### DIFF
--- a/ec/acc/deployment_snapshot_test.go
+++ b/ec/acc/deployment_snapshot_test.go
@@ -88,6 +88,7 @@ func readEsCredentials(t *testing.T, esCreds *creds) resource.TestCheckFunc {
 	}
 }
 
+// nolint, remove comment after the test is unskipped.
 func triggerSnapshot(t *testing.T, esCreds *creds) func() {
 	t.Helper()
 	return func() {

--- a/ec/acc/deployment_snapshot_test.go
+++ b/ec/acc/deployment_snapshot_test.go
@@ -35,6 +35,7 @@ type creds struct {
 }
 
 func TestAccDeployment_snapshot_restore(t *testing.T) {
+	t.Skip("skipped due flakiness: https://github.com/elastic/terraform-provider-ec/issues/443")
 	var esCreds creds
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Skips the test for now since it seems to be failing quite often and it
makes it difficult to rely on the acceptance tests for PR checks.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Part of #443
