### PR TITLE
Fix typo in GCP PSC datasource documentation

### DIFF
--- a/docs/data-sources/ec_gcp_private_service_connect_endpoint.md
+++ b/docs/data-sources/ec_gcp_private_service_connect_endpoint.md
@@ -6,7 +6,7 @@ description: |-
 
 # Data Source: ec_gcp_private_service_connect_endpoint
 
-Use this data source to retrieve information about the Azure Private Link configuration for a given region. Further documentation on how to establish a PrivateLink connection can be found in the ESS [documentation](https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-psc.html).
+Use this data source to retrieve information about the GCP Private Service Connect configuration for a given region. Further documentation on how to establish a PrivateLink connection can be found in the ESS [documentation](https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-psc.html).
 
 ~> **NOTE:** This data source provides data relevant to the Elasticsearch Service (ESS) only, and should not be used for ECE.
 


### PR DESCRIPTION
## Description
Typo fix in GCP PSC datasource documentation. It currently incorrectly references Azure.

## Related Issues
N/A

## Motivation and Context
It's a typo.

## How Has This Been Tested?
N/A

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
