### PR TITLE
Remove dependency on the old SDK

### DIFF
--- a/.changelog/720.txt
+++ b/.changelog/720.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Remove direct dependency on the old Terraform Plugin SDK
+```

--- a/ec/acc/datasource_deployment_basic_test.go
+++ b/ec/acc/datasource_deployment_basic_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDatasourceDeployment_basic(t *testing.T) {

--- a/ec/acc/datasource_stack_test.go
+++ b/ec/acc/datasource_stack_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDatasourceStack_latest(t *testing.T) {

--- a/ec/acc/datasource_tags_test.go
+++ b/ec/acc/datasource_tags_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // This test case takes ensures that the tag metadata of an "ec_deployment"

--- a/ec/acc/datasource_traffic_filter_test.go
+++ b/ec/acc/datasource_traffic_filter_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // This test creates a resource of type traffic filter with the randomName

--- a/ec/acc/deployment_autoscaling_test.go
+++ b/ec/acc/deployment_autoscaling_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_autoscaling(t *testing.T) {

--- a/ec/acc/deployment_basic_defaults_test.go
+++ b/ec/acc/deployment_basic_defaults_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // This test case takes ensures that several features of the "ec_deployment"

--- a/ec/acc/deployment_basic_tags_test.go
+++ b/ec/acc/deployment_basic_tags_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // This test case takes ensures that several features of the "ec_deployment"

--- a/ec/acc/deployment_basic_test.go
+++ b/ec/acc/deployment_basic_test.go
@@ -23,9 +23,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDeployment_basic_tf(t *testing.T) {

--- a/ec/acc/deployment_ccs_test.go
+++ b/ec/acc/deployment_ccs_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // This test case takes that on a ccs "ec_deployment".

--- a/ec/acc/deployment_checks_test.go
+++ b/ec/acc/deployment_checks_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"

--- a/ec/acc/deployment_compute_optimized_test.go
+++ b/ec/acc/deployment_compute_optimized_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_computeOptimized(t *testing.T) {

--- a/ec/acc/deployment_dedicated_test.go
+++ b/ec/acc/deployment_dedicated_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_dedicated_coordinating(t *testing.T) {

--- a/ec/acc/deployment_destroy_test.go
+++ b/ec/acc/deployment_destroy_test.go
@@ -20,7 +20,7 @@ package acc
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"

--- a/ec/acc/deployment_docker_image_override_test.go
+++ b/ec/acc/deployment_docker_image_override_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_docker_image_override(t *testing.T) {

--- a/ec/acc/deployment_elasticsearch_kesytore_destroy_test.go
+++ b/ec/acc/deployment_elasticsearch_kesytore_destroy_test.go
@@ -20,7 +20,7 @@ package acc
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/eskeystoreapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"

--- a/ec/acc/deployment_elasticsearch_keystore_test.go
+++ b/ec/acc/deployment_elasticsearch_keystore_test.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )

--- a/ec/acc/deployment_emptyconf_test.go
+++ b/ec/acc/deployment_emptyconf_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_emptyconfig(t *testing.T) {

--- a/ec/acc/deployment_enterprise_search_test.go
+++ b/ec/acc/deployment_enterprise_search_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_enterpriseSearch(t *testing.T) {

--- a/ec/acc/deployment_extension_basic_test.go
+++ b/ec/acc/deployment_extension_basic_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeploymentExtension_basic(t *testing.T) {

--- a/ec/acc/deployment_extension_bundle_file_test.go
+++ b/ec/acc/deployment_extension_bundle_file_test.go
@@ -27,9 +27,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
 )

--- a/ec/acc/deployment_extension_destroy_test.go
+++ b/ec/acc/deployment_extension_destroy_test.go
@@ -20,7 +20,7 @@ package acc
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"

--- a/ec/acc/deployment_extension_plugin_download_test.go
+++ b/ec/acc/deployment_extension_plugin_download_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeploymentExtension_pluginDownload(t *testing.T) {

--- a/ec/acc/deployment_failed_upgrade_retry_test.go
+++ b/ec/acc/deployment_failed_upgrade_retry_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDeployment_failed_upgrade_retry(t *testing.T) {

--- a/ec/acc/deployment_hotwarm_test.go
+++ b/ec/acc/deployment_hotwarm_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 // This test case takes that on a hot/warm "ec_deployment", a select number of

--- a/ec/acc/deployment_integrations_server_test.go
+++ b/ec/acc/deployment_integrations_server_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_integrationsServer(t *testing.T) {

--- a/ec/acc/deployment_keystore_test.go
+++ b/ec/acc/deployment_keystore_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_keystore(t *testing.T) {

--- a/ec/acc/deployment_memory_optimized_test.go
+++ b/ec/acc/deployment_memory_optimized_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_memoryOptimized(t *testing.T) {

--- a/ec/acc/deployment_observability_self_test.go
+++ b/ec/acc/deployment_observability_self_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_observability_createWithSelfObservability(t *testing.T) {

--- a/ec/acc/deployment_observability_test.go
+++ b/ec/acc/deployment_observability_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_observability_first(t *testing.T) {

--- a/ec/acc/deployment_observability_tpl_test.go
+++ b/ec/acc/deployment_observability_tpl_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_observabilityTpl(t *testing.T) {

--- a/ec/acc/deployment_post_node_role_upgrade_test.go
+++ b/ec/acc/deployment_post_node_role_upgrade_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_post_node_roles(t *testing.T) {

--- a/ec/acc/deployment_pre_node_role_migration_test.go
+++ b/ec/acc/deployment_pre_node_role_migration_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_pre_node_roles(t *testing.T) {

--- a/ec/acc/deployment_security_test.go
+++ b/ec/acc/deployment_security_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_security(t *testing.T) {

--- a/ec/acc/deployment_snapshot_test.go
+++ b/ec/acc/deployment_snapshot_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // creds is used as a container to pass around ES credentials.

--- a/ec/acc/deployment_sweep_test.go
+++ b/ec/acc/deployment_sweep_test.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"

--- a/ec/acc/deployment_template_migration_test.go
+++ b/ec/acc/deployment_template_migration_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeployment_template_migration(t *testing.T) {

--- a/ec/acc/deployment_traffic_filter_association_test.go
+++ b/ec/acc/deployment_traffic_filter_association_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeploymentTrafficFilterAssociation_basic(t *testing.T) {

--- a/ec/acc/deployment_traffic_filter_checks_test.go
+++ b/ec/acc/deployment_traffic_filter_checks_test.go
@@ -20,8 +20,8 @@ package acc
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"

--- a/ec/acc/deployment_traffic_filter_destroy_test.go
+++ b/ec/acc/deployment_traffic_filter_destroy_test.go
@@ -20,7 +20,7 @@ package acc
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"

--- a/ec/acc/deployment_traffic_filter_sweep_test.go
+++ b/ec/acc/deployment_traffic_filter_sweep_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"

--- a/ec/acc/deployment_traffic_filter_test.go
+++ b/ec/acc/deployment_traffic_filter_test.go
@@ -23,8 +23,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDeploymentTrafficFilter_basic(t *testing.T) {

--- a/ec/acc/deployment_with_extension_bundle_test.go
+++ b/ec/acc/deployment_with_extension_bundle_test.go
@@ -23,9 +23,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )

--- a/ec/acc/sweep_test.go
+++ b/ec/acc/sweep_test.go
@@ -20,7 +20,7 @@ package acc
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestMain(m *testing.M) {

--- a/ec/ecdatasource/deploymentsdatasource/datasource.go
+++ b/ec/ecdatasource/deploymentsdatasource/datasource.go
@@ -20,19 +20,18 @@ package deploymentsdatasource
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal"
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 var _ datasource.DataSource = &DataSource{}
@@ -100,7 +99,7 @@ func modelToState(ctx context.Context, res *models.DeploymentsSearchResponse, st
 	var diags diag.Diagnostics
 
 	if b, _ := res.MarshalBinary(); len(b) > 0 {
-		state.ID = types.StringValue(strconv.Itoa(schema.HashString(string(b))))
+		state.ID = types.StringValue(util.HashString(string(b)))
 	}
 	state.ReturnCount = types.Int64Value(int64(*res.ReturnCount))
 

--- a/ec/ecresource/deploymentresource/deployment_test.go
+++ b/ec/ecresource/deploymentresource/deployment_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
@@ -61,24 +61,24 @@ func Test_createDeploymentWithEmptyFields(t *testing.T) {
 
 	createDeploymentResponseJson := []byte(`
 	{
-		"alias": "my-deployment-name", 
-		"created": true, 
-		"id": "accd2e61fa835a5a32bb6b2938ce91f3", 
+		"alias": "my-deployment-name",
+		"created": true,
+		"id": "accd2e61fa835a5a32bb6b2938ce91f3",
 		"resources": [
 			{
-				"kind": "elasticsearch", 
-				"cloud_id": "my_deployment_name:cloud_id", 
-				"region": "us-east-1", 
-				"ref_id": "main-elasticsearch", 
+				"kind": "elasticsearch",
+				"cloud_id": "my_deployment_name:cloud_id",
+				"region": "us-east-1",
+				"ref_id": "main-elasticsearch",
 				"credentials": {
-					"username": "elastic", 
+					"username": "elastic",
 					"password": "password"
-				}, 
+				},
 				"id": "resource_id"
 			}
-		], 
+		],
 		"name": "my_deployment_name"
-	}	
+	}
 	`)
 
 	templateFileName := "testdata/aws-io-optimized-v2.json"

--- a/ec/ecresource/elasticsearchkeystoreresource/create.go
+++ b/ec/ecresource/elasticsearchkeystoreresource/create.go
@@ -19,14 +19,13 @@ package elasticsearchkeystoreresource
 
 import (
 	"context"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/eskeystoreapi"
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 // Create will create an item in the Elasticsearch keystore
@@ -73,5 +72,5 @@ func (r Resource) Create(ctx context.Context, request resource.CreateRequest, re
 }
 
 func hashID(elem ...string) string {
-	return strconv.Itoa(schema.HashString(strings.Join(elem, "-")))
+	return util.HashString(strings.Join(elem, "-"))
 }

--- a/ec/ecresource/elasticsearchkeystoreresource/resource_test.go
+++ b/ec/ecresource/elasticsearchkeystoreresource/resource_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"

--- a/ec/ecresource/extensionresource/resource_test.go
+++ b/ec/ecresource/extensionresource/resource_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"

--- a/ec/ecresource/snapshotrepositoryresource/resource_test.go
+++ b/ec/ecresource/snapshotrepositoryresource/resource_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"

--- a/ec/ecresource/trafficfilterassocresource/resource_test.go
+++ b/ec/ecresource/trafficfilterassocresource/resource_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
@@ -226,11 +226,11 @@ func readResponse() mock.Response {
 			},
 		},
 		mock.NewStringBody(`{
-							"id": "9db94e68e2f040a19dfb664d0e83bc2a", 
-							"name": "dummy", 
-							"type": "ip",  
-							"include_by_default": false,  
-							"region": "us-east-1",  
+							"id": "9db94e68e2f040a19dfb664d0e83bc2a",
+							"name": "dummy",
+							"type": "ip",
+							"include_by_default": false,
+							"region": "us-east-1",
 							"rules": [{"id": "6e4c8874f90d4793a2290f8199461952","source": "127.0.0.1"}  ],
 							"associations": [{"entity_type": "deployment", "id": "0a592ab2c5baf0fa95c77ac62135782e"}],
 							"total_associations": 1
@@ -251,11 +251,11 @@ func readResponseAssociationDeleted() mock.Response {
 			},
 		},
 		mock.NewStringBody(`{
-							"id": "9db94e68e2f040a19dfb664d0e83bc2a", 
-							"name": "dummy", 
-							"type": "ip",  
-							"include_by_default": false,  
-							"region": "us-east-1",  
+							"id": "9db94e68e2f040a19dfb664d0e83bc2a",
+							"name": "dummy",
+							"type": "ip",
+							"include_by_default": false,
+							"region": "us-east-1",
 							"rules": [{"id": "6e4c8874f90d4793a2290f8199461952","source": "127.0.0.1"}  ],
 							"associations": [{"entity_type": "deployment", "id": "some-unrelated-id"}],
 							"total_associations": 1

--- a/ec/ecresource/trafficfilterresource/resource_test.go
+++ b/ec/ecresource/trafficfilterresource/resource_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"

--- a/ec/internal/util/helpers.go
+++ b/ec/internal/util/helpers.go
@@ -18,6 +18,7 @@
 package util
 
 import (
+	"hash/crc32"
 	"os"
 	"strconv"
 
@@ -81,4 +82,10 @@ func StringToBool(str string) (bool, error) {
 	}
 
 	return v, nil
+}
+
+func HashString(str string) string {
+	// Consistent with the old TF SDK HashString
+	resHash := crc32.ChecksumIEEE([]byte(str))
+	return strconv.FormatUint(uint64(resHash), 10)
 }

--- a/ec/internal/util/testutils.go
+++ b/ec/internal/util/testutils.go
@@ -19,99 +19,14 @@ package util
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )
-
-// ResDataParams holds the raw configuration for NewResourceData to consume
-type ResDataParams struct {
-	// ID to set for the resource.
-	ID string
-
-	// The resource's schema.
-	Schema map[string]*schema.Schema
-
-	// The current resource state, to simulate a create or a case where no
-	// previous state has been persisted, only State should be specified.
-	State map[string]interface{}
-
-	// The desired resource configuration, this is useful to simulate "update"
-	// changes on a given resource.
-	Change map[string]interface{}
-}
-
-// Validate the parameters
-func (params ResDataParams) Validate() error {
-	merr := multierror.NewPrefixed("invalid NewResourceData parameters")
-	if params.ID == "" {
-		merr = merr.Append(errors.New("id cannot be empty"))
-	}
-
-	if len(params.Schema) == 0 {
-		merr = merr.Append(errors.New("schema cannot be empty"))
-	}
-
-	if params.State == nil {
-		merr = merr.Append(errors.New("state cannot be empty"))
-	}
-
-	return merr.ErrorOrNil()
-}
-
-// NewResourceData creates a ResourceData from a raw configuration map and schema.
-func NewResourceData(t *testing.T, params ResDataParams) *schema.ResourceData {
-	t.Helper()
-	if err := params.Validate(); err != nil {
-		t.Fatal(err)
-	}
-
-	return resourceDataRaw(t,
-		params.ID, params.Schema, params.State, params.Change,
-	)
-}
-
-// resourceDataRaw creates a ResourceData from a raw configuration map.
-// Setting the ID to the specified value, and using the desired map as diff
-// to be applied, if not specified, then the current is used as the desired
-// configuration starting off from an empty state.
-func resourceDataRaw(t *testing.T, id string, schemaMap map[string]*schema.Schema, current, desired map[string]interface{}) *schema.ResourceData {
-	t.Helper()
-
-	result := generateRD(t, schemaMap, current, nil)
-	result.SetId(id)
-	if len(desired) == 0 {
-		return result
-	}
-
-	return generateRD(t, schemaMap, desired, result.State())
-}
-
-func generateRD(t *testing.T, schemaMap map[string]*schema.Schema, rawAttr map[string]interface{}, state *terraform.InstanceState) *schema.ResourceData {
-	resCfg := terraform.NewResourceConfigRaw(rawAttr)
-	sm := schema.InternalMap(schemaMap)
-
-	diff, err := sm.Diff(context.Background(), state, resCfg, nil, nil, true)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	result, err := sm.Data(state, diff)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	return result
-}
 
 // Check conversion to attr.Value
 // it should catch cases when e.g. the func under test returns types.List{}

--- a/ec/version.go
+++ b/ec/version.go
@@ -18,4 +18,4 @@
 package ec
 
 // Version contains the current terraform provider version.
-const Version = "0.9.0-dev"
+const Version = "0.10.0-dev"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0
+	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
@@ -53,6 +53,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.18.1 // indirect
 	github.com/hashicorp/terraform-json v0.17.1 // indirect
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.1 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
@@ -72,7 +73,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/zclconf/go-cty v1.13.2 // indirect
+	github.com/zclconf/go-cty v1.13.3 // indirect
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9T
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0 h1:gY4SG34ANc6ZSeWEKC9hDTChY0ZiN+Myon17fSA0Xgc=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0/go.mod h1:deXEw/iJXtJxNV9d1c/OVJrvL7Zh0a++v7rzokW6wVY=
+github.com/hashicorp/terraform-plugin-testing v1.5.1 h1:T4aQh9JAhmWo4+t1A7x+rnxAJHCDIYW9kXyo4sVO92c=
+github.com/hashicorp/terraform-plugin-testing v1.5.1/go.mod h1:dg8clO6K59rZ8w9EshBmDp1CxTIPu3yA4iaDpX1h5u0=
 github.com/hashicorp/terraform-registry-address v0.2.1 h1:QuTf6oJ1+WSflJw6WYOHhLgwUiQ0FrROpHPYFtwTYWM=
 github.com/hashicorp/terraform-registry-address v0.2.1/go.mod h1:BSE9fIFzp0qWsJUUyGquo4ldV9k2n+psif6NYkBRS3Y=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=
@@ -262,8 +264,8 @@ github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23n
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
-github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
-github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
+github.com/zclconf/go-cty v1.13.3 h1:m+b9q3YDbg6Bec5rr+KGy1MzEVzY/jC2X+YX4yqKtHI=
+github.com/zclconf/go-cty v1.13.3/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=
 go.mongodb.org/mongo-driver v1.10.0/go.mod h1:wsihk0Kdgv8Kqu1Anit4sfK+22vSFbUrAVEYRhCXrA8=


### PR DESCRIPTION
The provider was still dependant on the old SDK package. There were two main uses:
* Acceptance testing, replaced by terraform-plugin-testing
* HashString, added a consistent internal representation 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
