### PR TITLE
Don't fire the changelog generation workflow in response to the changlog generation workflow

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
       - '[0-9].[0-9]+.[0-9]+'
+    paths-ignore:
+      - CHANGELOG.md
+      - NOTICE
   workflow_dispatch:
 jobs:
   GenerateChangelog:

--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - '[0-9].[0-9]+'
       - '[0-9].[0-9]+.[0-9]+'
     paths-ignore:
       - CHANGELOG.md


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Looking at the commit history, we can see multiple `Update CHANGELOG.md and NOTICE` commits in short succession, for example: 

<img width="961" alt="image" src="https://user-images.githubusercontent.com/444668/167550115-084b799f-63f8-4968-ad8d-cd934ad39f77.png">

This change forces the changelog gen workflow to ignore commits which only include files touched by the changelog gen workflow to short circuit these cycles. 