### PR TITLE
Check type casts to void crashing when casting explicit null values

### DIFF
--- a/.changelog/534.txt
+++ b/.changelog/534.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource: Updates all nested field accesses to validate type casts. This prevents a provider crash when a field is explicitly set to `null`.
+```

--- a/ec/ecresource/deploymentresource/apm_expanders_test.go
+++ b/ec/ecresource/deploymentresource/apm_expanders_test.go
@@ -252,6 +252,47 @@ func Test_expandApmResources(t *testing.T) {
 			}},
 		},
 		{
+			name: "parses an APM resource with explicit nils",
+			args: args{
+				tpl: tpl(),
+				ess: []interface{}{map[string]interface{}{
+					"ref_id":                       "tertiary-apm",
+					"elasticsearch_cluster_ref_id": "somerefid",
+					"resource_id":                  mock.ValidClusterID,
+					"region":                       nil,
+					"config": []interface{}{map[string]interface{}{
+						"user_settings_yaml":          nil,
+						"user_settings_override_yaml": nil,
+						"user_settings_json":          nil,
+						"user_settings_override_json": nil,
+						"debug_enabled":               nil,
+					}},
+					"topology": []interface{}{map[string]interface{}{
+						"instance_configuration_id": "aws.apm.r5d",
+						"size":                      "4g",
+						"size_resource":             "memory",
+						"zone_count":                1,
+					}},
+				}},
+			},
+			want: []*models.ApmPayload{{
+				ElasticsearchClusterRefID: ec.String("somerefid"),
+				Region:                    ec.String("us-east-1"),
+				RefID:                     ec.String("tertiary-apm"),
+				Plan: &models.ApmPlan{
+					Apm: &models.ApmConfiguration{},
+					ClusterTopology: []*models.ApmTopologyElement{{
+						ZoneCount:               1,
+						InstanceConfigurationID: "aws.apm.r5d",
+						Size: &models.TopologySize{
+							Resource: ec.String("memory"),
+							Value:    ec.Int32(4096),
+						},
+					}},
+				},
+			}},
+		},
+		{
 			name: "tries to parse an apm resource when the template doesn't have an APM instance set.",
 			args: args{
 				tpl: nil,

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders_test.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders_test.go
@@ -594,6 +594,115 @@ func Test_expandEsResource(t *testing.T) {
 			}),
 		},
 		{
+			name: "parses an ES resource with explicit nils",
+			args: args{
+				dt: hotWarmTpl770(),
+				ess: []interface{}{
+					map[string]interface{}{
+						"ref_id":                 "main-elasticsearch",
+						"resource_id":            mock.ValidClusterID,
+						"version":                "7.7.0",
+						"region":                 "some-region",
+						"deployment_template_id": "aws-hot-warm-v2",
+						"config": []interface{}{map[string]interface{}{
+							"user_settings_yaml": nil,
+						}},
+						"topology": []interface{}{
+							map[string]interface{}{
+								"id":         "hot_content",
+								"size":       nil,
+								"zone_count": 1,
+							},
+							map[string]interface{}{
+								"id":         "warm",
+								"size":       "2g",
+								"zone_count": nil,
+							},
+						},
+					},
+				},
+			},
+			want: enrichWithEmptyTopologies(hotWarmTpl770(), &models.ElasticsearchPayload{
+				Region: ec.String("some-region"),
+				RefID:  ec.String("main-elasticsearch"),
+				Settings: &models.ElasticsearchClusterSettings{
+					DedicatedMastersThreshold: 6,
+					Curation:                  nil,
+				},
+				Plan: &models.ElasticsearchClusterPlan{
+					AutoscalingEnabled: ec.Bool(false),
+					Elasticsearch: &models.ElasticsearchConfiguration{
+						Version:          "7.7.0",
+						Curation:         nil,
+						UserSettingsYaml: "",
+					},
+					DeploymentTemplate: &models.DeploymentTemplateReference{
+						ID: ec.String("aws-hot-warm-v2"),
+					},
+					ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+						{
+							ID: "hot_content",
+							Elasticsearch: &models.ElasticsearchConfiguration{
+								NodeAttributes: map[string]string{
+									"data": "hot",
+								},
+							},
+							ZoneCount:               1,
+							InstanceConfigurationID: "aws.data.highio.i3",
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(4096),
+							},
+							NodeType: &models.ElasticsearchNodeType{
+								Data:   ec.Bool(true),
+								Ingest: ec.Bool(true),
+								Master: ec.Bool(true),
+							},
+							TopologyElementControl: &models.TopologyElementControl{
+								Min: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+							},
+							AutoscalingMax: &models.TopologySize{
+								Value:    ec.Int32(118784),
+								Resource: ec.String("memory"),
+							},
+						},
+						{
+							ID: "warm",
+							Elasticsearch: &models.ElasticsearchConfiguration{
+								NodeAttributes: map[string]string{
+									"data": "warm",
+								},
+							},
+							ZoneCount:               2,
+							InstanceConfigurationID: "aws.data.highstorage.d2",
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(2048),
+							},
+							NodeType: &models.ElasticsearchNodeType{
+								Data:   ec.Bool(true),
+								Ingest: ec.Bool(true),
+								Master: ec.Bool(false),
+							},
+							TopologyElementControl: &models.TopologyElementControl{
+								Min: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(0),
+								},
+							},
+							AutoscalingMax: &models.TopologySize{
+								Value:    ec.Int32(118784),
+								Resource: ec.String("memory"),
+							},
+						},
+					},
+				},
+			}),
+		},
+		{
 			name: "parses an ES resource without a topology (HotWarm)",
 			args: args{
 				dt: hotWarmTpl770(),

--- a/ec/ecresource/deploymentresource/enterprise_search_expanders.go
+++ b/ec/ecresource/deploymentresource/enterprise_search_expanders.go
@@ -53,31 +53,29 @@ func expandEssResources(ess []interface{}, tpl *models.EnterpriseSearchPayload) 
 func expandEssResource(raw interface{}, res *models.EnterpriseSearchPayload) (*models.EnterpriseSearchPayload, error) {
 	ess := raw.(map[string]interface{})
 
-	if esRefID, ok := ess["elasticsearch_cluster_ref_id"]; ok {
-		res.ElasticsearchClusterRefID = ec.String(esRefID.(string))
+	if esRefID, ok := ess["elasticsearch_cluster_ref_id"].(string); ok {
+		res.ElasticsearchClusterRefID = ec.String(esRefID)
 	}
 
-	if refID, ok := ess["ref_id"]; ok {
-		res.RefID = ec.String(refID.(string))
+	if refID, ok := ess["ref_id"].(string); ok {
+		res.RefID = ec.String(refID)
 	}
 
-	if version, ok := ess["version"]; ok {
-		res.Plan.EnterpriseSearch.Version = version.(string)
+	if version, ok := ess["version"].(string); ok {
+		res.Plan.EnterpriseSearch.Version = version
 	}
 
-	if region, ok := ess["region"]; ok {
-		if r := region.(string); r != "" {
-			res.Region = ec.String(r)
-		}
+	if region, ok := ess["region"].(string); ok && region != "" {
+		res.Region = ec.String(region)
 	}
 
-	if cfg, ok := ess["config"]; ok {
+	if cfg, ok := ess["config"].([]interface{}); ok {
 		if err := expandEssConfig(cfg, res.Plan.EnterpriseSearch); err != nil {
 			return nil, err
 		}
 	}
 
-	if rt, ok := ess["topology"]; ok && len(rt.([]interface{})) > 0 {
+	if rt, ok := ess["topology"].([]interface{}); ok && len(rt) > 0 {
 		topology, err := expandEssTopology(rt, res.Plan.ClusterTopology)
 		if err != nil {
 			return nil, err
@@ -90,14 +88,17 @@ func expandEssResource(raw interface{}, res *models.EnterpriseSearchPayload) (*m
 	return res, nil
 }
 
-func expandEssTopology(raw interface{}, topologies []*models.EnterpriseSearchTopologyElement) ([]*models.EnterpriseSearchTopologyElement, error) {
-	rawTopologies := raw.([]interface{})
+func expandEssTopology(rawTopologies []interface{}, topologies []*models.EnterpriseSearchTopologyElement) ([]*models.EnterpriseSearchTopologyElement, error) {
 	res := make([]*models.EnterpriseSearchTopologyElement, 0, len(rawTopologies))
 	for i, rawTop := range rawTopologies {
-		topology := rawTop.(map[string]interface{})
+		topology, ok := rawTop.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
 		var icID string
-		if id, ok := topology["instance_configuration_id"]; ok {
-			icID = id.(string)
+		if id, ok := topology["instance_configuration_id"].(string); ok {
+			icID = id
 		}
 
 		// When a topology element is set but no instance_configuration_id
@@ -129,10 +130,8 @@ func expandEssTopology(raw interface{}, topologies []*models.EnterpriseSearchTop
 			elem.Size = size
 		}
 
-		if zones, ok := topology["zone_count"]; ok {
-			if z := zones.(int); z > 0 {
-				elem.ZoneCount = int32(z)
-			}
+		if zones, ok := topology["zone_count"].(int); ok && zones > 0 {
+			elem.ZoneCount = int32(zones)
 		}
 
 		res = append(res, elem)
@@ -141,32 +140,32 @@ func expandEssTopology(raw interface{}, topologies []*models.EnterpriseSearchTop
 	return res, nil
 }
 
-func expandEssConfig(raw interface{}, res *models.EnterpriseSearchConfiguration) error {
-	for _, rawCfg := range raw.([]interface{}) {
-		cfg := rawCfg.(map[string]interface{})
-		if settings, ok := cfg["user_settings_json"]; ok && settings != nil {
-			if s, ok := settings.(string); ok && s != "" {
-				if err := json.Unmarshal([]byte(s), &res.UserSettingsJSON); err != nil {
-					return fmt.Errorf("failed expanding enterprise_search user_settings_json: %w", err)
-				}
-			}
-		}
-		if settings, ok := cfg["user_settings_override_json"]; ok && settings != nil {
-			if s, ok := settings.(string); ok && s != "" {
-				if err := json.Unmarshal([]byte(s), &res.UserSettingsOverrideJSON); err != nil {
-					return fmt.Errorf("failed expanding enterprise_search user_settings_override_json: %w", err)
-				}
-			}
-		}
-		if settings, ok := cfg["user_settings_yaml"]; ok {
-			res.UserSettingsYaml = settings.(string)
-		}
-		if settings, ok := cfg["user_settings_override_yaml"]; ok {
-			res.UserSettingsOverrideYaml = settings.(string)
+func expandEssConfig(raw []interface{}, res *models.EnterpriseSearchConfiguration) error {
+	for _, rawCfg := range raw {
+		cfg, ok := rawCfg.(map[string]interface{})
+		if !ok {
+			continue
 		}
 
-		if v, ok := cfg["docker_image"]; ok {
-			res.DockerImage = v.(string)
+		if settings, ok := cfg["user_settings_json"].(string); ok && settings != "" {
+			if err := json.Unmarshal([]byte(settings), &res.UserSettingsJSON); err != nil {
+				return fmt.Errorf("failed expanding enterprise_search user_settings_json: %w", err)
+			}
+		}
+		if settings, ok := cfg["user_settings_override_json"].(string); ok && settings != "" {
+			if err := json.Unmarshal([]byte(settings), &res.UserSettingsOverrideJSON); err != nil {
+				return fmt.Errorf("failed expanding enterprise_search user_settings_override_json: %w", err)
+			}
+		}
+		if settings, ok := cfg["user_settings_yaml"].(string); ok && settings != "" {
+			res.UserSettingsYaml = settings
+		}
+		if settings, ok := cfg["user_settings_override_yaml"].(string); ok && settings != "" {
+			res.UserSettingsOverrideYaml = settings
+		}
+
+		if v, ok := cfg["docker_image"].(string); ok {
+			res.DockerImage = v
 		}
 	}
 

--- a/ec/ecresource/deploymentresource/enterprise_search_expanders_test.go
+++ b/ec/ecresource/deploymentresource/enterprise_search_expanders_test.go
@@ -320,6 +320,49 @@ func Test_expandEssResources(t *testing.T) {
 			}},
 		},
 		{
+			name: "parses an enterprise_search resource with explicit nils",
+			args: args{
+				tpl: tpl(),
+				ess: []interface{}{map[string]interface{}{
+					"ref_id":                       "secondary-enterprise_search",
+					"elasticsearch_cluster_ref_id": "somerefid",
+					"resource_id":                  mock.ValidClusterID,
+					"version":                      "7.7.0",
+					"region":                       nil,
+					"config": []interface{}{map[string]interface{}{
+						"user_settings_yaml":          nil,
+						"user_settings_override_yaml": nil,
+						"user_settings_json":          nil,
+						"user_settings_override_json": nil,
+					}},
+					"topology": nil,
+				}},
+			},
+			want: []*models.EnterpriseSearchPayload{{
+				ElasticsearchClusterRefID: ec.String("somerefid"),
+				Region:                    ec.String("us-east-1"),
+				RefID:                     ec.String("secondary-enterprise_search"),
+				Plan: &models.EnterpriseSearchPlan{
+					EnterpriseSearch: &models.EnterpriseSearchConfiguration{
+						Version: "7.7.0",
+					},
+					ClusterTopology: []*models.EnterpriseSearchTopologyElement{{
+						ZoneCount:               2,
+						InstanceConfigurationID: "aws.enterprisesearch.m5d",
+						Size: &models.TopologySize{
+							Resource: ec.String("memory"),
+							Value:    ec.Int32(2048),
+						},
+						NodeType: &models.EnterpriseSearchNodeTypes{
+							Appserver: ec.Bool(true),
+							Connector: ec.Bool(true),
+							Worker:    ec.Bool(true),
+						},
+					}},
+				},
+			}},
+		},
+		{
 			name: "parses an enterprise_search resource with invalid instance_configuration_id",
 			args: args{
 				tpl: tpl(),

--- a/ec/ecresource/deploymentresource/integrations_server_expanders_test.go
+++ b/ec/ecresource/deploymentresource/integrations_server_expanders_test.go
@@ -252,6 +252,51 @@ func Test_expandIntegrationsServerResources(t *testing.T) {
 			}},
 		},
 		{
+			name: "parses an Integrations Server resource with explicit nils",
+			args: args{
+				tpl: tpl(),
+				ess: []interface{}{map[string]interface{}{
+					"ref_id":                       "tertiary-integrations_server",
+					"elasticsearch_cluster_ref_id": "somerefid",
+					"resource_id":                  mock.ValidClusterID,
+					"region":                       "some-region",
+					"config": []interface{}{map[string]interface{}{
+						"user_settings_yaml":          nil,
+						"user_settings_override_yaml": nil,
+						"user_settings_json":          nil,
+						"user_settings_override_json": nil,
+						"debug_enabled":               true,
+					}},
+					"topology": []interface{}{map[string]interface{}{
+						"instance_configuration_id": "integrations.server",
+						"size":                      nil,
+						"size_resource":             "memory",
+						"zone_count":                1,
+					}},
+				}},
+			},
+			want: []*models.IntegrationsServerPayload{{
+				ElasticsearchClusterRefID: ec.String("somerefid"),
+				Region:                    ec.String("some-region"),
+				RefID:                     ec.String("tertiary-integrations_server"),
+				Plan: &models.IntegrationsServerPlan{
+					IntegrationsServer: &models.IntegrationsServerConfiguration{
+						SystemSettings: &models.IntegrationsServerSystemSettings{
+							DebugEnabled: ec.Bool(true),
+						},
+					},
+					ClusterTopology: []*models.IntegrationsServerTopologyElement{{
+						ZoneCount:               1,
+						InstanceConfigurationID: "integrations.server",
+						Size: &models.TopologySize{
+							Resource: ec.String("memory"),
+							Value:    ec.Int32(1024),
+						},
+					}},
+				},
+			}},
+		},
+		{
 			name: "tries to parse an integrations_server resource when the template doesn't have an Integrations Server instance set.",
 			args: args{
 				tpl: nil,

--- a/ec/ecresource/deploymentresource/kibana_expanders_test.go
+++ b/ec/ecresource/deploymentresource/kibana_expanders_test.go
@@ -87,6 +87,45 @@ func Test_expandKibanaResources(t *testing.T) {
 			},
 		},
 		{
+			name: "parses a kibana resource with explicit nils",
+			args: args{
+				tpl: tpl(),
+				ess: []interface{}{
+					map[string]interface{}{
+						"ref_id":                       "main-kibana",
+						"resource_id":                  mock.ValidClusterID,
+						"region":                       nil,
+						"elasticsearch_cluster_ref_id": "somerefid",
+						"topology": []interface{}{map[string]interface{}{
+							"instance_configuration_id": "aws.kibana.r5d",
+							"size":                      nil,
+							"zone_count":                1,
+						}},
+					},
+				},
+			},
+			want: []*models.KibanaPayload{
+				{
+					ElasticsearchClusterRefID: ec.String("somerefid"),
+					Region:                    ec.String("us-east-1"),
+					RefID:                     ec.String("main-kibana"),
+					Plan: &models.KibanaClusterPlan{
+						Kibana: &models.KibanaConfiguration{},
+						ClusterTopology: []*models.KibanaClusterTopologyElement{
+							{
+								ZoneCount:               1,
+								InstanceConfigurationID: "aws.kibana.r5d",
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "parses a kibana resource with incorrect instance_configuration_id",
 			args: args{
 				tpl: tpl(),

--- a/ec/ecresource/deploymentresource/observability.go
+++ b/ec/ecresource/deploymentresource/observability.go
@@ -66,12 +66,12 @@ func expandObservability(raw []interface{}, client *api.API) (*models.Deployment
 	for _, rawObs := range raw {
 		var obs = rawObs.(map[string]interface{})
 
-		depID, ok := obs["deployment_id"]
+		depID, ok := obs["deployment_id"].(string)
 		if !ok {
 			return nil, nil
 		}
 
-		refID, ok := obs["ref_id"]
+		refID, ok := obs["ref_id"].(string)
 		if depID == "self" {
 			// For self monitoring, the refID is not mandatory
 			if !ok {
@@ -83,7 +83,7 @@ func expandObservability(raw []interface{}, client *api.API) (*models.Deployment
 			params := deploymentapi.PopulateRefIDParams{
 				Kind:         util.Elasticsearch,
 				API:          client,
-				DeploymentID: depID.(string),
+				DeploymentID: depID,
 				RefID:        ec.String(""),
 			}
 
@@ -94,20 +94,20 @@ func expandObservability(raw []interface{}, client *api.API) (*models.Deployment
 			refID = *params.RefID
 		}
 
-		if logging := obs["logs"]; logging.(bool) {
+		if logging, ok := obs["logs"].(bool); ok && logging {
 			req.Logging = &models.DeploymentLoggingSettings{
 				Destination: &models.ObservabilityAbsoluteDeployment{
-					DeploymentID: ec.String(depID.(string)),
-					RefID:        refID.(string),
+					DeploymentID: ec.String(depID),
+					RefID:        refID,
 				},
 			}
 		}
 
-		if metrics := obs["metrics"]; metrics.(bool) {
+		if metrics, ok := obs["metrics"].(bool); ok && metrics {
 			req.Metrics = &models.DeploymentMetricsSettings{
 				Destination: &models.ObservabilityAbsoluteDeployment{
-					DeploymentID: ec.String(depID.(string)),
-					RefID:        refID.(string),
+					DeploymentID: ec.String(depID),
+					RefID:        refID,
 				},
 			}
 		}

--- a/ec/ecresource/deploymentresource/observability_test.go
+++ b/ec/ecresource/deploymentresource/observability_test.go
@@ -158,6 +158,18 @@ func TestExpandObservability(t *testing.T) {
 			},
 		},
 		{
+			name: "handles explicit nils",
+			args: args{
+				v: []interface{}{map[string]interface{}{
+					"deployment_id": mock.ValidClusterID,
+					"ref_id":        "main-elasticsearch",
+					"metrics":       nil,
+					"logs":          nil,
+				}},
+			},
+			want: &models.DeploymentObservabilitySettings{},
+		},
+		{
 			name: "expands all observability settings",
 			args: args{
 				API: api.NewMock(

--- a/ec/ecresource/trafficfilterresource/expanders.go
+++ b/ec/ecresource/trafficfilterresource/expanders.go
@@ -35,8 +35,12 @@ func expandModel(d *schema.ResourceData) *models.TrafficFilterRulesetRequest {
 	}
 
 	for _, r := range ruleSet.List() {
-		var m = r.(map[string]interface{})
-		var rule = models.TrafficFilterRule{
+		m, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		rule := models.TrafficFilterRule{
 			Source: m["source"].(string),
 		}
 
@@ -44,16 +48,16 @@ func expandModel(d *schema.ResourceData) *models.TrafficFilterRulesetRequest {
 			rule.ID = val.(string)
 		}
 
-		if val, ok := m["description"]; ok {
-			rule.Description = val.(string)
+		if val, ok := m["description"].(string); ok {
+			rule.Description = val
 		}
 
-		if val, ok := m["azure_endpoint_name"]; ok {
-			rule.AzureEndpointName = val.(string)
+		if val, ok := m["azure_endpoint_name"].(string); ok {
+			rule.AzureEndpointName = val
 		}
 
-		if val, ok := m["azure_endpoint_guid"]; ok {
-			rule.AzureEndpointGUID = val.(string)
+		if val, ok := m["azure_endpoint_guid"].(string); ok {
+			rule.AzureEndpointGUID = val
 		}
 
 		request.Rules = append(request.Rules, &rule)

--- a/ec/ecresource/trafficfilterresource/expanders_test.go
+++ b/ec/ecresource/trafficfilterresource/expanders_test.go
@@ -125,6 +125,36 @@ func Test_expandModel(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "parses an privatelink resource with explicit nils",
+			args: args{d: util.NewResourceData(t, util.ResDataParams{
+				ID: "some-random-id",
+				State: map[string]interface{}{
+					"name":               "my traffic filter",
+					"type":               "azure_private_endpoint",
+					"include_by_default": false,
+					"region":             "azure-australiaeast",
+					"rule": []interface{}{map[string]interface{}{
+						"description":         nil,
+						"azure_endpoint_guid": "1231312-1231-1231-1231-1231312",
+						"azure_endpoint_name": "my-azure-pl",
+					}},
+				},
+				Schema: newSchema(),
+			})},
+			want: &models.TrafficFilterRulesetRequest{
+				Name:             ec.String("my traffic filter"),
+				Type:             ec.String("azure_private_endpoint"),
+				IncludeByDefault: ec.Bool(false),
+				Region:           ec.String("azure-australiaeast"),
+				Rules: []*models.TrafficFilterRule{
+					{
+						AzureEndpointGUID: "1231312-1231-1231-1231-1231312",
+						AzureEndpointName: "my-azure-pl",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ec/internal/util/parsers.go
+++ b/ec/internal/util/parsers.go
@@ -37,23 +37,21 @@ func MemoryToState(mem int32) string {
 
 // ParseTopologySize parses a flattened topology into its model.
 func ParseTopologySize(topology map[string]interface{}) (*models.TopologySize, error) {
-	if mem, ok := topology["size"]; ok {
-		if m := mem.(string); m != "" {
-			val, err := deploymentsize.ParseGb(m)
-			if err != nil {
-				return nil, err
-			}
-
-			var sizeResource = defaultSizeResource
-			if sr, ok := topology["size_resource"]; ok {
-				sizeResource = sr.(string)
-			}
-
-			return &models.TopologySize{
-				Value:    ec.Int32(val),
-				Resource: ec.String(sizeResource),
-			}, nil
+	if mem, ok := topology["size"].(string); ok && mem != "" {
+		val, err := deploymentsize.ParseGb(mem)
+		if err != nil {
+			return nil, err
 		}
+
+		var sizeResource = defaultSizeResource
+		if sr, ok := topology["size_resource"].(string); ok {
+			sizeResource = sr
+		}
+
+		return &models.TopologySize{
+			Value:    ec.Int32(val),
+			Resource: ec.String(sizeResource),
+		}, nil
 	}
 
 	return nil, nil


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Repro in the linked issue. 

Some fields may be sourced from Terraform variables, if those variables are optional then it's not uncommon to explicitly set fields to null, which the provider should treat as if the field was left unset. 

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Fixes https://github.com/elastic/terraform-provider-ec/issues/522

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
