### PR TITLE
Link through to the ESS region list in the ec_stack docs

### DIFF
--- a/docs/data-sources/ec_stack.md
+++ b/docs/data-sources/ec_stack.md
@@ -8,6 +8,8 @@ description: |-
 
 Use this data source to retrieve information about an existing Elastic Cloud stack.
 
+-> **Note on regions** Before you start, you might want to check the [full list](https://www.elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html) of regions available in Elasticsearch Service (ESS).
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-ec/issues/593

Essentially copies the note from the `ec_deployment` resource docs, linking through to the list of available regions. 