### PR TITLE
Changes introduced in 1.4 lead to infinite diff loops with this provider

### DIFF
--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -20,7 +20,7 @@ _report_path:
 .PHONY: unit
 unit: _report_path
 	@ echo "-> Running unit tests for $(BINARY)..."
-	@ go test $(TEST) $(TESTARGS) $(TESTUNITARGS)
+	@ TF_ACC_TERRAFORM_VERSION=1.3.9 go test $(TEST) $(TESTARGS) $(TESTUNITARGS)
 
 ## Alias to "unit".
 tests: unit

--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -42,7 +42,7 @@ endif
 
 .PHONY: testacc-ci
 testacc-ci:
-	@ EC_API_KEY=$(shell cat .ci/.apikey) $(MAKE) testacc
+	@ TF_ACC_TERRAFORM_VERSION=1.3.9 EC_API_KEY=$(shell cat .ci/.apikey) $(MAKE) testacc
 
 .PHONY: sweep-ci
 sweep-ci:


### PR DESCRIPTION
Fix the CI testing version so we have accurate test results whilst the underlying issues are fixed
Related to https://github.com/elastic/terraform-provider-ec/issues/599
