### PR TITLE
Stateless resources require kibana

### DIFF
--- a/ec/ecresource/deploymentresource/apm/v2/schema.go
+++ b/ec/ecresource/deploymentresource/apm/v2/schema.go
@@ -19,16 +19,22 @@ package v2
 
 import (
 	"github.com/elastic/terraform-provider-ec/ec/internal/planmodifiers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 func ApmConfigSchema() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		Description: `Optionally define the Apm configuration options for the APM Server`,
 		Optional:    true,
+		Validators: []validator.Object{
+			objectvalidator.AlsoRequires(path.MatchRoot("kibana")),
+		},
 		Attributes: map[string]schema.Attribute{
 			"docker_image": schema.StringAttribute{
 				Description: "Optionally override the docker image the APM nodes will use. This option will not work in ESS customers and should only be changed if you know what you're doing.",

--- a/ec/ecresource/deploymentresource/enterprisesearch/v2/schema.go
+++ b/ec/ecresource/deploymentresource/enterprisesearch/v2/schema.go
@@ -19,17 +19,23 @@ package v2
 
 import (
 	"github.com/elastic/terraform-provider-ec/ec/internal/planmodifiers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
 func EnterpriseSearchSchema() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		Description: "Enterprise Search cluster definition.",
 		Optional:    true,
+		Validators: []validator.Object{
+			objectvalidator.AlsoRequires(path.MatchRoot("kibana")),
+		},
 		Attributes: map[string]schema.Attribute{
 			"elasticsearch_cluster_ref_id": schema.StringAttribute{
 				Optional: true,

--- a/ec/ecresource/deploymentresource/integrationsserver/v2/schema.go
+++ b/ec/ecresource/deploymentresource/integrationsserver/v2/schema.go
@@ -19,12 +19,15 @@ package v2
 
 import (
 	"github.com/elastic/terraform-provider-ec/ec/internal/planmodifiers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -32,6 +35,9 @@ func IntegrationsServerSchema() schema.Attribute {
 	return schema.SingleNestedAttribute{
 		Description: "Integrations Server cluster definition. Integrations Server replaces `apm` in Stack versions > 8.0",
 		Optional:    true,
+		Validators: []validator.Object{
+			objectvalidator.AlsoRequires(path.MatchRoot("kibana")),
+		},
 		Attributes: map[string]schema.Attribute{
 			"elasticsearch_cluster_ref_id": schema.StringAttribute{
 				Optional: true,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
It's currently possible to configure a deployment with Integrations Server, but no Kibana. Attempting to do so results in difficult to understand API errors. In reality, Integrations Server (along with APM, EntSearch) requires Kibana and this can be simply expressed in the schema. 

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Likely fixes https://github.com/elastic/terraform-provider-ec/issues/562

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
