### PR TITLE
Observability: Handle passing 'self' as target deployment-id.

### DIFF
--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -139,6 +139,13 @@ resource "ec_deployment" "example_observability" {
 }
 ```
 
+It is possible to enable observability without a second deployment, by keeping observability data in the current deployment. To enable this use `self` as `deployment_id`.
+```hcl
+observability {
+  deployment_id = "self"
+}
+```
+
 ### With Cross Cluster Search settings
 
 ```hcl
@@ -262,7 +269,7 @@ The following arguments are supported:
 * `enterprise_search` (Optional) Enterprise Search server definition, can only be specified once. For multi-node Enterprise Search deployments, use multiple `topology` blocks.
 * `apm` **DEPRECATED** (Optional) APM instance definition, can only be specified once. It should only be used with deployments with a version prior to 8.0.0.
 * `traffic_filter` (Optional) List of traffic filter rule identifiers that will be applied to the deployment.
-* `observability` (Optional) Observability settings that you can set to ship logs and metrics to a separate deployment.
+* `observability` (Optional) Observability settings that you can set to ship logs and metrics to a deployment. The target deployment can also be the current deployment itself.
 * `tags` (Optional) Key value map of arbitrary string tags.
 
 ### Resources
@@ -543,7 +550,7 @@ In addition to all the arguments above, the following attributes are exported:
 * `enterprise_search.#.topology.#.node_type_appserver` - Node type (Appserver) for the Enterprise Search topology element.
 * `enterprise_search.#.topology.#.node_type_connector` - Node type (Connector) for the Enterprise Search topology element.
 * `enterprise_search.#.topology.#.node_type_worker` - Node type (worker) for the Enterprise Search topology element.
-* `observability.#.deployment_id` - Destination deployment ID for the shipped logs and monitoring metrics.
+* `observability.#.deployment_id` - Destination deployment ID for the shipped logs and monitoring metrics. Use `self` as destination deployment ID to target the current deployment.
 * `observability.#.ref_id` - (Optional) Elasticsearch resource kind ref_id of the destination deployment.
 * `observability.#.logs` - Enables or disables shipping logs. Defaults to true.
 * `observability.#.metrics` - Enables or disables shipping metrics. Defaults to true.

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -139,7 +139,7 @@ resource "ec_deployment" "example_observability" {
 }
 ```
 
-It is possible to enable observability without a second deployment, by keeping observability data in the current deployment. To enable this use `self` as `deployment_id`.
+It is possible to enable observability without using a second deployment, by storing the observability data in the current deployment. To enable this, set `deployment_id` to `self`.
 ```hcl
 observability {
   deployment_id = "self"

--- a/ec/acc/deployment_observability_self_test.go
+++ b/ec/acc/deployment_observability_self_test.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDeployment_observability_createWithSelfObservability(t *testing.T) {
+	resName := "ec_deployment.observability"
+	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	configFile := "testdata/deployment_observability_self.tf"
+	config := fixtureAccDeploymentResourceSelfObs(t, configFile, randomName, getRegion(), defaultTemplate)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create a deployment with observability-target 'self'
+				// After creation, the target-deployment-id should be the id of the created deployment
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resName, "observability.0.deployment_id", resName, "id"),
+					resource.TestCheckResourceAttr(resName, "observability.0.metrics", "true"),
+					resource.TestCheckResourceAttr(resName, "observability.0.logs", "true"),
+				),
+			},
+		},
+	})
+}
+
+func fixtureAccDeploymentResourceSelfObs(t *testing.T, fileName, name, region, depTpl string) string {
+	t.Helper()
+
+	deploymentTpl := setDefaultTemplate(region, depTpl)
+
+	b, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf(string(b),
+		region, name, region, deploymentTpl,
+	)
+}

--- a/ec/acc/testdata/deployment_observability_self.tf
+++ b/ec/acc/testdata/deployment_observability_self.tf
@@ -1,0 +1,32 @@
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
+
+resource "ec_deployment" "observability" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
+
+  observability {
+    deployment_id = "self"
+  }
+
+  elasticsearch {
+    autoscale = "false"
+
+    topology {
+      id         = "hot_content"
+      size       = "1g"
+      zone_count = 1
+    }
+  }
+
+  kibana {
+    topology {
+      size       = "1g"
+      zone_count = 1
+    }
+  }
+}

--- a/ec/ecresource/deploymentresource/observability.go
+++ b/ec/ecresource/deploymentresource/observability.go
@@ -72,7 +72,14 @@ func expandObservability(raw []interface{}, client *api.API) (*models.Deployment
 		}
 
 		refID, ok := obs["ref_id"]
-		if !ok || refID == "" {
+		if depID == "self" {
+			// For self monitoring, the refID is not mandatory
+			if !ok {
+				refID = ""
+			}
+		} else if !ok || refID == "" {
+			// Since ms-77, the refID is optional.
+			// To not break ECE users with older versions, we still pre-calculate the refID here
 			params := deploymentapi.PopulateRefIDParams{
 				Kind:         util.Elasticsearch,
 				API:          client,

--- a/ec/ecresource/deploymentresource/observability_test.go
+++ b/ec/ecresource/deploymentresource/observability_test.go
@@ -259,6 +259,71 @@ func TestExpandObservability(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "observability targeting self without ref-id",
+			args: args{
+				API: api.NewMock(
+					mock.New200Response(
+						mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String(mock.ValidClusterID),
+							Resources: &models.DeploymentResources{
+								Elasticsearch: []*models.ElasticsearchResourceInfo{{
+									ID:    ec.String(mock.ValidClusterID),
+									RefID: ec.String("main-elasticsearch"),
+								}},
+							},
+						}),
+					),
+				),
+				v: []interface{}{map[string]interface{}{
+					"deployment_id": "self",
+					"metrics":       true,
+					"logs":          false,
+				}},
+			},
+			want: &models.DeploymentObservabilitySettings{
+				Metrics: &models.DeploymentMetricsSettings{
+					Destination: &models.ObservabilityAbsoluteDeployment{
+						DeploymentID: ec.String("self"),
+						RefID:        "",
+					},
+				},
+			},
+		},
+		{
+			name: "observability targeting self with ref-id",
+			args: args{
+				API: api.NewMock(
+					mock.New200Response(
+						mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String(mock.ValidClusterID),
+							Resources: &models.DeploymentResources{
+								Elasticsearch: []*models.ElasticsearchResourceInfo{{
+									ID:    ec.String(mock.ValidClusterID),
+									RefID: ec.String("main-elasticsearch"),
+								}},
+							},
+						}),
+					),
+				),
+				v: []interface{}{map[string]interface{}{
+					"deployment_id": "self",
+					"ref_id":        "main-elasticsearch",
+					"metrics":       true,
+					"logs":          false,
+				}},
+			},
+			want: &models.DeploymentObservabilitySettings{
+				Metrics: &models.DeploymentMetricsSettings{
+					Destination: &models.ObservabilityAbsoluteDeployment{
+						DeploymentID: ec.String("self"),
+						RefID:        "main-elasticsearch",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Passing 'self' as the deployment-id is considered the same as the actual deployment-id of the resource itself. Adjusts the diff-calculation to always map 'self' to the current deployment-id. When creating the deployment, the value stays as 'self' since the deployment-id will only be known after creation.

I updated the docs to show this new capability, but might need some improvement. It is now possible to use the following config
```
observability {
  deployment_id: "self"
}
```
To directly enable self-monitoring even when creating a deployment

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Fixes https://github.com/elastic/terraform-provider-ec/issues/333

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

