### PR TITLE
Provide a default for the autoscaling min/max resource

### DIFF
--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -239,6 +239,11 @@ func expandEsTopology(raw interface{}, topologies []*models.ElasticsearchCluster
 	return res, nil
 }
 
+// expandAutoscalingDimension centralises processing of %_size and %_size_resource attributes
+// Due to limitations in the Terraform SDK, it's not possible to specify a Default on a Computed schema member
+// to work around this limitation, this function will default the %_size_resource attribute to `memory`.
+// Without this default, setting autoscaling limits on tiers which do not have those limits in the deployment
+// template leads to an API error due to the empty resource field on the TopologySize model.
 func expandAutoscalingDimension(autoscale map[string]interface{}, model *models.TopologySize, dimension string) error {
 	sizeAttribute := fmt.Sprintf("%s_size", dimension)
 	resourceAttribute := fmt.Sprintf("%s_size_resource", dimension)


### PR DESCRIPTION
## Description
This fixes an issue when specifying an autoscaling min/max when there is no corresponding min/max defined in the deployment template. 

We're unable to specify a default in the Terraform schema since the resource attributes are `Computed`. Instead we define a default in code. 

## Related Issues
Fixes https://github.com/elastic/terraform-provider-ec/issues/401

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests

Manually with:

```
resource "ec_deployment" "staging" {
  region                 = "eu-west-1"
  deployment_template_id = "aws-storage-optimized"
  version = "7.17.3"

  elasticsearch {
    topology {
      id         = "hot_content"
      size       = "2g"
      zone_count = 3

      autoscaling {
        max_size = "8g"
      }
    }

    topology {
      id         = "warm"
      size       = "2g"
      zone_count = 2

      autoscaling {
        max_size = "15g"
        min_size = "4g"
      }
    }
  }
}
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
