### PR TITLE
Install jq before releasing.

### DIFF
--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -7,5 +7,9 @@ echo -n "$GPG_PRIVATE_SECRET" | base64 --decode | gpg --import --batch --yes --p
 echo "--- Caching GPG passphrase"
 echo "$GPG_PASSPHRASE_SECRET" | gpg --armor --detach-sign --passphrase-fd 0 --pinentry-mode loopback
 
+echo "--- Installing jq"
+apt-get update
+apt-get install jq -y
+
 echo "--- Release the binaries"
 make release


### PR DESCRIPTION
The 0.11.0 release failed due to `jq` missing.

```
modify_spec.sh: 3: jq: not found
go: downloading github.com/hashicorp/terraform-plugin-codegen-framework v0.4.0
time=2024-08-28T11:45:58.017Z level=ERROR msg="error executing command" err="error validating IR JSON: invalid JSON"
exit status 1
ec/internal/gen/serverless/serverless.go:20: running "go": exit status 1
make[1]: *** [build/Makefile.build:14: gen] Error 1
```

- `jq` is now needed to run the script `modify_spec.sh`
- Since the release runs from the `docker.io/library/golang:1.22` image, it doesn't have jq installed
- as a workaround, the release script now installs jq first
  - We could also prepare a dedicated build-image that contains jq, but as we release very rarely, I think it is fine to just install jq for now.