### PR TITLE
build: replace x/exp package with stdlib slices packages

### DIFF
--- a/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
@@ -21,12 +21,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/blang/semver"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"golang.org/x/exp/slices"
 
 	apmv2 "github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/apm/v2"
 	elasticsearchv2 "github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/elasticsearch/v2"

--- a/ec/ecresource/deploymentresource/elasticsearch/v2/elasticsearch_payload.go
+++ b/ec/ecresource/deploymentresource/elasticsearch/v2/elasticsearch_payload.go
@@ -19,6 +19,7 @@ package v2
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
@@ -26,7 +27,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"golang.org/x/exp/slices"
 )
 
 type ElasticsearchTF struct {

--- a/ec/ecresource/trafficfilterresource/schema.go
+++ b/ec/ecresource/trafficfilterresource/schema.go
@@ -19,6 +19,7 @@ package trafficfilterresource
 
 import (
 	"context"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -30,7 +31,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"golang.org/x/exp/slices"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 

--- a/ec/internal/validators/urlvalidator.go
+++ b/ec/internal/validators/urlvalidator.go
@@ -21,10 +21,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"golang.org/x/exp/slices"
 )
 
 type isURLWithSchemeValidator struct {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 )
 
 require (
@@ -78,6 +77,7 @@ require (
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	golang.org/x/crypto v0.13.0 // indirect
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.13.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

Go 1.21 introduced the new slices package to replace x/exp/slices. Migrate to slices and drop the dependency

## Related Issues
Closes https://github.com/elastic/terraform-provider-ec/issues/737

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://go.dev/doc/go1.21#slices

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
