### PR TITLE
Reset es password

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -266,6 +266,7 @@ resource "ec_deployment" "ccs" {
 - `name` (String) Name for the deployment
 - `observability` (Attributes) Observability settings that you can set to ship logs and metrics to a deployment. The target deployment can also be the current deployment itself by setting observability.deployment_id to `self`. (see [below for nested schema](#nestedatt--observability))
 - `request_id` (String) Request ID to set when you create the deployment. Use it only when previous attempts return an error and `request_id` is returned as part of the error.
+- `reset_elasticsearch_password` (Boolean) Explicitly resets the elasticsearch_password when true
 - `tags` (Map of String) Optional map of deployment tags
 - `traffic_filter` (Set of String) List of traffic filters rule identifiers that will be applied to the deployment.
 

--- a/ec/acc/testdata/deployment_basic_reset_password.tf
+++ b/ec/acc/testdata/deployment_basic_reset_password.tf
@@ -1,0 +1,33 @@
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
+
+resource "ec_deployment" "basic" {
+  alias                  = "%s"
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
+
+  elasticsearch = {
+    hot = {
+      size        = "1g"
+      autoscaling = {}
+    }
+  }
+
+  kibana = {
+    instance_configuration_id = "%s"
+  }
+
+  apm = {
+    instance_configuration_id = "%s"
+  }
+
+  enterprise_search = {
+    instance_configuration_id = "%s"
+  }
+
+  reset_elasticsearch_password = true
+}

--- a/ec/ecresource/deploymentresource/deployment/v2/deployment_create_payload.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/deployment_create_payload.go
@@ -38,24 +38,25 @@ import (
 )
 
 type DeploymentTF struct {
-	Id                    types.String `tfsdk:"id"`
-	Alias                 types.String `tfsdk:"alias"`
-	Version               types.String `tfsdk:"version"`
-	Region                types.String `tfsdk:"region"`
-	DeploymentTemplateId  types.String `tfsdk:"deployment_template_id"`
-	Name                  types.String `tfsdk:"name"`
-	RequestId             types.String `tfsdk:"request_id"`
-	ElasticsearchUsername types.String `tfsdk:"elasticsearch_username"`
-	ElasticsearchPassword types.String `tfsdk:"elasticsearch_password"`
-	ApmSecretToken        types.String `tfsdk:"apm_secret_token"`
-	TrafficFilter         types.Set    `tfsdk:"traffic_filter"`
-	Tags                  types.Map    `tfsdk:"tags"`
-	Elasticsearch         types.Object `tfsdk:"elasticsearch"`
-	Kibana                types.Object `tfsdk:"kibana"`
-	Apm                   types.Object `tfsdk:"apm"`
-	IntegrationsServer    types.Object `tfsdk:"integrations_server"`
-	EnterpriseSearch      types.Object `tfsdk:"enterprise_search"`
-	Observability         types.Object `tfsdk:"observability"`
+	Id                         types.String `tfsdk:"id"`
+	Alias                      types.String `tfsdk:"alias"`
+	Version                    types.String `tfsdk:"version"`
+	Region                     types.String `tfsdk:"region"`
+	DeploymentTemplateId       types.String `tfsdk:"deployment_template_id"`
+	Name                       types.String `tfsdk:"name"`
+	RequestId                  types.String `tfsdk:"request_id"`
+	ElasticsearchUsername      types.String `tfsdk:"elasticsearch_username"`
+	ElasticsearchPassword      types.String `tfsdk:"elasticsearch_password"`
+	ApmSecretToken             types.String `tfsdk:"apm_secret_token"`
+	TrafficFilter              types.Set    `tfsdk:"traffic_filter"`
+	Tags                       types.Map    `tfsdk:"tags"`
+	Elasticsearch              types.Object `tfsdk:"elasticsearch"`
+	Kibana                     types.Object `tfsdk:"kibana"`
+	Apm                        types.Object `tfsdk:"apm"`
+	IntegrationsServer         types.Object `tfsdk:"integrations_server"`
+	EnterpriseSearch           types.Object `tfsdk:"enterprise_search"`
+	Observability              types.Object `tfsdk:"observability"`
+	ResetElasticsearchPassword types.Bool   `tfsdk:"reset_elasticsearch_password"`
 }
 
 func (dep DeploymentTF) CreateRequest(ctx context.Context, client *api.API) (*models.DeploymentCreateRequest, diag.Diagnostics) {

--- a/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
@@ -39,24 +39,25 @@ import (
 )
 
 type Deployment struct {
-	Id                    string                                   `tfsdk:"id"`
-	Alias                 string                                   `tfsdk:"alias"`
-	Version               string                                   `tfsdk:"version"`
-	Region                string                                   `tfsdk:"region"`
-	DeploymentTemplateId  string                                   `tfsdk:"deployment_template_id"`
-	Name                  string                                   `tfsdk:"name"`
-	RequestId             string                                   `tfsdk:"request_id"`
-	ElasticsearchUsername string                                   `tfsdk:"elasticsearch_username"`
-	ElasticsearchPassword string                                   `tfsdk:"elasticsearch_password"`
-	ApmSecretToken        *string                                  `tfsdk:"apm_secret_token"`
-	TrafficFilter         []string                                 `tfsdk:"traffic_filter"`
-	Tags                  map[string]string                        `tfsdk:"tags"`
-	Elasticsearch         *elasticsearchv2.Elasticsearch           `tfsdk:"elasticsearch"`
-	Kibana                *kibanav2.Kibana                         `tfsdk:"kibana"`
-	Apm                   *apmv2.Apm                               `tfsdk:"apm"`
-	IntegrationsServer    *integrationsserverv2.IntegrationsServer `tfsdk:"integrations_server"`
-	EnterpriseSearch      *enterprisesearchv2.EnterpriseSearch     `tfsdk:"enterprise_search"`
-	Observability         *observabilityv2.Observability           `tfsdk:"observability"`
+	Id                         string                                   `tfsdk:"id"`
+	Alias                      string                                   `tfsdk:"alias"`
+	Version                    string                                   `tfsdk:"version"`
+	Region                     string                                   `tfsdk:"region"`
+	DeploymentTemplateId       string                                   `tfsdk:"deployment_template_id"`
+	Name                       string                                   `tfsdk:"name"`
+	RequestId                  string                                   `tfsdk:"request_id"`
+	ElasticsearchUsername      string                                   `tfsdk:"elasticsearch_username"`
+	ElasticsearchPassword      string                                   `tfsdk:"elasticsearch_password"`
+	ApmSecretToken             *string                                  `tfsdk:"apm_secret_token"`
+	TrafficFilter              []string                                 `tfsdk:"traffic_filter"`
+	Tags                       map[string]string                        `tfsdk:"tags"`
+	Elasticsearch              *elasticsearchv2.Elasticsearch           `tfsdk:"elasticsearch"`
+	Kibana                     *kibanav2.Kibana                         `tfsdk:"kibana"`
+	Apm                        *apmv2.Apm                               `tfsdk:"apm"`
+	IntegrationsServer         *integrationsserverv2.IntegrationsServer `tfsdk:"integrations_server"`
+	EnterpriseSearch           *enterprisesearchv2.EnterpriseSearch     `tfsdk:"enterprise_search"`
+	Observability              *observabilityv2.Observability           `tfsdk:"observability"`
+	ResetElasticsearchPassword *bool                                    `tfsdk:"reset_elasticsearch_password"`
 }
 
 // Nullify Elasticsearch topologies that have zero size and are not specified in plan

--- a/ec/ecresource/deploymentresource/deployment/v2/schema.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/schema.go
@@ -171,8 +171,6 @@ func (m setUnknownIfResetPasswordIsTrue) Modify(ctx context.Context, req tfsdk.M
 	}
 
 	if isResetting != nil && *isResetting {
-		planVal := resp.AttributePlan.(types.String)
-		planVal.Unknown = true
-		resp.AttributePlan = planVal
+		resp.AttributePlan = types.String{Unknown: true}
 	}
 }

--- a/ec/ecresource/deploymentresource/read.go
+++ b/ec/ecresource/deploymentresource/read.go
@@ -154,6 +154,9 @@ func (r *Resource) read(ctx context.Context, id string, state *deploymentv2.Depl
 	}
 
 	deployment.RequestId = base.RequestId.Value
+	if !base.ResetElasticsearchPassword.IsNull() && !base.ResetElasticsearchPassword.IsUnknown() {
+		deployment.ResetElasticsearchPassword = &base.ResetElasticsearchPassword.Value
+	}
 
 	deployment.SetCredentialsIfEmpty(state)
 

--- a/ec/ecresource/deploymentresource/update.go
+++ b/ec/ecresource/deploymentresource/update.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/depresourceapi"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	v2 "github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/deployment/v2"
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
@@ -77,7 +78,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	resp.Diagnostics.Append(v2.HandleRemoteClusters(ctx, r.client, plan.Id.Value, plan.Elasticsearch)...)
 
 	deployment, diags := r.read(ctx, plan.Id.Value, &state, &plan, res.Resources)
-
 	resp.Diagnostics.Append(diags...)
 
 	if deployment == nil {
@@ -86,7 +86,33 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
+	if plan.ResetElasticsearchPassword.Value {
+		newPassword, diags := r.ResetElasticsearchPassword(plan.Id.Value, *deployment.Elasticsearch.RefId)
+		if resp.Diagnostics.Append(diags...); resp.Diagnostics.HasError() {
+			return
+		}
+
+		deployment.ElasticsearchPassword = newPassword
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, deployment)...)
+}
+
+func (r *Resource) ResetElasticsearchPassword(deploymentID string, refID string) (string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	resetResp, err := depresourceapi.ResetElasticsearchPassword(depresourceapi.ResetElasticsearchPasswordParams{
+		API:   r.client,
+		ID:    deploymentID,
+		RefID: refID,
+	})
+
+	if err != nil {
+		diags.AddError("failed to reset elasticsearch password", err.Error())
+		return "", diags
+	}
+
+	return *resetResp.Password, diags
 }
 
 func HandleTrafficFilterChange(ctx context.Context, client *api.API, plan, state v2.DeploymentTF) diag.Diagnostics {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
Adds a `reset_elasticsearch_password` attribute to the deployment resource, when true this explicitly resets the password, updating the value in state with the new credentials. 

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Fixes https://github.com/elastic/terraform-provider-ec/issues/99

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With the migration to 0.6 and higher requiring re-importing existing deployments, which in turn does not include the current elastic user, customers need a path to programatically update the credentials in TF state.  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Acceptance tests, manual tests. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
