### PR TITLE
docs: Add GCP PSC to Traffic Filter argument reference for type

### DIFF
--- a/docs/resources/ec_deployment_traffic_filter.md
+++ b/docs/resources/ec_deployment_traffic_filter.md
@@ -143,7 +143,7 @@ resource "ec_deployment_traffic_filter" "gcp_psc" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the ruleset.
-* `type` - (Required) Type of the ruleset.  It can be `"ip"`, `"vpce"` or `"azure_private_endpoint"`.
+* `type` - (Required) Type of the ruleset.  It can be `"ip"`, `"vpce"`, `"azure_private_endpoint"`, or `"gcp_private_service_connect_endpoint"`.
 * `region` - (Required) Filter region, the ruleset can only be attached to deployments in the specific region.
 * `rule` (Required) Rule block, which can be specified multiple times for multiple rules.
 * `include_by_default` - (Optional) To automatically include the ruleset in the new deployments. Defaults to `false`.

--- a/ec/ecresource/trafficfilterresource/schema.go
+++ b/ec/ecresource/trafficfilterresource/schema.go
@@ -33,7 +33,7 @@ func newSchema() map[string]*schema.Schema {
 		},
 		"type": {
 			Type:        schema.TypeString,
-			Description: `Required type of the ruleset ("ip", "vpce" or "azure_private_endpoint")`,
+			Description: `Required type of the ruleset ("ip", "vpce", "azure_private_endpoint", or "gcp_private_service_connect_endpoint")`,
 			Required:    true,
 		},
 		"region": {


### PR DESCRIPTION
The Traffic Filter resource docs include an [example](https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/ec_deployment_traffic_filter#gcp-private-service-connect-type) of the "GCP Private Service Connect type", but it was not listed in the argument reference for [`type`](https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/ec_deployment_traffic_filter#type).

## Motivation and Context

Including this in the documentation gives confidence to the user that GCP Private Service Connect is supported by the provider and helps them use it correctly.

## How Has This Been Tested?

I copied the value from my working Terraform code where I have a working Traffic Filter for GCP PSC. It also reflects the [documented example](https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/ec_deployment_traffic_filter#gcp-private-service-connect-type).

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
