### PR TITLE
feat(serverless): Set the credentials.password as sensitive

### DIFF
--- a/docs/resources/elasticsearch_project.md
+++ b/docs/resources/elasticsearch_project.md
@@ -59,7 +59,7 @@ Optional:
 
 Read-Only:
 
-- `password` (String) Basic auth password that can be used to access the Elasticsearch API.
+- `password` (String, Sensitive) Basic auth password that can be used to access the Elasticsearch API.
 - `username` (String) Basic auth username that can be used to access the Elasticsearch API.
 
 

--- a/docs/resources/observability_project.md
+++ b/docs/resources/observability_project.md
@@ -48,7 +48,7 @@ resource "ec_observability_project" "my_project" {
 
 Read-Only:
 
-- `password` (String) Basic auth password that can be used to access the Elasticsearch API.
+- `password` (String, Sensitive) Basic auth password that can be used to access the Elasticsearch API.
 - `username` (String) Basic auth username that can be used to access the Elasticsearch API.
 
 

--- a/docs/resources/security_project.md
+++ b/docs/resources/security_project.md
@@ -59,7 +59,7 @@ Required:
 
 Read-Only:
 
-- `password` (String) Basic auth password that can be used to access the Elasticsearch API.
+- `password` (String, Sensitive) Basic auth password that can be used to access the Elasticsearch API.
 - `username` (String) Basic auth username that can be used to access the Elasticsearch API.
 
 

--- a/ec/internal/gen/serverless/resource_elasticsearch_project/elasticsearch_project_resource_gen.go
+++ b/ec/internal/gen/serverless/resource_elasticsearch_project/elasticsearch_project_resource_gen.go
@@ -66,6 +66,7 @@ func ElasticsearchProjectResourceSchema(ctx context.Context) schema.Schema {
 				Attributes: map[string]schema.Attribute{
 					"password": schema.StringAttribute{
 						Computed:            true,
+						Sensitive:           true,
 						Description:         "Basic auth password that can be used to access the Elasticsearch API.",
 						MarkdownDescription: "Basic auth password that can be used to access the Elasticsearch API.",
 					},

--- a/ec/internal/gen/serverless/resource_observability_project/observability_project_resource_gen.go
+++ b/ec/internal/gen/serverless/resource_observability_project/observability_project_resource_gen.go
@@ -65,6 +65,7 @@ func ObservabilityProjectResourceSchema(ctx context.Context) schema.Schema {
 				Attributes: map[string]schema.Attribute{
 					"password": schema.StringAttribute{
 						Computed:            true,
+						Sensitive:           true,
 						Description:         "Basic auth password that can be used to access the Elasticsearch API.",
 						MarkdownDescription: "Basic auth password that can be used to access the Elasticsearch API.",
 					},

--- a/ec/internal/gen/serverless/resource_security_project/security_project_resource_gen.go
+++ b/ec/internal/gen/serverless/resource_security_project/security_project_resource_gen.go
@@ -78,6 +78,7 @@ func SecurityProjectResourceSchema(ctx context.Context) schema.Schema {
 				Attributes: map[string]schema.Attribute{
 					"password": schema.StringAttribute{
 						Computed:            true,
+						Sensitive:           true,
 						Description:         "Basic auth password that can be used to access the Elasticsearch API.",
 						MarkdownDescription: "Basic auth password that can be used to access the Elasticsearch API.",
 					},

--- a/ec/internal/gen/serverless/serverless-project-api-dereferenced.yml
+++ b/ec/internal/gen/serverless/serverless-project-api-dereferenced.yml
@@ -1278,6 +1278,7 @@ components:
         password:
           type: string
           description: Basic auth password that can be used to access the Elasticsearch API.
+          format: password
           example: '*****'
     ProjectID:
       type: string

--- a/ec/internal/gen/serverless/spec-mod.json
+++ b/ec/internal/gen/serverless/spec-mod.json
@@ -183,7 +183,8 @@
                   "name": "password",
                   "string": {
                     "computed_optional_required": "computed",
-                    "description": "Basic auth password that can be used to access the Elasticsearch API."
+                    "description": "Basic auth password that can be used to access the Elasticsearch API.",
+                    "sensitive": true
                   }
                 },
                 {
@@ -407,7 +408,8 @@
                   "name": "password",
                   "string": {
                     "computed_optional_required": "computed",
-                    "description": "Basic auth password that can be used to access the Elasticsearch API."
+                    "description": "Basic auth password that can be used to access the Elasticsearch API.",
+                    "sensitive": true
                   }
                 },
                 {
@@ -717,7 +719,8 @@
                   "name": "password",
                   "string": {
                     "computed_optional_required": "computed",
-                    "description": "Basic auth password that can be used to access the Elasticsearch API."
+                    "description": "Basic auth password that can be used to access the Elasticsearch API.",
+                    "sensitive": true
                   }
                 },
                 {

--- a/ec/internal/gen/serverless/spec.json
+++ b/ec/internal/gen/serverless/spec.json
@@ -147,7 +147,8 @@
 									"name": "password",
 									"string": {
 										"computed_optional_required": "computed",
-										"description": "Basic auth password that can be used to access the Elasticsearch API."
+										"description": "Basic auth password that can be used to access the Elasticsearch API.",
+										"sensitive": true
 									}
 								},
 								{
@@ -323,7 +324,8 @@
 									"name": "password",
 									"string": {
 										"computed_optional_required": "computed",
-										"description": "Basic auth password that can be used to access the Elasticsearch API."
+										"description": "Basic auth password that can be used to access the Elasticsearch API.",
+										"sensitive": true
 									}
 								},
 								{
@@ -585,7 +587,8 @@
 									"name": "password",
 									"string": {
 										"computed_optional_required": "computed",
-										"description": "Basic auth password that can be used to access the Elasticsearch API."
+										"description": "Basic auth password that can be used to access the Elasticsearch API.",
+										"sensitive": true
 									}
 								},
 								{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

When creating a new Serverless project, the password of the ES
credentials is marked as non sensitive. This means that it will be shown
in the terraform output when creating an `output` block to print it.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This commit sets the credentials.password of all Serverless resources to
sensitive, so that it is not even allowed to create a terraform `output`
block without marking it as sensitive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

As an example, for the following block:
```terraform
output "password" {
  value = ec_elasticsearch_project.test.credentials.password
}
```

Before this commit, the `terraform apply` outputs the password. After
this commit, we get the following output:

```
│ Error: Output refers to sensitive values
│
│   on main.tf line 28:
│   28: output "password" {
│
│ To reduce the risk of accidentally exporting sensitive data that was intended to be only internal, Terraform requires that any root module output containing sensitive data be explicitly marked as sensitive, to confirm your intent.
│
│ If you do intend to export this data, annotate the output value as sensitive by adding the following argument:
│     sensitive = true
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation

I am not sure if it should be considered a New feature or a Breaking
change. An `output` block of a Serverless resource will need to be
adjusted so that the `sensitive = true` parameter be added, otherwise
the plan/apply will fail.

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed