### PR TITLE
Note file extension is not supported for ECE

### DIFF
--- a/docs/resources/deployment_extension.md
+++ b/docs/resources/deployment_extension.md
@@ -22,7 +22,7 @@ description: |-
 
 ## Example Usage
 
-### With extension file
+### With extension file (not usable for ECE)
 
 ```terraform
 locals {


### PR DESCRIPTION
Per https://www.elastic.co/guide/en/cloud-enterprise/3,7/ece-add-custom-bundle-plugin.html extension zip files in ECE must be added as URL and passing a file does not appear to be supported

Might be good to double-check with developers of the provider if this is correct