### PR TITLE
Support deployments without autoscaling fields defined in the deployments data source

### DIFF
--- a/.changelog/667.txt
+++ b/.changelog/667.txt
@@ -1,0 +1,3 @@
+```release-note:bug-fix
+datasource/deployments: Fix bug causing a provider crash when no autoscaling fields are defined in the matching deployment
+```

--- a/ec/acc/datasource_deployment_basic_test.go
+++ b/ec/acc/datasource_deployment_basic_test.go
@@ -34,7 +34,8 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 	secondRandomName := prefix + "-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	randomAlias := "alias" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	depCfg := "testdata/datasource_deployment_basic.tf"
-	cfg := fixtureAccDeploymentDatasourceBasicAlias(t, depCfg, randomAlias, randomName, secondRandomName, getRegion(), computeOpTemplate)
+	cfgWithAutoscaling := fixtureAccDeploymentDatasourceBasicAlias(t, depCfg, randomAlias, randomName, secondRandomName, getRegion(), computeOpTemplate, "true")
+	cfgWithoutAutoscaling := fixtureAccDeploymentDatasourceBasicAlias(t, depCfg, randomAlias, randomName, secondRandomName, getRegion(), computeOpTemplate, "false")
 	var namePrefix = secondRandomName[:22]
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,7 +44,7 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 		CheckDestroy:             testAccDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: cfg,
+				Config: cfgWithoutAutoscaling,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "alias", resourceName, "alias"),
@@ -104,7 +105,68 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: cfg,
+				Config: cfgWithAutoscaling,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "alias", resourceName, "alias"),
+					resource.TestCheckResourceAttrPair(datasourceName, "region", resourceName, "region"),
+					resource.TestCheckResourceAttrPair(datasourceName, "deployment_template_id", resourceName, "deployment_template_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "traffic_filter.#", resourceName, "traffic_filter.#"),
+
+					// Elasticsearch
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.ref_id", resourceName, "elasticsearch.ref_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.cloud_id", resourceName, "elasticsearch.cloud_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.resource_id", resourceName, "elasticsearch.resource_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.http_endpoint_id", resourceName, "elasticsearch.http_endpoint_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.https_endpoint_id", resourceName, "elasticsearch.https_endpoint_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.instance_configuration_id", resourceName, "elasticsearch.hot.instance_configuration_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.size", resourceName, "elasticsearch.hot.size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.size_resource", resourceName, "elasticsearch.hot.size_resource"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.zone_count", resourceName, "elasticsearch.hot.zone_count"),
+					resource.TestCheckResourceAttrPair(datasourceName, "elasticsearch.0.topology.0.node_roles.*", resourceName, "elasticsearch.hot.node_roles.*"),
+
+					// Kibana
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.elasticsearch_cluster_ref_id", resourceName, "kibana.elasticsearch_cluster_ref_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.ref_id", resourceName, "kibana.ref_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.cloud_id", resourceName, "kibana.cloud_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.resource_id", resourceName, "kibana.resource_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.http_endpoint_id", resourceName, "kibana.http_endpoint_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.https_endpoint_id", resourceName, "kibana.https_endpoint_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.topology.0.instance_configuration_id", resourceName, "kibana.instance_configuration_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.topology.0.size", resourceName, "kibana.size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.topology.0.size_resource", resourceName, "kibana.size_resource"),
+					resource.TestCheckResourceAttrPair(datasourceName, "kibana.0.topology.0.zone_count", resourceName, "kibana.zone_count"),
+
+					// APM
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.elasticsearch_cluster_ref_id", resourceName, "apm.elasticsearch_cluster_ref_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.ref_id", resourceName, "apm.ref_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.cloud_id", resourceName, "apm.cloud_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.resource_id", resourceName, "apm.resource_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.http_endpoint_id", resourceName, "apm.http_endpoint_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.https_endpoint_id", resourceName, "apm.https_endpoint_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.topology.0.instance_configuration_id", resourceName, "apm.instance_configuration_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.topology.0.size", resourceName, "apm.size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.topology.0.size_resource", resourceName, "apm.size_resource"),
+					resource.TestCheckResourceAttrPair(datasourceName, "apm.0.topology.0.zone_count", resourceName, "apm.zone_count"),
+
+					// Enterprise Search
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.elasticsearch_cluster_ref_id", resourceName, "enterprise_search.elasticsearch_cluster_ref_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.ref_id", resourceName, "enterprise_search.ref_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.cloud_id", resourceName, "enterprise_search.cloud_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.resource_id", resourceName, "enterprise_search.resource_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.http_endpoint_id", resourceName, "enterprise_search.http_endpoint_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.https_endpoint_id", resourceName, "enterprise_search.https_endpoint_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.topology.0.instance_configuration_id", resourceName, "enterprise_search.instance_configuration_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.topology.0.size", resourceName, "enterprise_search.size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.topology.0.size_resource", resourceName, "enterprise_search.size_resource"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.topology.0.zone_count", resourceName, "enterprise_search.zone_count"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.topology.0.node_type_appserver", resourceName, "enterprise_search.node_type_appserver"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.topology.0.node_type_connector", resourceName, "enterprise_search.node_type_connector"),
+					resource.TestCheckResourceAttrPair(datasourceName, "enterprise_search.0.topology.0.node_type_worker", resourceName, "enterprise_search.node_type_worker"),
+				),
+			},
+			{
+				Config: cfgWithAutoscaling,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(depsDatasourceName, "name_prefix", namePrefix),
 					resource.TestCheckResourceAttrPair(depsDatasourceName, "deployment_template_id", resourceName, "deployment_template_id"),
@@ -130,7 +192,7 @@ func TestAccDatasourceDeployment_basic(t *testing.T) {
 	})
 }
 
-func fixtureAccDeploymentDatasourceBasicAlias(t *testing.T, fileName, alias, name, secondName, region, depTpl string) string {
+func fixtureAccDeploymentDatasourceBasicAlias(t *testing.T, fileName, alias, name, secondName, region, depTpl, autoscaling string) string {
 	t.Helper()
 
 	deploymentTpl := setDefaultTemplate(region, depTpl)
@@ -139,6 +201,6 @@ func fixtureAccDeploymentDatasourceBasicAlias(t *testing.T, fileName, alias, nam
 		t.Fatal(err)
 	}
 	return fmt.Sprintf(string(b),
-		region, name, region, deploymentTpl, alias, secondName, region, deploymentTpl, secondName, region, deploymentTpl,
+		region, name, region, deploymentTpl, autoscaling, alias, secondName, region, deploymentTpl, secondName, region, deploymentTpl,
 	)
 }

--- a/ec/acc/testdata/datasource_deployment_basic.tf
+++ b/ec/acc/testdata/datasource_deployment_basic.tf
@@ -10,7 +10,7 @@ resource "ec_deployment" "basic_observability" {
   deployment_template_id = "%s"
 
   elasticsearch = {
-    autoscale = %s
+    autoscale = "%s"
     hot = {
       size        = "1g"
       zone_count  = 1

--- a/ec/acc/testdata/datasource_deployment_basic.tf
+++ b/ec/acc/testdata/datasource_deployment_basic.tf
@@ -10,6 +10,7 @@ resource "ec_deployment" "basic_observability" {
   deployment_template_id = "%s"
 
   elasticsearch = {
+    autoscale = %s
     hot = {
       size        = "1g"
       zone_count  = 1

--- a/ec/ecdatasource/deploymentdatasource/flatteners_elasticsearch.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_elasticsearch.go
@@ -96,7 +96,8 @@ func flattenElasticsearchTopology(ctx context.Context, plan *models.Elasticsearc
 	var result = make([]elasticsearchTopologyModelV0, 0, len(plan.ClusterTopology))
 	for _, topology := range plan.ClusterTopology {
 		model := elasticsearchTopologyModelV0{
-			NodeRoles: types.SetNull(types.StringType),
+			NodeRoles:   types.SetNull(types.StringType),
+			Autoscaling: types.ListNull(elasticsearchAutoscalingElemType()),
 		}
 
 		if isElasticsearchSizePopulated(topology) && *topology.Size.Value == 0 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
When no autoscaling fields are defined, the autoscaling property on the model will be nil (with nil ElemType), causing the provider to crash. This PR sets the initial value to a NullList with the correct ElemTypes set. 

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Fixes https://github.com/elastic/terraform-provider-ec/issues/649

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, added an acceptance test. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
