### PR TITLE
Fix acceptance pipeline cleanup.

### DIFF
--- a/.buildkite/acceptance_pipeline.yml
+++ b/.buildkite/acceptance_pipeline.yml
@@ -1,5 +1,6 @@
 steps:
   - label: ":test_tube: Acceptance tests"
+    key: "acceptance-tests"
     command: .buildkite/acceptance.sh
     agents:
       image: "docker.io/library/golang:1.21"


### PR DESCRIPTION
The step currently has a key of "" so the `pre-exit` code never runs (Referenced in `.buildkite/hooks/pre-exit`). This leads to old acceptance-test deployments piling up over time.

With this change the step should run after the tests and clean up hanging deployments.