### PR TITLE
Utilise the migrate template API when applying changes to the deployment template id 

### DIFF
--- a/.changelog/547.txt
+++ b/.changelog/547.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+resource/deployment: Utilise the template migration API to build the base update request when changing `deployment_template_id`. This results in more reliable changes between deployment templates.
+```

--- a/ec/acc/deployment_template_migration_test.go
+++ b/ec/acc/deployment_template_migration_test.go
@@ -1,0 +1,96 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDeployment_template_migration(t *testing.T) {
+	resName := "ec_deployment.compute_optimized"
+	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	basicCfg := "testdata/deployment_compute_optimized_1.tf"
+	region := getRegion()
+	cfg := fixtureAccDeploymentResourceBasicDefaults(t, basicCfg, randomName, region, computeOpTemplate)
+	secondConfigCfg := fixtureAccDeploymentResourceBasicDefaults(t, basicCfg, randomName, region, memoryOpTemplate)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create a Compute Optimized deployment with the default settings.
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, computeOpTemplate)),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.id", "hot_content"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.node_roles.#"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "2"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "1"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.topology.0.zone_count", "1"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "kibana.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.topology.0.size", "1g"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+				),
+			},
+			{
+				// Change the deployment to memory optimized
+				Config: secondConfigCfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, memoryOpTemplate)),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_data", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ingest", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_master", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.node_type_ml", ""),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.id", "hot_content"),
+					resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.topology.0.node_roles.#"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.zone_count", "2"),
+					resource.TestCheckResourceAttr(resName, "kibana.#", "1"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.topology.0.zone_count", "1"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.topology.#", "1"),
+					resource.TestCheckResourceAttrSet(resName, "kibana.0.topology.0.instance_configuration_id"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.topology.0.size", "1g"),
+					resource.TestCheckResourceAttr(resName, "kibana.0.topology.0.size_resource", "memory"),
+					resource.TestCheckResourceAttr(resName, "apm.#", "0"),
+					resource.TestCheckResourceAttr(resName, "enterprise_search.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/ec/acc/testdata/deployment_basic_defaults_hw_2.tf
+++ b/ec/acc/testdata/deployment_basic_defaults_hw_2.tf
@@ -9,7 +9,16 @@ resource "ec_deployment" "defaults" {
   version                = data.ec_stack.latest.version
   deployment_template_id = "%s"
 
-  elasticsearch {}
+  elasticsearch {
+    topology {
+      id   = "hot_content"
+      size = "4g"
+    }
+    topology {
+      id   = "warm"
+      size = "4g"
+    }
+  }
 
   kibana {}
 }

--- a/ec/ecresource/deploymentresource/apm_expanders.go
+++ b/ec/ecresource/deploymentresource/apm_expanders.go
@@ -202,3 +202,12 @@ func apmResource(res *models.DeploymentTemplateInfoV2) *models.ApmPayload {
 	}
 	return res.DeploymentTemplate.Resources.Apm[0]
 }
+
+// apmResourceFromUpdate returns the ApmPayload from a deployment
+// update request or an empty version of the payload.
+func apmResourceFromUpdate(res *models.DeploymentUpdateResources) *models.ApmPayload {
+	if len(res.Apm) == 0 {
+		return nil
+	}
+	return res.Apm[0]
+}

--- a/ec/ecresource/deploymentresource/elasticsearch_expanders.go
+++ b/ec/ecresource/deploymentresource/elasticsearch_expanders.go
@@ -374,18 +374,32 @@ func matchEsTopologyID(id string, topologies []*models.ElasticsearchClusterTopol
 	)
 }
 
+func emptyEsResource() *models.ElasticsearchPayload {
+	return &models.ElasticsearchPayload{
+		Plan: &models.ElasticsearchClusterPlan{
+			Elasticsearch: &models.ElasticsearchConfiguration{},
+		},
+		Settings: &models.ElasticsearchClusterSettings{},
+	}
+}
+
 // esResource returns the ElaticsearchPayload from a deployment
 // template or an empty version of the payload.
 func esResource(res *models.DeploymentTemplateInfoV2) *models.ElasticsearchPayload {
 	if len(res.DeploymentTemplate.Resources.Elasticsearch) == 0 {
-		return &models.ElasticsearchPayload{
-			Plan: &models.ElasticsearchClusterPlan{
-				Elasticsearch: &models.ElasticsearchConfiguration{},
-			},
-			Settings: &models.ElasticsearchClusterSettings{},
-		}
+		return emptyEsResource()
 	}
 	return res.DeploymentTemplate.Resources.Elasticsearch[0]
+}
+
+// esResourceFromUpdate returns the ElaticsearchPayload from a deployment
+// update request or an empty version of the payload.
+func esResourceFromUpdate(res *models.DeploymentUpdateResources) *models.ElasticsearchPayload {
+	if len(res.Elasticsearch) == 0 {
+		return emptyEsResource()
+	}
+
+	return res.Elasticsearch[0]
 }
 
 func unsetElasticsearchCuration(payload *models.ElasticsearchPayload) {

--- a/ec/ecresource/deploymentresource/enterprise_search_expanders.go
+++ b/ec/ecresource/deploymentresource/enterprise_search_expanders.go
@@ -208,3 +208,12 @@ func essResource(res *models.DeploymentTemplateInfoV2) *models.EnterpriseSearchP
 	}
 	return res.DeploymentTemplate.Resources.EnterpriseSearch[0]
 }
+
+// essResourceFromUpdate returns the EnterpriseSearchPayload from a deployment
+// update request or an empty version of the payload.
+func essResourceFromUpdate(res *models.DeploymentUpdateResources) *models.EnterpriseSearchPayload {
+	if len(res.EnterpriseSearch) == 0 {
+		return nil
+	}
+	return res.EnterpriseSearch[0]
+}

--- a/ec/ecresource/deploymentresource/expanders_test.go
+++ b/ec/ecresource/deploymentresource/expanders_test.go
@@ -2956,6 +2956,9 @@ func Test_updateResourceToModel(t *testing.T) {
 	ccsTpl := func() io.ReadCloser {
 		return fileAsResponseBody(t, "testdata/template-aws-cross-cluster-search-v2.json")
 	}
+	ccsDeploymentUpdate := func() io.ReadCloser {
+		return fileAsResponseBody(t, "testdata/deployment-update-aws-cross-cluster-search-v2.json")
+	}
 	deploymentEmptyRDWithTemplateChange := util.NewResourceData(t, util.ResDataParams{
 		ID:    mock.ValidClusterID,
 		State: newSampleLegacyDeployment(),
@@ -3018,9 +3021,6 @@ func Test_updateResourceToModel(t *testing.T) {
 		Schema: newSchema(),
 	})
 
-	emptyTpl := func() io.ReadCloser {
-		return fileAsResponseBody(t, "testdata/template-empty.json")
-	}
 	deploymentChangeFromExplicitSizingToEmpty := util.NewResourceData(t, util.ResDataParams{
 		ID: mock.ValidClusterID,
 		State: map[string]interface{}{
@@ -3061,56 +3061,6 @@ func Test_updateResourceToModel(t *testing.T) {
 		Change: map[string]interface{}{
 			"name":                   "my_deployment_name",
 			"deployment_template_id": "aws-io-optimized-v2",
-			"region":                 "us-east-1",
-			"version":                "7.9.2",
-			"elasticsearch":          []interface{}{map[string]interface{}{}},
-			"kibana":                 []interface{}{map[string]interface{}{}},
-			"apm":                    []interface{}{map[string]interface{}{}},
-			"enterprise_search":      []interface{}{map[string]interface{}{}},
-		},
-		Schema: newSchema(),
-	})
-
-	deploymentChangeToEmptyDT := util.NewResourceData(t, util.ResDataParams{
-		ID: mock.ValidClusterID,
-		State: map[string]interface{}{
-			"name":                   "my_deployment_name",
-			"deployment_template_id": "aws-io-optimized-v2",
-			"region":                 "us-east-1",
-			"version":                "7.9.2",
-			"elasticsearch": []interface{}{
-				map[string]interface{}{
-					"topology": []interface{}{map[string]interface{}{
-						"id":   "hot_content",
-						"size": "16g",
-					}},
-				},
-				map[string]interface{}{
-					"topology": []interface{}{map[string]interface{}{
-						"id":   "coordinating",
-						"size": "16g",
-					}},
-				},
-			},
-			"kibana": []interface{}{map[string]interface{}{
-				"topology": []interface{}{map[string]interface{}{
-					"size": "2g",
-				}},
-			}},
-			"apm": []interface{}{map[string]interface{}{
-				"topology": []interface{}{map[string]interface{}{
-					"size": "1g",
-				}},
-			}},
-			"enterprise_search": []interface{}{map[string]interface{}{
-				"topology": []interface{}{map[string]interface{}{
-					"size": "8g",
-				}},
-			}},
-		},
-		Change: map[string]interface{}{
-			"name":                   "my_deployment_name",
-			"deployment_template_id": "empty-deployment-template",
 			"region":                 "us-east-1",
 			"version":                "7.9.2",
 			"elasticsearch":          []interface{}{map[string]interface{}{}},
@@ -3699,8 +3649,11 @@ func Test_updateResourceToModel(t *testing.T) {
 		{
 			name: "toplogy change from hot / warm to cross cluster search",
 			args: args{
-				d:      deploymentEmptyRDWithTemplateChange,
-				client: api.NewMock(mock.New200Response(ccsTpl())),
+				d: deploymentEmptyRDWithTemplateChange,
+				client: api.NewMock(
+					mock.New200Response(ccsTpl()),
+					mock.New200Response(ccsDeploymentUpdate()),
+				),
 			},
 			want: &models.DeploymentUpdateRequest{
 				Name:         "my_deployment_name",
@@ -3713,7 +3666,7 @@ func Test_updateResourceToModel(t *testing.T) {
 					Tags: []*models.MetadataItem{},
 				},
 				Resources: &models.DeploymentUpdateResources{
-					Elasticsearch: enrichWithEmptyTopologies(readerToESPayload(t, ccsTpl(), false), &models.ElasticsearchPayload{
+					Elasticsearch: enrichWithEmptyTopologies(readerDeploymentUpdateToESPayload(t, ccsDeploymentUpdate(), false, "aws-cross-cluster-search-v2"), &models.ElasticsearchPayload{
 						Region:   ec.String("us-east-1"),
 						RefID:    ec.String("main-elasticsearch"),
 						Settings: &models.ElasticsearchClusterSettings{},
@@ -3726,16 +3679,18 @@ func Test_updateResourceToModel(t *testing.T) {
 							},
 							ClusterTopology: []*models.ElasticsearchClusterTopologyElement{{
 								ID:                      "hot_content",
+								Elasticsearch:           &models.ElasticsearchConfiguration{},
 								ZoneCount:               1,
 								InstanceConfigurationID: "aws.ccs.r5d",
 								Size: &models.TopologySize{
 									Resource: ec.String("memory"),
-									Value:    ec.Int32(1024),
+									Value:    ec.Int32(2048),
 								},
 								NodeType: &models.ElasticsearchNodeType{
 									Data:   ec.Bool(true),
 									Ingest: ec.Bool(true),
 									Master: ec.Bool(true),
+									Ml:     ec.Bool(false),
 								},
 								TopologyElementControl: &models.TopologyElementControl{
 									Min: &models.TopologySize{
@@ -3768,14 +3723,16 @@ func Test_updateResourceToModel(t *testing.T) {
 			},
 		},
 		// The behavior of this change should be:
-		// * Resets the Elasticsearch topology: from 16g (due to unsetTopology call on DT change).
 		// * Keeps the kibana toplogy size to 2g even though the topology element has been removed (saved value persists).
 		// * Removes all other non present resources
 		{
 			name: "topology change with sizes not default from io optimized to cross cluster search",
 			args: args{
-				d:      deploymentEmptyRDWithTemplateChangeWithDiffSize,
-				client: api.NewMock(mock.New200Response(ccsTpl())),
+				d: deploymentEmptyRDWithTemplateChangeWithDiffSize,
+				client: api.NewMock(
+					mock.New200Response(ccsTpl()),
+					mock.New200Response(ccsDeploymentUpdate()),
+				),
 			},
 			want: &models.DeploymentUpdateRequest{
 				Name:         "my_deployment_name",
@@ -3785,7 +3742,7 @@ func Test_updateResourceToModel(t *testing.T) {
 					Tags: []*models.MetadataItem{},
 				},
 				Resources: &models.DeploymentUpdateResources{
-					Elasticsearch: enrichWithEmptyTopologies(readerToESPayload(t, ccsTpl(), false), &models.ElasticsearchPayload{
+					Elasticsearch: enrichWithEmptyTopologies(readerDeploymentUpdateToESPayload(t, ccsDeploymentUpdate(), false, "aws-cross-cluster-search-v2"), &models.ElasticsearchPayload{
 						Region:   ec.String("us-east-1"),
 						RefID:    ec.String("main-elasticsearch"),
 						Settings: &models.ElasticsearchClusterSettings{},
@@ -3798,12 +3755,12 @@ func Test_updateResourceToModel(t *testing.T) {
 							},
 							ClusterTopology: []*models.ElasticsearchClusterTopologyElement{{
 								ID:                      "hot_content",
+								Elasticsearch:           &models.ElasticsearchConfiguration{},
 								ZoneCount:               1,
 								InstanceConfigurationID: "aws.ccs.r5d",
 								Size: &models.TopologySize{
 									Resource: ec.String("memory"),
-									// This field's value is reset.
-									Value: ec.Int32(1024),
+									Value:    ec.Int32(16384),
 								},
 								NodeType: &models.ElasticsearchNodeType{
 									Data:   ec.Bool(true),
@@ -5028,18 +4985,6 @@ func Test_updateResourceToModel(t *testing.T) {
 					}),
 				},
 			},
-		},
-		{
-			name: "topology change with invalid resources returns an error",
-			args: args{
-				d:      deploymentChangeToEmptyDT,
-				client: api.NewMock(mock.New200Response(emptyTpl())),
-			},
-			err: multierror.NewPrefixed("invalid configuration",
-				errors.New("kibana specified but deployment template is not configured for it. Use a different template if you wish to add kibana"),
-				errors.New("apm specified but deployment template is not configured for it. Use a different template if you wish to add apm"),
-				errors.New("enterprise_search specified but deployment template is not configured for it. Use a different template if you wish to add enterprise_search"),
-			),
 		},
 	}
 	for _, tt := range tests {

--- a/ec/ecresource/deploymentresource/integrations_server_expanders.go
+++ b/ec/ecresource/deploymentresource/integrations_server_expanders.go
@@ -202,3 +202,12 @@ func integrationsServerResource(res *models.DeploymentTemplateInfoV2) *models.In
 	}
 	return res.DeploymentTemplate.Resources.IntegrationsServer[0]
 }
+
+// integrationsServerResourceFromUpdate returns the IntegrationsServerPayload from a deployment
+// update request or an empty version of the payload.
+func integrationsServerResourceFromUpdate(res *models.DeploymentUpdateResources) *models.IntegrationsServerPayload {
+	if len(res.IntegrationsServer) == 0 {
+		return nil
+	}
+	return res.IntegrationsServer[0]
+}

--- a/ec/ecresource/deploymentresource/kibana_expanders.go
+++ b/ec/ecresource/deploymentresource/kibana_expanders.go
@@ -192,3 +192,12 @@ func kibanaResource(res *models.DeploymentTemplateInfoV2) *models.KibanaPayload 
 	}
 	return res.DeploymentTemplate.Resources.Kibana[0]
 }
+
+// kibanaResourceFromUpdate returns the KibanaPayload from a deployment
+// update request or an empty version of the payload.
+func kibanaResourceFromUpdate(res *models.DeploymentUpdateResources) *models.KibanaPayload {
+	if len(res.Kibana) == 0 {
+		return nil
+	}
+	return res.Kibana[0]
+}

--- a/ec/ecresource/deploymentresource/testdata/deployment-update-aws-cross-cluster-search-v2.json
+++ b/ec/ecresource/deploymentresource/testdata/deployment-update-aws-cross-cluster-search-v2.json
@@ -1,0 +1,92 @@
+{
+  "resources": {
+    "apm": null,
+    "appsearch": null,
+    "elasticsearch": [
+      {
+        "plan": {
+          "cluster_topology": [
+            {
+              "id": "hot_content",
+              "instance_configuration_id": "aws.ccs.r5d",
+              "node_roles": [
+                "master",
+                "ingest",
+                "remote_cluster_client",
+                "data_hot",
+                "transform",
+                "data_content"
+              ],
+              "node_type": {
+                "data": true,
+                "ingest": true,
+                "master": true
+              },
+              "size": {
+                "resource": "memory",
+                "value": 1024
+              },
+              "topology_element_control": {
+                "min": {
+                  "resource": "memory",
+                  "value": 1024
+                }
+              },
+              "zone_count": 1
+            },
+            {
+              "id": "ml",
+              "instance_configuration_id": "aws.ml.m5d",
+              "node_roles": [
+                "ml",
+                "remote_cluster_client"
+              ],
+              "node_type": {
+                "data": false,
+                "ingest": false,
+                "master": false,
+                "ml": true
+              },
+              "size": {
+                "resource": "memory",
+                "value": 0
+              },
+              "topology_element_control": {
+                "min": {
+                  "resource": "memory",
+                  "value": 0
+                }
+              },
+              "zone_count": 1
+            }
+          ],
+          "elasticsearch": {}
+        },
+        "ref_id": "es-ref-id",
+        "region": "us-east-1",
+        "settings": {}
+      }
+    ],
+    "enterprise_search": null,
+    "kibana": [
+      {
+        "elasticsearch_cluster_ref_id": "es-ref-id",
+        "plan": {
+          "cluster_topology": [
+            {
+              "instance_configuration_id": "aws.kibana.r5d",
+              "size": {
+                "resource": "memory",
+                "value": 1024
+              },
+              "zone_count": 1
+            }
+          ],
+          "kibana": {}
+        },
+        "ref_id": "kibana-ref-id",
+        "region": "us-east-1"
+      }
+    ]
+  }
+}

--- a/ec/ecresource/deploymentresource/testutil_func.go
+++ b/ec/ecresource/deploymentresource/testutil_func.go
@@ -87,6 +87,22 @@ func enrichWithEmptyTopologies(tpl, want *models.ElasticsearchPayload) []*models
 	return []*models.ElasticsearchPayload{tpl}
 }
 
+func readerDeploymentUpdateToESPayload(t *testing.T, rc io.Reader, nr bool, tplID string) *models.ElasticsearchPayload {
+	t.Helper()
+
+	var tpl models.DeploymentUpdateRequest
+	if err := json.NewDecoder(rc).Decode(&tpl); err != nil {
+		t.Fatal(err)
+	}
+
+	return enrichElasticsearchTemplate(
+		tpl.Resources.Elasticsearch[0],
+		tplID,
+		"",
+		nr,
+	)
+}
+
 func readerToESPayload(t *testing.T, rc io.Reader, nr bool) *models.ElasticsearchPayload {
 	t.Helper()
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Use the migrate template API to build the base update request when an existing deployment changes.  `deployment_template_id`, 

## Related Issues
Fixes https://github.com/elastic/terraform-provider-ec/issues/487
Fixes https://github.com/elastic/terraform-provider-ec/issues/556

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This API is purpose built to update deployment options to be compatible with a different template and simplifies the process for migrating deployments between hardware types. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, acceptance test, unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
