### PR TITLE
Persist snapshot source in the read response

### DIFF
--- a/.changelog/788.txt
+++ b/.changelog/788.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/deployment: Persist the snapshot source settings during reads. This fixes a [provider crash](https://github.com/elastic/terraform-provider-ec/issues/787) when creating a deployment from a snapshot.
+```

--- a/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
@@ -69,6 +69,10 @@ type Deployment struct {
 }
 
 func (dep *Deployment) PersistSnapshotSource(ctx context.Context, esPlan *elasticsearchv2.ElasticsearchTF) diag.Diagnostics {
+	if dep == nil || dep.Elasticsearch == nil {
+		return nil
+	}
+
 	if esPlan == nil || esPlan.SnapshotSource.IsNull() || esPlan.SnapshotSource.IsUnknown() {
 		return nil
 	}

--- a/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
@@ -21,15 +21,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
 	"slices"
 	"strings"
+
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
 
 	"github.com/blang/semver"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 
 	apmv2 "github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/apm/v2"
+	elasticsearchv1 "github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/elasticsearch/v1"
 	elasticsearchv2 "github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/elasticsearch/v2"
 	enterprisesearchv2 "github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/enterprisesearch/v2"
 	integrationsserverv2 "github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/integrationsserver/v2"
@@ -39,6 +41,7 @@ import (
 	"github.com/elastic/terraform-provider-ec/ec/internal/converters"
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -63,6 +66,24 @@ type Deployment struct {
 	Observability              *observabilityv2.Observability           `tfsdk:"observability"`
 	ResetElasticsearchPassword *bool                                    `tfsdk:"reset_elasticsearch_password"`
 	MigrateToLatestHardware    *bool                                    `tfsdk:"migrate_to_latest_hardware"`
+}
+
+func (dep *Deployment) PersistSnapshotSource(ctx context.Context, esPlan *elasticsearchv2.ElasticsearchTF) diag.Diagnostics {
+	if esPlan == nil || esPlan.SnapshotSource.IsNull() || esPlan.SnapshotSource.IsUnknown() {
+		return nil
+	}
+
+	var snapshotSource *elasticsearchv1.ElasticsearchSnapshotSourceTF
+	if diags := tfsdk.ValueAs(ctx, esPlan.SnapshotSource, &snapshotSource); diags.HasError() {
+		return diags
+	}
+
+	dep.Elasticsearch.SnapshotSource = &elasticsearchv2.ElasticsearchSnapshotSource{
+		SourceElasticsearchClusterId: snapshotSource.SourceElasticsearchClusterId.ValueString(),
+		SnapshotName:                 snapshotSource.SnapshotName.ValueString(),
+	}
+
+	return nil
 }
 
 // Nullify Elasticsearch topologies that have zero size and are not specified in plan

--- a/ec/ecresource/deploymentresource/elasticsearch/v2/schema.go
+++ b/ec/ecresource/deploymentresource/elasticsearch/v2/schema.go
@@ -141,7 +141,7 @@ func ElasticsearchSchema() schema.Attribute {
 
 			"snapshot": elasticsearchSnapshotSchema(),
 
-			"snapshot_source": elasticsearchSnapshotSourceSchema(),
+			"snapshot_source": ElasticsearchSnapshotSourceSchema(),
 
 			"extension": elasticsearchExtensionSchema(),
 
@@ -361,7 +361,7 @@ func elasticsearchSnapshotRepositoryReferenceSchema() schema.Attribute {
 	}
 }
 
-func elasticsearchSnapshotSourceSchema() schema.Attribute {
+func ElasticsearchSnapshotSourceSchema() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		Description: `Restores data from a snapshot of another deployment.
 

--- a/ec/ecresource/deploymentresource/read.go
+++ b/ec/ecresource/deploymentresource/read.go
@@ -177,6 +177,7 @@ func (r *Resource) read(ctx context.Context, id string, state *deploymentv2.Depl
 	deployment.ProcessSelfInObservability()
 
 	deployment.NullifyUnusedEsTopologies(ctx, baseElasticsearch)
+	diags.Append(deployment.PersistSnapshotSource(ctx, baseElasticsearch)...)
 
 	if !deployment.HasNodeTypes() {
 		// The MigrateDeploymentTemplate request can only be performed for deployments that use node roles.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Since the `snapshot_name` is computed we must persist it in the response from read. This PR ensures that any configured value is maintained through the read cycle. 

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Fixes https://github.com/elastic/terraform-provider-ec/issues/787

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
