### PR TITLE
Deployment traffic filters are computed to not conflict with a traffic filter association resource

### DIFF
--- a/.changelog/632.txt
+++ b/.changelog/632.txt
@@ -1,0 +1,5 @@
+```release-note:bug-fix
+Prevents traffic filters managed with the `ec_deployment_traffic_filter_association` from being disassociated by the `ec_deployment` resource ([#419](https://github.com/elastic/terraform-provider-ec/issues/419)).
+This also fixes a provider crash for the above scenario present in 0.6 ([#621](https://github.com/elastic/terraform-provider-ec/issues/621))
+```
+https://github.com/elastic/terraform-provider-ec/pull/632

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -268,7 +268,7 @@ resource "ec_deployment" "ccs" {
 - `request_id` (String) Request ID to set when you create the deployment. Use it only when previous attempts return an error and `request_id` is returned as part of the error.
 - `reset_elasticsearch_password` (Boolean) Explicitly resets the elasticsearch_password when true
 - `tags` (Map of String) Optional map of deployment tags
-- `traffic_filter` (Set of String) List of traffic filters rule identifiers that will be applied to the deployment.
+- `traffic_filter` (Set of String) List of traffic filters rule identifiers that will be applied to the deployment. Removing this attribute entirely *will not* remove managed traffic filters, instead first set it to an empty list (e.g `traffic_filter = []`) to remove the managed traffic filters.
 
 ### Read-Only
 

--- a/ec/acc/deployment_basic_test.go
+++ b/ec/acc/deployment_basic_test.go
@@ -35,10 +35,12 @@ func TestAccDeployment_basic_tf(t *testing.T) {
 	randomAlias := "alias" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 	trafficFilterCfg := "testdata/deployment_basic_with_traffic_filter_2.tf"
 	trafficFilterUpdateCfg := "testdata/deployment_basic_with_traffic_filter_3.tf"
+	emptyTrafficFilterCfg := "testdata/deployment_basic_with_empty_traffic_filter.tf"
 	resetPasswordCfg := "testdata/deployment_basic_reset_password.tf"
 	cfg := fixtureAccDeploymentResourceBasicWithAppsAlias(t, startCfg, randomAlias, randomName, getRegion(), defaultTemplate)
 	cfgWithTrafficFilter := fixtureAccDeploymentResourceBasicWithTF(t, trafficFilterCfg, randomName, getRegion(), defaultTemplate)
 	cfgWithTrafficFilterUpdate := fixtureAccDeploymentResourceBasicWithTF(t, trafficFilterUpdateCfg, randomName, getRegion(), defaultTemplate)
+	cfgWithEmptyTrafficFilter := fixtureAccDeploymentResourceBasicWithAppsAlias(t, emptyTrafficFilterCfg, randomAlias, randomName, getRegion(), defaultTemplate)
 	cfgResetPassword := fixtureAccDeploymentResourceBasicWithAppsAlias(t, resetPasswordCfg, randomAlias, randomName, getRegion(), defaultTemplate)
 	deploymentVersion, err := latestStackVersion()
 	if err != nil {
@@ -76,9 +78,16 @@ func TestAccDeployment_basic_tf(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "1"),
 				),
 			},
-			// Remove traffic filter.
+			// Unset the traffic filter (this should not remove the traffic filter)
 			{
 				Config: cfg,
+				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
+					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "1"),
+				),
+			},
+			// Explicitly set the traffic filter to an empty list to remove the traffic filter
+			{
+				Config: cfgWithEmptyTrafficFilter,
 				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "0"),
 					func(s *terraform.State) error {

--- a/ec/acc/deployment_traffic_filter_association_test.go
+++ b/ec/acc/deployment_traffic_filter_association_test.go
@@ -43,10 +43,7 @@ func TestAccDeploymentTrafficFilterAssociation_basic(t *testing.T) {
 		CheckDestroy:             testAccDeploymentTrafficFilterDestroy,
 		Steps: []resource.TestStep{
 			{
-				// Expects a non-empty plan since "ec_deployment.traffic_filter"
-				// will have changes due to the traffic filter association.
-				ExpectNonEmptyPlan: true,
-				Config:             cfg,
+				Config: cfg,
 				Check: checkBasicDeploymentTrafficFilterAssociationResource(
 					resName, resAssocName, randomName,
 					resource.TestCheckResourceAttr(resName, "include_by_default", "false"),
@@ -56,10 +53,7 @@ func TestAccDeploymentTrafficFilterAssociation_basic(t *testing.T) {
 				),
 			},
 			{
-				// Expects a non-empty plan since "ec_deployment.traffic_filter"
-				// will have changes due to the traffic filter association.
-				ExpectNonEmptyPlan: true,
-				Config:             updateConfigCfg,
+				Config: updateConfigCfg,
 				Check: checkBasicDeploymentTrafficFilterAssociationResource(
 					resNameSecond, resAssocName, randomNameSecond,
 					resource.TestCheckResourceAttr(resNameSecond, "include_by_default", "false"),
@@ -94,10 +88,7 @@ func TestAccDeploymentTrafficFilterAssociation_UpgradeFrom0_4_1(t *testing.T) {
 						Source:            "elastic/ec",
 					},
 				},
-				// Expects a non-empty plan since "ec_deployment.traffic_filter"
-				// will have changes due to the traffic filter association.
-				ExpectNonEmptyPlan: true,
-				Config:             cfg,
+				Config: cfg,
 				Check: checkBasicDeploymentTrafficFilterAssociationResource(
 					resName, resAssocName, randomName,
 					resource.TestCheckResourceAttr(resName, "include_by_default", "false"),

--- a/ec/acc/testdata/deployment_basic_with_empty_traffic_filter.tf
+++ b/ec/acc/testdata/deployment_basic_with_empty_traffic_filter.tf
@@ -1,0 +1,33 @@
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
+
+resource "ec_deployment" "basic" {
+  alias                  = "%s"
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
+
+  elasticsearch = {
+    hot = {
+      size        = "1g"
+      autoscaling = {}
+    }
+  }
+
+  kibana = {
+    instance_configuration_id = "%s"
+  }
+
+  apm = {
+    instance_configuration_id = "%s"
+  }
+
+  enterprise_search = {
+    instance_configuration_id = "%s"
+  }
+
+  traffic_filter = []
+}

--- a/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
@@ -240,13 +240,9 @@ func (dep *Deployment) HandleEmptyTrafficFilters(ctx context.Context, base Deplo
 			return diags
 		}
 
-		if len(baseFilters) > 0 {
-			return diag.Diagnostics{
-				diag.NewErrorDiagnostic("Unable to override traffic filters with non-empty value", "Overriding missing traffic filters with a non-empty value should not occur. This is likely a bug with the underlying Cloud API."),
-			}
+		if len(baseFilters) == 0 {
+			dep.TrafficFilter = baseFilters
 		}
-
-		dep.TrafficFilter = baseFilters
 	}
 
 	return diags

--- a/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
@@ -35,6 +35,7 @@ import (
 	"github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/utils"
 	"github.com/elastic/terraform-provider-ec/ec/internal/converters"
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -225,6 +226,30 @@ func (dep *Deployment) ProcessSelfInObservability() {
 	if *dep.Observability.DeploymentId == dep.Id {
 		*dep.Observability.DeploymentId = "self"
 	}
+}
+
+func (dep *Deployment) HandleEmptyTrafficFilters(ctx context.Context, base DeploymentTF) diag.Diagnostics {
+	var diags diag.Diagnostics
+	// Ensure consistency between null, and empty configured traffic filter values.
+	// The Cloud API represents an empty set of traffic filters as a null/missing value. Terraform does distinguish between those two cases.
+	// If the Cloud response does not include traffic filters, then set the read value as the planned value, but only if the planned value is empty.
+	if dep.TrafficFilter == nil {
+		var baseFilters []string
+		diags := base.TrafficFilter.ElementsAs(ctx, &baseFilters, true)
+		if diags.HasError() {
+			return diags
+		}
+
+		if len(baseFilters) > 0 {
+			return diag.Diagnostics{
+				diag.NewErrorDiagnostic("Unable to override traffic filters with non-empty value", "Overriding missing traffic filters with a non-empty value should not occur. This is likely a bug with the underlying Cloud API."),
+			}
+		}
+
+		dep.TrafficFilter = baseFilters
+	}
+
+	return diags
 }
 
 func (dep *Deployment) SetCredentialsIfEmpty(state *DeploymentTF) {

--- a/ec/ecresource/deploymentresource/deployment/v2/schema.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/schema.go
@@ -120,9 +120,6 @@ func DeploymentSchema() tfsdk.Schema {
 				Optional:    true,
 				Computed:    true,
 				Description: "List of traffic filters rule identifiers that will be applied to the deployment. Removing this attribute entirely *will not* remove managed traffic filters, instead first set it to an empty list (e.g `traffic_filter = []`) to remove the managed traffic filters.",
-				PlanModifiers: tfsdk.AttributePlanModifiers{
-					resource.UseStateForUnknown(),
-				},
 			},
 			"tags": {
 				Description: "Optional map of deployment tags",

--- a/ec/ecresource/deploymentresource/deployment/v2/schema.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/schema.go
@@ -118,7 +118,11 @@ func DeploymentSchema() tfsdk.Schema {
 					ElemType: types.StringType,
 				},
 				Optional:    true,
-				Description: `List of traffic filters rule identifiers that will be applied to the deployment.`,
+				Computed:    true,
+				Description: "List of traffic filters rule identifiers that will be applied to the deployment. Removing this attribute entirely *will not* remove managed traffic filters, instead first set it to an empty list (e.g `traffic_filter = []`) to remove the managed traffic filters.",
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					resource.UseStateForUnknown(),
+				},
 			},
 			"tags": {
 				Description: "Optional map of deployment tags",

--- a/ec/ecresource/deploymentresource/read.go
+++ b/ec/ecresource/deploymentresource/read.go
@@ -153,17 +153,12 @@ func (r *Resource) read(ctx context.Context, id string, state *deploymentv2.Depl
 		return nil, diags
 	}
 
-	if deployment.TrafficFilter == nil {
-		diags.Append(base.TrafficFilter.ElementsAs(ctx, &deployment.TrafficFilter, true)...)
-		if diags.HasError() {
-			return nil, diags
-		}
-	}
-
 	deployment.RequestId = base.RequestId.Value
 	if !base.ResetElasticsearchPassword.IsNull() && !base.ResetElasticsearchPassword.IsUnknown() {
 		deployment.ResetElasticsearchPassword = &base.ResetElasticsearchPassword.Value
 	}
+
+	diags.Append(deployment.HandleEmptyTrafficFilters(ctx, base)...)
 
 	deployment.SetCredentialsIfEmpty(state)
 

--- a/ec/ecresource/deploymentresource/read.go
+++ b/ec/ecresource/deploymentresource/read.go
@@ -153,6 +153,13 @@ func (r *Resource) read(ctx context.Context, id string, state *deploymentv2.Depl
 		return nil, diags
 	}
 
+	if deployment.TrafficFilter == nil {
+		diags.Append(base.TrafficFilter.ElementsAs(ctx, &deployment.TrafficFilter, true)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+	}
+
 	deployment.RequestId = base.RequestId.Value
 	if !base.ResetElasticsearchPassword.IsNull() && !base.ResetElasticsearchPassword.IsUnknown() {
 		deployment.ResetElasticsearchPassword = &base.ResetElasticsearchPassword.Value

--- a/ec/ecresource/deploymentresource/update.go
+++ b/ec/ecresource/deploymentresource/update.go
@@ -116,7 +116,7 @@ func (r *Resource) ResetElasticsearchPassword(deploymentID string, refID string)
 }
 
 func HandleTrafficFilterChange(ctx context.Context, client *api.API, plan, state v2.DeploymentTF) diag.Diagnostics {
-	if plan.TrafficFilter.IsNull() || plan.TrafficFilter.Equal(state.TrafficFilter) {
+	if plan.TrafficFilter.Equal(state.TrafficFilter) {
 		return nil
 	}
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
Marks the ec_deployment traffic_filter attribute as computed, since it can also be managed via a ec_deployment_traffic_filter_association resource. 

## Related Issues
Fixes https://github.com/elastic/terraform-provider-ec/issues/621
Fixes https://github.com/elastic/terraform-provider-ec/issues/419

<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, acceptance tests 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
