### PR TITLE
Update CODEOWNERS with new team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repository.
-*       @elastic/cloud-applications-solutions
-docs/   @alaudazzi @nrichers @elastic/cloud-applications-solutions
+*       @elastic/control-plane-stateful-applications @tobio
+docs/   @alaudazzi @elastic/control-plane-stateful-applications

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # These owners will be the default owners for everything in
 # the repository.
 *       @elastic/control-plane-stateful-applications @tobio
-docs/   @alaudazzi @elastic/control-plane-stateful-applications

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repository.
-*       @elastic/control-plane-stateful-applications @tobio
+*       @elastic/control-plane-stateful-applications


### PR DESCRIPTION
The team was renamed to `control-plane-stateful-applications`. This way the right people are added as reviewers.

@tobio If you want I can also add you here so you are still added as reviewer to new PRs. (But I can also remove you if the notifications are annoying).