### PR TITLE
Use ephemeral github token.

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -18,5 +18,5 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "terraform-provider-ec-release" ]]; then
   export GPG_PRIVATE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_private ${RELEASE_VAULT_PATH})
   export GPG_PASSPHRASE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_passphrase ${RELEASE_VAULT_PATH})
   export GPG_FINGERPRINT_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_fingerprint ${RELEASE_VAULT_PATH})
-  export GITHUB_TOKEN=$(scripts/retry.sh 5 vault kv get -field gh_personal_access_token ${RELEASE_VAULT_PATH})
+  export GITHUB_TOKEN="${VAULT_GITHUB_TOKEN}"
 fi


### PR DESCRIPTION
The currently used GITHUB_TOKEN has expired and can't be used anymore, instead we now use an ephemeral token provided with every build. The `VAULT_GITHUB_TOKEN` is created fresh for every build and injected automatically (similar to the github token provided in github actions)

We did the same thing for the elasticstack provider:
https://github.com/elastic/terraform-provider-elasticstack/pull/712