### PR TITLE
Bugfix: node-types-validation should handle empty stack version.

### DIFF
--- a/ec/ecresource/deploymentresource/elasticsearch/v2/node_types_validator.go
+++ b/ec/ecresource/deploymentresource/elasticsearch/v2/node_types_validator.go
@@ -20,11 +20,11 @@ package v2
 import (
 	"context"
 	"fmt"
-
 	"github.com/blang/semver"
 	"github.com/elastic/terraform-provider-ec/ec/ecresource/deploymentresource/utils"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ validator.String = versionSupportsNodeTypes{}
@@ -49,13 +49,13 @@ func (v versionSupportsNodeTypes) ValidateString(ctx context.Context, req valida
 		return
 	}
 
-	var version string
+	var version types.String
 	resp.Diagnostics = req.Config.GetAttribute(ctx, path.Root("version"), &version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	parsedVersion, err := semver.Parse(version)
+	parsedVersion, err := semver.Parse(version.ValueString())
 	if err != nil {
 		// Ignore this error, it's validated as part of the version schema definition
 		return


### PR DESCRIPTION
Fixes an error in the validation when using legacy node-type configs.

If the version is unset, the validation crashes with an error. This can happen in certain scenarios: When using a reference (e.g. `data.ec_stack.latest.version`) it will not be resolved in a first phase when this validation is called. In such cases the validation should be skipped.

The validation still works as it is called again after the reading phase when the field has been resolved.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
https://github.com/elastic/terraform-provider-ec/issues/734

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
