### PR TITLE
Bugfix: Only pass snapshot settings into the update plan if there are changes

### DIFF
--- a/.changelog/858.txt
+++ b/.changelog/858.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/deployment: Avoid overriding snapshot settings with every update. The snapshot settings are now only updated if they are actually set in the terraform config. This allows managing the snapshot lifecycle policy with the elasticstack provider instead of the ec provider.
+```

--- a/ec/ecresource/deploymentresource/elasticsearch/v2/elasticsearch_keystore_contents.go
+++ b/ec/ecresource/deploymentresource/elasticsearch/v2/elasticsearch_keystore_contents.go
@@ -37,10 +37,10 @@ type ElasticsearchKeystoreContents struct {
 	AsFile *bool  `tfsdk:"as_file"`
 }
 
-func elasticsearchKeystoreContentsPayload(ctx context.Context, keystoreContentsTF types.Map, model *models.ElasticsearchClusterSettings, esStateObj *types.Object) (*models.ElasticsearchClusterSettings, diag.Diagnostics) {
+func elasticsearchKeystoreContentsPayload(ctx context.Context, keystoreContentsTF types.Map, model *models.ElasticsearchClusterSettings, esState *ElasticsearchTF) (*models.ElasticsearchClusterSettings, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	if (keystoreContentsTF.IsNull() || len(keystoreContentsTF.Elements()) == 0) && esStateObj == nil {
+	if (keystoreContentsTF.IsNull() || len(keystoreContentsTF.Elements()) == 0) && esState == nil {
 		return model, nil
 	}
 
@@ -69,13 +69,7 @@ func elasticsearchKeystoreContentsPayload(ctx context.Context, keystoreContentsT
 	}
 
 	// remove secrets that were in state but are removed from plan
-	if esStateObj != nil && !esStateObj.IsNull() {
-		var esState ElasticsearchTF
-
-		if diags := tfsdk.ValueAs(ctx, esStateObj, &esState); diags.HasError() {
-			return nil, diags
-		}
-
+	if esState != nil {
 		if !esState.KeystoreContents.IsNull() {
 			for k := range esState.KeystoreContents.Elements() {
 				if _, ok := secrets[k]; !ok {

--- a/ec/ecresource/deploymentresource/elasticsearch/v2/elasticsearch_snapshot.go
+++ b/ec/ecresource/deploymentresource/elasticsearch/v2/elasticsearch_snapshot.go
@@ -78,9 +78,15 @@ func readElasticsearchSnapshot(in *models.ElasticsearchClusterSettings) (*Elasti
 	return &snapshot, nil
 }
 
-func elasticsearchSnapshotPayload(ctx context.Context, srcObj attr.Value, model *models.ElasticsearchClusterSettings) (*models.ElasticsearchClusterSettings, diag.Diagnostics) {
+func elasticsearchSnapshotPayload(ctx context.Context, srcObj attr.Value, model *models.ElasticsearchClusterSettings, state *ElasticsearchTF) (*models.ElasticsearchClusterSettings, diag.Diagnostics) {
 	var snapshot ElasticsearchSnapshotTF
 	if srcObj.IsNull() || srcObj.IsUnknown() {
+		return model, nil
+	}
+
+	// Only put snapshot updates into the payload, if the plan is making changes to the snapshot settings
+	// (To avoid overwriting changes made outside, i.e. with the elasticstack provider)
+	if state != nil && state.Snapshot.Equal(srcObj) {
 		return model, nil
 	}
 


### PR DESCRIPTION
- This ensures the settings are only put into the update request if there are actual changes in the config
- Otherwise the settings are left out of the payload
- This solves a bug where every apply would reset the policy back to the default (because putting the default settings in the plan will cause it to reset the policy).
  - When using the elasticstack provider to manage the policy, we want the ec provider to not touch it.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
https://github.com/elastic/terraform-provider-ec/issues/854
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
