### PR TITLE
Set username to unknown when resetting password

### DIFF
--- a/.changelog/777.txt
+++ b/.changelog/777.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/deployment: Fix issue setting the elasticsearch_username when resetting the elasticsearch_password
+```

--- a/ec/ecresource/deploymentresource/deployment/v2/schema.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/schema.go
@@ -90,6 +90,7 @@ func DeploymentSchema() schema.Schema {
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+					setUnknownIfResetPasswordIsTrue{},
 				},
 			},
 			"elasticsearch_password": schema.StringAttribute{


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
When resetting the password on an imported deployment we set the username along with the password, prior to this PR this caused the provider to blow up. 

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Fixes https://github.com/elastic/terraform-provider-ec/issues/766

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, it's hard to add an acceptance test here since it requires importing the existing deployment. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
