### PR TITLE
Elasticsearch configuration strategy support

### DIFF
--- a/.changelog/507.txt
+++ b/.changelog/507.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+resource/elasticsearch: Adds support for the `strategy` property to the `elasticsearch` resource. This allows users to define how different plan changes are coordinated.
+```

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -382,7 +382,7 @@ The optional `elasticsearch.trust_external` block, allows external trust relatio
 
 ##### Strategy
 
-The optional `elasticsearch.strategy` allows choosing the configuration strategy used to apply the changes. This is a fine tune setting, you do not change it unless you have a specific case where the `autodetect` do not cover your use case.
+The optional `elasticsearch.strategy` allows you to choose the configuration strategy used to apply the changes. You do not need to change this setting unless you have a specific case where the `autodetect` does not cover your use case.
 
 * `type` Set the type of configuration strategy [autodetect, grow_and_shrink, rolling_grow_and_shrink, rolling_all].
   * `autodetect` try to use the best associated with the type of change in the plan.

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -387,8 +387,8 @@ The optional `elasticsearch.strategy` allow to choose the configuration strategy
 * `type` Set the type of configuration strategy [autodetect, grow_and_shrink, rolling_grow_and_shrink, rolling_all].
   * `autodetect` try to use the best associated with the type of change in the plan.
   * `grow_and_shrink` Add all nodes with the new changes before to stop any node.
-  * `rolling_grow_and_shrink` Add nodes one by one replacing the existing ones when the new node es ready.
-  * `rolling_all` Strop all nodes perform the changes and start all nodes.
+  * `rolling_grow_and_shrink` Add nodes one by one replacing the existing ones when the new node is ready.
+  * `rolling_all` Stop all nodes, perform the changes and start all nodes.
  
 #### Kibana
 

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -207,6 +207,36 @@ resource "ec_deployment" "with_tags" {
 }
 ```
 
+### With configuration strategy
+
+```hcl
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "us-east-1"
+}
+
+resource "ec_deployment" "with_tags" {
+  # Optional name.
+  name = "my_example_deployment"
+
+  # Mandatory fields
+  region                 = "us-east-1"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "aws-io-optimized-v2"
+
+  elasticsearch {
+    strategy {
+      type = "rolling_all"
+    }
+  }
+
+  tags = {
+    owner     = "elastic cloud"
+    component = "search"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -260,6 +290,7 @@ The required `elasticsearch` block supports the following arguments:
 * `autoscale` (Optional) Enable or disable autoscaling. Defaults to the setting coming from the deployment template. Accepted values are `"true"` or `"false"`.
 * `trust_account` (Optional) The trust relationships with other ESS accounts.
 * `trust_external` (Optional) The trust relationship with external entities (remote environments, remote accounts...).
+* `strategy` (Optional) Choose the configuration strategy used to apply the changes.
 
 ##### Topology
 
@@ -349,6 +380,16 @@ The optional `elasticsearch.trust_external` block, allows external trust relatio
 * `trust_all` (Optional) If true, all clusters in this external entity will be trusted and the `trust_allowlist` is ignored.
 * `trust_allowlist` (Optional) The list of clusters to trust. Only used when `trust_all` is `false`.
 
+##### Strategy
+
+The optional `elasticsearch.strategy` allow to choose the configuration strategy used to apply the changes.
+
+* `type` Set the type of configuration strategy [autodetect, grow_and_shrink, rolling_grow_and_shrink, rolling_all].
+  * `autodetect` try to use the best associated with the type of change in the plan.
+  * `grow_and_shrink` Add all nodes with the new changes before to stop any node.
+  * `rolling_grow_and_shrink` Add nodes one by one replacing the existing ones when the new node es ready.
+  * `rolling_all` Strop all nodes perform the changes and start all nodes.
+ 
 #### Kibana
 
 The optional `kibana` block supports the following arguments:

--- a/docs/resources/ec_deployment.md
+++ b/docs/resources/ec_deployment.md
@@ -382,7 +382,7 @@ The optional `elasticsearch.trust_external` block, allows external trust relatio
 
 ##### Strategy
 
-The optional `elasticsearch.strategy` allow to choose the configuration strategy used to apply the changes.
+The optional `elasticsearch.strategy` allows choosing the configuration strategy used to apply the changes. This is a fine tune setting, you do not change it unless you have a specific case where the `autodetect` do not cover your use case.
 
 * `type` Set the type of configuration strategy [autodetect, grow_and_shrink, rolling_grow_and_shrink, rolling_all].
   * `autodetect` try to use the best associated with the type of change in the plan.

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -145,13 +145,13 @@ func expandEsResource(raw interface{}, res *models.ElasticsearchPayload) (*model
 	}
 
 	if strategy, ok := es["strategy"]; ok {
-		if s := strategy.(*schema.Set); s.Len() > 0 {
+		if s := strategy.([]interface{}); len(s) > 0 {
 			if res.Plan.Transient == nil {
 				res.Plan.Transient = &models.TransientElasticsearchPlanConfiguration{
 					Strategy: &models.PlanStrategy{},
 				}
 			}
-			expandStrategy(s.List(), res.Plan.Transient.Strategy)
+			expandStrategy(s, res.Plan.Transient.Strategy)
 		}
 	}
 

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -159,9 +159,8 @@ func expandEsResource(raw interface{}, res *models.ElasticsearchPayload) (*model
 }
 
 // expandStrategy expands the Configuration Strategy.
-func expandStrategy(raw interface{}, strategy *models.PlanStrategy) (*models.PlanStrategy, error) {
+func expandStrategy(raw interface{}, strategy *models.PlanStrategy) *models.PlanStrategy {
 	res := strategy
-	var err error = nil
 	for _, rawStrategy := range raw.([]interface{}) {
 		strategyCfg, ok := rawStrategy.(map[string]interface{})
 		if !ok {
@@ -178,13 +177,9 @@ func expandStrategy(raw interface{}, strategy *models.PlanStrategy) (*models.Pla
 			strategy.Rolling = &models.RollingStrategyConfig{
 				GroupBy: "__all__",
 			}
-		} else {
-			err = fmt.Errorf(`invalid strategy: valid strategies are %s`,
-				strings.Join(strategiesList, ", "),
-			)
 		}
 	}
-	return res, err
+	return res
 }
 
 // expandEsTopology expands a flattened topology

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -159,27 +159,25 @@ func expandEsResource(raw interface{}, res *models.ElasticsearchPayload) (*model
 }
 
 // expandStrategy expands the Configuration Strategy.
-func expandStrategy(raw interface{}, strategy *models.PlanStrategy) *models.PlanStrategy {
-	res := strategy
-	for _, rawStrategy := range raw.([]interface{}) {
-		strategyCfg, ok := rawStrategy.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		rawValue := strategyCfg["type"].(string)
-		if rawValue == autodetect {
-			strategy.Autodetect = new(models.AutodetectStrategyConfig)
-		} else if rawValue == growAndShrink {
-			strategy.GrowAndShrink = new(models.GrowShrinkStrategyConfig)
-		} else if rawValue == rollingGrowAndShrink {
-			strategy.RollingGrowAndShrink = new(models.RollingGrowShrinkStrategyConfig)
-		} else if rawValue == rollingAll {
-			strategy.Rolling = &models.RollingStrategyConfig{
-				GroupBy: "__all__",
-			}
-		}
-	}
-	return res
+func expandStrategy(raw interface{}, strategy *models.PlanStrategy) {
+   for _, rawStrategy := range raw.([]interface{}) {
+   	strategyCfg, ok := rawStrategy.(map[string]interface{})
+   	if !ok {
+   		continue
+   	}
+   	rawValue := strategyCfg["type"].(string)
+   	if rawValue == autodetect {
+   		strategy.Autodetect = new(models.AutodetectStrategyConfig)
+   	} else if rawValue == growAndShrink {
+   		strategy.GrowAndShrink = new(models.GrowShrinkStrategyConfig)
+   	} else if rawValue == rollingGrowAndShrink {
+   		strategy.RollingGrowAndShrink = new(models.RollingGrowShrinkStrategyConfig)
+   	} else if rawValue == rollingAll {
+   		strategy.Rolling = &models.RollingStrategyConfig{
+   			GroupBy: "__all__",
+   		}
+   	}
+   }
 }
 
 // expandEsTopology expands a flattened topology

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -160,24 +160,24 @@ func expandEsResource(raw interface{}, res *models.ElasticsearchPayload) (*model
 
 // expandStrategy expands the Configuration Strategy.
 func expandStrategy(raw interface{}, strategy *models.PlanStrategy) {
-   for _, rawStrategy := range raw.([]interface{}) {
-   	strategyCfg, ok := rawStrategy.(map[string]interface{})
-   	if !ok {
-   		continue
-   	}
-   	rawValue := strategyCfg["type"].(string)
-   	if rawValue == autodetect {
-   		strategy.Autodetect = new(models.AutodetectStrategyConfig)
-   	} else if rawValue == growAndShrink {
-   		strategy.GrowAndShrink = new(models.GrowShrinkStrategyConfig)
-   	} else if rawValue == rollingGrowAndShrink {
-   		strategy.RollingGrowAndShrink = new(models.RollingGrowShrinkStrategyConfig)
-   	} else if rawValue == rollingAll {
-   		strategy.Rolling = &models.RollingStrategyConfig{
-   			GroupBy: "__all__",
-   		}
-   	}
-   }
+	for _, rawStrategy := range raw.([]interface{}) {
+		strategyCfg, ok := rawStrategy.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rawValue := strategyCfg["type"].(string)
+		if rawValue == autodetect {
+			strategy.Autodetect = new(models.AutodetectStrategyConfig)
+		} else if rawValue == growAndShrink {
+			strategy.GrowAndShrink = new(models.GrowShrinkStrategyConfig)
+		} else if rawValue == rollingGrowAndShrink {
+			strategy.RollingGrowAndShrink = new(models.RollingGrowShrinkStrategyConfig)
+		} else if rawValue == rollingAll {
+			strategy.Rolling = &models.RollingStrategyConfig{
+				GroupBy: "__all__",
+			}
+		}
+	}
 }
 
 // expandEsTopology expands a flattened topology

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -169,16 +169,12 @@ func expandStrategy(raw interface{}, strategy *models.PlanStrategy) (*models.Pla
 		}
 		rawValue := strategyCfg["type"].(string)
 		if rawValue == autodetect {
-			fmt.Printf("Strategy configured autodetect ---------------------------------------->>>>>>>>>>>>>>>>>>>>>>")
 			strategy.Autodetect = new(models.AutodetectStrategyConfig)
 		} else if rawValue == growAndShrink {
-			fmt.Print("Strategy configured growAndShrink ---------------------------------------->>>>>>>>>>>>>>>>>>>>>>")
 			strategy.GrowAndShrink = new(models.GrowShrinkStrategyConfig)
 		} else if rawValue == rollingGrowAndShrink {
-			fmt.Print("Strategy configured rollingGrowAndShrink ---------------------------------------->>>>>>>>>>>>>>>>>>>>>>")
 			strategy.RollingGrowAndShrink = new(models.RollingGrowShrinkStrategyConfig)
 		} else if rawValue == rollingAll {
-			fmt.Print("Strategy configured rollingAll ---------------------------------------->>>>>>>>>>>>>>>>>>>>>>")
 			strategy.Rolling = &models.RollingStrategyConfig{
 				GroupBy: "__all__",
 			}

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -145,13 +145,13 @@ func expandEsResource(raw interface{}, res *models.ElasticsearchPayload) (*model
 	}
 
 	if strategy, ok := es["strategy"]; ok {
-		if s := strategy.([]interface{}); len(s) > 0 {
+		if s := strategy.(*schema.Set); s.Len() > 0 {
 			if res.Plan.Transient == nil {
 				res.Plan.Transient = &models.TransientElasticsearchPlanConfiguration{
 					Strategy: &models.PlanStrategy{},
 				}
 			}
-			expandStrategy(s, res.Plan.Transient.Strategy)
+			expandStrategy(s.List(), res.Plan.Transient.Strategy)
 		}
 	}
 

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders_test.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders_test.go
@@ -1663,6 +1663,316 @@ func Test_expandEsResource(t *testing.T) {
 				},
 			}),
 		},
+		{
+			name: "parse autodetect configuration strategy",
+			args: args{
+				dt: tp770(),
+				ess: []interface{}{
+					map[string]interface{}{
+						"ref_id":      "main-elasticsearch",
+						"resource_id": mock.ValidClusterID,
+						"version":     "7.7.0",
+						"region":      "some-region",
+						"topology": []interface{}{map[string]interface{}{
+							"id":         "hot_content",
+							"size":       "2g",
+							"zone_count": 1,
+						}},
+						"strategy": map[string]interface{}{
+							"autodetect": "true",
+						},
+					},
+				},
+			},
+
+			want: enrichWithEmptyTopologies(tp770(), &models.ElasticsearchPayload{
+				Region: ec.String("some-region"),
+				RefID:  ec.String("main-elasticsearch"),
+				Settings: &models.ElasticsearchClusterSettings{
+					DedicatedMastersThreshold: 6,
+				},
+				Plan: &models.ElasticsearchClusterPlan{
+					AutoscalingEnabled: ec.Bool(false),
+					Elasticsearch: &models.ElasticsearchConfiguration{
+						Version: "7.7.0",
+					},
+					DeploymentTemplate: &models.DeploymentTemplateReference{
+						ID: ec.String("aws-io-optimized-v2"),
+					},
+					ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+						{
+							ID:                      "hot_content",
+							ZoneCount:               1,
+							InstanceConfigurationID: "aws.data.highio.i3",
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(2048),
+							},
+							NodeType: &models.ElasticsearchNodeType{
+								Data:   ec.Bool(true),
+								Ingest: ec.Bool(true),
+								Master: ec.Bool(true),
+							},
+							Elasticsearch: &models.ElasticsearchConfiguration{
+								NodeAttributes: map[string]string{
+									"data": "hot",
+								},
+							},
+							TopologyElementControl: &models.TopologyElementControl{
+								Min: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+							},
+							AutoscalingMax: &models.TopologySize{
+								Value:    ec.Int32(118784),
+								Resource: ec.String("memory"),
+							},
+						},
+					},
+					Transient: &models.TransientElasticsearchPlanConfiguration{
+						Strategy: &models.PlanStrategy{
+							Autodetect: new(models.AutodetectStrategyConfig),
+						},
+					},
+				},
+			}),
+		},
+		{
+			name: "parse grow_and_shrink configuration strategy",
+			args: args{
+				dt: tp770(),
+				ess: []interface{}{
+					map[string]interface{}{
+						"ref_id":      "main-elasticsearch",
+						"resource_id": mock.ValidClusterID,
+						"version":     "7.7.0",
+						"region":      "some-region",
+						"topology": []interface{}{map[string]interface{}{
+							"id":         "hot_content",
+							"size":       "2g",
+							"zone_count": 1,
+						}},
+						"strategy": map[string]interface{}{
+							"grow_and_shrink": "true",
+						},
+					},
+				},
+			},
+
+			want: enrichWithEmptyTopologies(tp770(), &models.ElasticsearchPayload{
+				Region: ec.String("some-region"),
+				RefID:  ec.String("main-elasticsearch"),
+				Settings: &models.ElasticsearchClusterSettings{
+					DedicatedMastersThreshold: 6,
+				},
+				Plan: &models.ElasticsearchClusterPlan{
+					AutoscalingEnabled: ec.Bool(false),
+					Elasticsearch: &models.ElasticsearchConfiguration{
+						Version: "7.7.0",
+					},
+					DeploymentTemplate: &models.DeploymentTemplateReference{
+						ID: ec.String("aws-io-optimized-v2"),
+					},
+					ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+						{
+							ID:                      "hot_content",
+							ZoneCount:               1,
+							InstanceConfigurationID: "aws.data.highio.i3",
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(2048),
+							},
+							NodeType: &models.ElasticsearchNodeType{
+								Data:   ec.Bool(true),
+								Ingest: ec.Bool(true),
+								Master: ec.Bool(true),
+							},
+							Elasticsearch: &models.ElasticsearchConfiguration{
+								NodeAttributes: map[string]string{
+									"data": "hot",
+								},
+							},
+							TopologyElementControl: &models.TopologyElementControl{
+								Min: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+							},
+							AutoscalingMax: &models.TopologySize{
+								Value:    ec.Int32(118784),
+								Resource: ec.String("memory"),
+							},
+						},
+					},
+					Transient: &models.TransientElasticsearchPlanConfiguration{
+						Strategy: &models.PlanStrategy{
+							GrowAndShrink: new(models.GrowShrinkStrategyConfig),
+						},
+					},
+				},
+			}),
+		},
+		{
+			name: "parse rolling_grow_and_shrink configuration strategy",
+			args: args{
+				dt: tp770(),
+				ess: []interface{}{
+					map[string]interface{}{
+						"ref_id":      "main-elasticsearch",
+						"resource_id": mock.ValidClusterID,
+						"version":     "7.7.0",
+						"region":      "some-region",
+						"topology": []interface{}{map[string]interface{}{
+							"id":         "hot_content",
+							"size":       "2g",
+							"zone_count": 1,
+						}},
+						"strategy": map[string]interface{}{
+							"rolling_grow_and_shrink": "true",
+						},
+					},
+				},
+			},
+
+			want: enrichWithEmptyTopologies(tp770(), &models.ElasticsearchPayload{
+				Region: ec.String("some-region"),
+				RefID:  ec.String("main-elasticsearch"),
+				Settings: &models.ElasticsearchClusterSettings{
+					DedicatedMastersThreshold: 6,
+				},
+				Plan: &models.ElasticsearchClusterPlan{
+					AutoscalingEnabled: ec.Bool(false),
+					Elasticsearch: &models.ElasticsearchConfiguration{
+						Version: "7.7.0",
+					},
+					DeploymentTemplate: &models.DeploymentTemplateReference{
+						ID: ec.String("aws-io-optimized-v2"),
+					},
+					ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+						{
+							ID:                      "hot_content",
+							ZoneCount:               1,
+							InstanceConfigurationID: "aws.data.highio.i3",
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(2048),
+							},
+							NodeType: &models.ElasticsearchNodeType{
+								Data:   ec.Bool(true),
+								Ingest: ec.Bool(true),
+								Master: ec.Bool(true),
+							},
+							Elasticsearch: &models.ElasticsearchConfiguration{
+								NodeAttributes: map[string]string{
+									"data": "hot",
+								},
+							},
+							TopologyElementControl: &models.TopologyElementControl{
+								Min: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+							},
+							AutoscalingMax: &models.TopologySize{
+								Value:    ec.Int32(118784),
+								Resource: ec.String("memory"),
+							},
+						},
+					},
+					Transient: &models.TransientElasticsearchPlanConfiguration{
+						Strategy: &models.PlanStrategy{
+							RollingGrowAndShrink: new(models.RollingGrowShrinkStrategyConfig),
+						},
+					},
+				},
+			}),
+		},
+		{
+			name: "parse rolling configuration strategy",
+			args: args{
+				dt: tp770(),
+				ess: []interface{}{
+					map[string]interface{}{
+						"ref_id":      "main-elasticsearch",
+						"resource_id": mock.ValidClusterID,
+						"version":     "7.7.0",
+						"region":      "some-region",
+						"topology": []interface{}{map[string]interface{}{
+							"id":         "hot_content",
+							"size":       "2g",
+							"zone_count": 1,
+						}},
+						"strategy": map[string]interface{}{
+							"rolling": map[string]interface{}{
+								"allowInlineResize": false,
+								"skipSyncedFlush":   false,
+								"shardInitWaitTime": int64(600),
+								"groupBy":           "__all__",
+							},
+						},
+					},
+				},
+			},
+
+			want: enrichWithEmptyTopologies(tp770(), &models.ElasticsearchPayload{
+				Region: ec.String("some-region"),
+				RefID:  ec.String("main-elasticsearch"),
+				Settings: &models.ElasticsearchClusterSettings{
+					DedicatedMastersThreshold: 6,
+				},
+				Plan: &models.ElasticsearchClusterPlan{
+					AutoscalingEnabled: ec.Bool(false),
+					Elasticsearch: &models.ElasticsearchConfiguration{
+						Version: "7.7.0",
+					},
+					DeploymentTemplate: &models.DeploymentTemplateReference{
+						ID: ec.String("aws-io-optimized-v2"),
+					},
+					ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+						{
+							ID:                      "hot_content",
+							ZoneCount:               1,
+							InstanceConfigurationID: "aws.data.highio.i3",
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(2048),
+							},
+							NodeType: &models.ElasticsearchNodeType{
+								Data:   ec.Bool(true),
+								Ingest: ec.Bool(true),
+								Master: ec.Bool(true),
+							},
+							Elasticsearch: &models.ElasticsearchConfiguration{
+								NodeAttributes: map[string]string{
+									"data": "hot",
+								},
+							},
+							TopologyElementControl: &models.TopologyElementControl{
+								Min: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+							},
+							AutoscalingMax: &models.TopologySize{
+								Value:    ec.Int32(118784),
+								Resource: ec.String("memory"),
+							},
+						},
+					},
+					Transient: &models.TransientElasticsearchPlanConfiguration{
+						Strategy: &models.PlanStrategy{
+							Rolling: &models.RollingStrategyConfig{
+								AllowInlineResize: ec.Bool(false),
+								ShardInitWaitTime: 600,
+								SkipSyncedFlush:   ec.Bool(false),
+								GroupBy:           "__all__",
+							},
+						},
+					},
+				},
+			}),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders_test.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders_test.go
@@ -1678,9 +1678,9 @@ func Test_expandEsResource(t *testing.T) {
 							"size":       "2g",
 							"zone_count": 1,
 						}},
-						"strategy": map[string]interface{}{
-							"autodetect": "true",
-						},
+						"strategy": []interface{}{map[string]interface{}{
+							"type": "autodetect",
+						}},
 					},
 				},
 			},
@@ -1753,9 +1753,9 @@ func Test_expandEsResource(t *testing.T) {
 							"size":       "2g",
 							"zone_count": 1,
 						}},
-						"strategy": map[string]interface{}{
-							"grow_and_shrink": "true",
-						},
+						"strategy": []interface{}{map[string]interface{}{
+							"type": "grow_and_shrink",
+						}},
 					},
 				},
 			},
@@ -1828,9 +1828,9 @@ func Test_expandEsResource(t *testing.T) {
 							"size":       "2g",
 							"zone_count": 1,
 						}},
-						"strategy": map[string]interface{}{
-							"rolling_grow_and_shrink": "true",
-						},
+						"strategy": []interface{}{map[string]interface{}{
+							"type": "rolling_grow_and_shrink",
+						}},
 					},
 				},
 			},
@@ -1903,14 +1903,9 @@ func Test_expandEsResource(t *testing.T) {
 							"size":       "2g",
 							"zone_count": 1,
 						}},
-						"strategy": map[string]interface{}{
-							"rolling": map[string]interface{}{
-								"allowInlineResize": false,
-								"skipSyncedFlush":   false,
-								"shardInitWaitTime": int64(600),
-								"groupBy":           "__all__",
-							},
-						},
+						"strategy": []interface{}{map[string]interface{}{
+							"type": "rolling_all",
+						}},
 					},
 				},
 			},
@@ -1963,10 +1958,7 @@ func Test_expandEsResource(t *testing.T) {
 					Transient: &models.TransientElasticsearchPlanConfiguration{
 						Strategy: &models.PlanStrategy{
 							Rolling: &models.RollingStrategyConfig{
-								AllowInlineResize: ec.Bool(false),
-								ShardInitWaitTime: 600,
-								SkipSyncedFlush:   ec.Bool(false),
-								GroupBy:           "__all__",
+								GroupBy: "__all__",
 							},
 						},
 					},

--- a/ec/ecresource/deploymentresource/import_test.go
+++ b/ec/ecresource/deploymentresource/import_test.go
@@ -121,6 +121,7 @@ func Test_importFunc(t *testing.T) {
 				"elasticsearch.0.topology.#":        "0",
 				"elasticsearch.0.trust_account.#":   "0",
 				"elasticsearch.0.trust_external.#":  "0",
+				"elasticsearch.0.strategy.#":        "0",
 			},
 		},
 		{
@@ -169,6 +170,7 @@ func Test_importFunc(t *testing.T) {
 				"elasticsearch.0.topology.#":        "0",
 				"elasticsearch.0.trust_account.#":   "0",
 				"elasticsearch.0.trust_external.#":  "0",
+				"elasticsearch.0.strategy.#":        "0",
 			},
 		},
 		{
@@ -217,6 +219,7 @@ func Test_importFunc(t *testing.T) {
 				"elasticsearch.0.topology.#":        "0",
 				"elasticsearch.0.trust_account.#":   "0",
 				"elasticsearch.0.trust_external.#":  "0",
+				"elasticsearch.0.strategy.#":        "0",
 			},
 		},
 	}

--- a/ec/ecresource/deploymentresource/schema_elasticsearch.go
+++ b/ec/ecresource/deploymentresource/schema_elasticsearch.go
@@ -387,10 +387,11 @@ func newSnapshotSourceSettings() *schema.Schema {
 
 func newExtensionSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:        schema.TypeList,
+		Type:        schema.TypeSet,
+		Set:         esExtensionHash,
 		Description: "Optional Elasticsearch extensions such as custom bundles or plugins.",
 		Optional:    true,
-		MaxItems:    1,
+		MinItems:    1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"name": {

--- a/ec/ecresource/deploymentresource/schema_elasticsearch.go
+++ b/ec/ecresource/deploymentresource/schema_elasticsearch.go
@@ -538,6 +538,10 @@ func strategyResource() *schema.Resource {
 					}
 					return
 				},
+				// changes on this setting do not change the plan.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 		},
 	}

--- a/ec/ecresource/deploymentresource/schema_elasticsearch.go
+++ b/ec/ecresource/deploymentresource/schema_elasticsearch.go
@@ -514,7 +514,7 @@ func externalResource() *schema.Resource {
 
 func newStrategySchema() *schema.Schema {
 	return &schema.Schema{
-		Type:        schema.TypeSet,
+		Type:        schema.TypeList,
 		Description: "Configuration strategy settings.",
 		Optional:    true,
 		MaxItems:    1,

--- a/ec/ecresource/deploymentresource/schema_elasticsearch.go
+++ b/ec/ecresource/deploymentresource/schema_elasticsearch.go
@@ -92,6 +92,8 @@ func newElasticsearchResource() *schema.Resource {
 
 			"trust_account":  newTrustAccountSchema(),
 			"trust_external": newTrustExternalSchema(),
+
+			"strategy": newStrategySchema(),
 		},
 	}
 }
@@ -385,11 +387,10 @@ func newSnapshotSourceSettings() *schema.Schema {
 
 func newExtensionSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:        schema.TypeSet,
-		Set:         esExtensionHash,
+		Type:        schema.TypeList,
 		Description: "Optional Elasticsearch extensions such as custom bundles or plugins.",
 		Optional:    true,
-		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"name": {
@@ -504,6 +505,29 @@ func externalResource() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+		},
+	}
+}
+
+func newStrategySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "Configuration strategy settings.",
+		Optional:    true,
+		Computed:    true,
+		MaxItems:    1,
+		Elem:        strategyResource(),
+	}
+}
+
+func strategyResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Description: "Configuration strategy type [autodetect, grow_and_shrink, rolling_grow_and_shrink, rolling_all].",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 		},
 	}

--- a/ec/version.go
+++ b/ec/version.go
@@ -18,4 +18,4 @@
 package ec
 
 // Version contains the current terraform provider version.
-const Version = "0.4.0-dev"
+const Version = "0.5.0-dev"

--- a/ec/version.go
+++ b/ec/version.go
@@ -18,4 +18,4 @@
 package ec
 
 // Version contains the current terraform provider version.
-const Version = "0.5.0-dev"
+const Version = "0.4.0-dev"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

The current implementation uses `autodetect` configuration strategy, this strategy is fine in most cases. This PR allows to choose the configuration strategy from a set of pre-configured strategies.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

In our case we use SNAPSHOT versions and this strategy does not work as expected when we changed the Docker image for a new SNAPSHOT version, we need to perform a `rolling` with `groupBy` to `__all__` to perform a stop and start of all nodes at the same time to avoid version conflicts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have made a manual test and the PR includes some unit tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
