### PR TITLE
Set the username when resetting the elastic password

### DIFF
--- a/.changelog/752.txt
+++ b/.changelog/752.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/deployment: Update the elasticsearch_username when resetting the password.
+```

--- a/ec/acc/deployment_basic_test.go
+++ b/ec/acc/deployment_basic_test.go
@@ -98,6 +98,7 @@ func TestAccDeployment_basic_tf(t *testing.T) {
 				ExpectNonEmptyPlan: true, // reset_elasticsearch_password will always result in a non-empty plan
 				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "0"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch_username", "elastic"),
 					func(s *terraform.State) error {
 						currentPw, ok := captureElasticsearchPassword(s, resName)
 						if !ok {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Resetting the credentials of imported resources should result in the username being set as well as the password. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
