### PR TITLE
adding fleet_endpoint to integrations_server

### DIFF
--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -156,6 +156,7 @@ Read-Only:
 - `status` (String) Resource kind status (for example, "started", "stopped", etc).
 - `topology` (Attributes List) Node topology element definition. (see [below for nested schema](#nestedatt--integrations_server--topology))
 - `version` (String) Elastic stack version.
+- `fleet_endpoint` (String) The endpoint for the Fleet server
 
 <a id="nestedatt--integrations_server--topology"></a>
 ### Nested Schema for `integrations_server.topology`

--- a/ec/ecdatasource/deploymentdatasource/flatteners_integrations_server.go
+++ b/ec/ecdatasource/deploymentdatasource/flatteners_integrations_server.go
@@ -76,6 +76,15 @@ func flattenIntegrationsServerResources(ctx context.Context, in []*models.Integr
 			if res.Info.Metadata != nil {
 				model.HttpEndpoint, model.HttpsEndpoint = converters.ExtractEndpointsToTypes(res.Info.Metadata)
 			}
+
+			// Set the fleet endpoint if available
+			if res.Info.Metadata.ServicesUrls != nil {
+				for _, service := range res.Info.Metadata.ServicesUrls {
+					if service.Service != nil && *service.Service == "fleet" {
+						model.FleetEndpoint = types.StringValue(*service.URL)
+					}
+				}
+			}
 		}
 
 		result = append(result, model)

--- a/ec/ecdatasource/deploymentdatasource/schema_integrations_server.go
+++ b/ec/ecdatasource/deploymentdatasource/schema_integrations_server.go
@@ -65,6 +65,10 @@ func integrationsServerResourceInfoSchema() schema.Attribute {
 					Computed:    true,
 				},
 				"topology": integrationsServerTopologySchema(),
+				"fleet_endpoint": schema.StringAttribute{
+					Description: "HTTPS endpoint for the fleet.",
+					Computed:    true,
+				},
 			},
 		},
 	}
@@ -116,6 +120,7 @@ type integrationsServerResourceInfoModelV0 struct {
 	Status                    types.String `tfsdk:"status"`
 	Version                   types.String `tfsdk:"version"`
 	Topology                  types.List   `tfsdk:"topology"` //< integrationsServerTopologyModelV0
+	FleetEndpoint             types.String `tfsdk:"fleet_endpoint"`
 }
 
 type integrationsServerTopologyModelV0 struct {


### PR DESCRIPTION
Add a property to the datasource of `ec_deployment` to directly get the fleet endpoint.

## Description
<!--- Describe your changes in detail. -->

## Related Issues
#875 

## Motivation and Context
It allows a deployment to directly reference `data.ec_deployment.stack.integrations_server.fleet_endpoint` instead of having to dynamically build it from available properties (see issue)

## How Has This Been Tested?
1. first determined the api response (focussed on int.server):
```json
...
"integrations_server" : [
      {
        ...
        "info" : {
          ...
          "metadata" : {
            ...
            "ports" : {
              "http" : 80,
              "https" : 443,
              "transport_passthrough" : 9400
            },
            "services_urls" : [
              {
                "service" : "fleet",
                "url" : "https://hosted-sholzhauer.fleet.us-west2.gcp.elastic-cloud.com"
              },
              {
                "service" : "apm",
                "url" : "https://hosted-sholzhauer.apm.us-west2.gcp.elastic-cloud.com"
              }
            ]
          },
          ...
        }
      }
    ]
...
```
which showed the availability of the endpoint

2. determined how the endpoint (http/https) was currently build
3. added the code in the commit
4. ran `make build` 
5. copied the binary from `/bin/` to my test directory
6. ran `terraform init -upgrade` and `terraform apply` in test directory
7. got the fleet_endpoint in the output

#### Test template
> referencing a test cluster of mine
```tf
terraform {
  required_providers {
    ec = {
      source = "elastic/ec"
      version = ">= 0.0.1"
      #source = "terraform-provider-ec"
    }
  }
}

variable "apikey" {}
variable "region" { default = "gcp-us-west1" }

provider "ec" {
  apikey = var.apikey  
}

data "ec_deployment" "example" {
  id = var.cluster_id
}

output "fleet" {
  value = data.ec_deployment.example
}
``` 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
