### PR TITLE
Revert "Run acceptance tests in CI against 1.2.9"

### DIFF
--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -42,7 +42,7 @@ endif
 
 .PHONY: testacc-ci
 testacc-ci:
-	@ EC_API_KEY=$(shell cat .ci/.apikey) TF_ACC_TERRAFORM_VERSION=1.2.9 $(MAKE) testacc
+	@ EC_API_KEY=$(shell cat .ci/.apikey) $(MAKE) testacc
 
 .PHONY: sweep-ci
 sweep-ci:


### PR DESCRIPTION
Reverts elastic/terraform-provider-ec#542

Testing against 1.3+ should work with [this](https://github.com/elastic/terraform-provider-ec/pull/549) SDK update. 