### PR TITLE
fix: add missing europe-west9 for ec_gcp_private_service_connect_endp…

### DIFF
--- a/.changelog/860.txt
+++ b/.changelog/860.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+datasource/gcp_private_service_connect_endpoint: Add missing regions.
+```

--- a/ec/ecdatasource/privatelinkdatasource/regionPrivateLinkMap.json
+++ b/ec/ecdatasource/privatelinkdatasource/regionPrivateLinkMap.json
@@ -197,6 +197,10 @@
             "service_attachment_uri": "projects/cloud-production-168820/regions/asia-southeast1/serviceAttachments/proxy-psc-production-asia-southeast1-v1-attachment",
             "domain_name": "psc.asia-southeast1.gcp.elastic-cloud.com"
         },
+        "asia-southeast2": {
+            "service_attachment_uri": "projects/cloud-production-168820/regions/asia-southeast2/serviceAttachments/proxy-psc-production-asia-southeast2-v1-attachment",
+            "domain_name": "psc.asia-southeast2.gcp.elastic-cloud.com"
+        },
         "australia-southeast1": {
             "service_attachment_uri": "projects/cloud-production-168820/regions/australia-southeast1/serviceAttachments/proxy-psc-production-australia-southeast1-v1-attachment",
             "domain_name": "psc.australia-southeast1.gcp.elastic-cloud.com"
@@ -220,6 +224,14 @@
         "europe-west4": {
             "service_attachment_uri": "projects/cloud-production-168820/regions/europe-west4/serviceAttachments/proxy-psc-production-europe-west4-v1-attachment",
             "domain_name": "psc.europe-west4.gcp.elastic-cloud.com"
+        },
+        "europe-west9": {
+            "service_attachment_uri": "projects/cloud-production-168820/regions/europe-west9/serviceAttachments/proxy-psc-production-europe-west9-v1-attachment",
+            "domain_name": "psc.europe-west9.gcp.elastic-cloud.com"
+        },
+        "me-west1": {
+            "service_attachment_uri": "projects/cloud-production-168820/regions/me-west1/serviceAttachments/proxy-psc-production-me-west1-v1-attachment",
+            "domain_name": "psc.me-west1.gcp.elastic-cloud.com"
         },
         "northamerica-northeast1": {
             "service_attachment_uri": "projects/cloud-production-168820/regions/northamerica-northeast1/serviceAttachments/proxy-psc-production-northamerica-northeast1-v1-attachment",


### PR DESCRIPTION
Adds missing configurations for europe-west9 for the `ec_gcp_private_service_connect_endpoint` data source.

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
#860

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
