### PR TITLE
Docs Micro-Update: Fix Step 4 of generating an API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ To generate an API key, follow these steps:
   1. Open your browser and navigate to <https://cloud.elastic.co/login>.
   2. Log in with your email and password.
   3. Click on [Elasticsearch Service](https://cloud.elastic.co/deployments).
-  4. Navigate to [Features > API Keys](https://cloud.elastic.co/deployment-features/keys) and click on **Generate API Key**.
+  4. Navigate to [Organization > API Keys](https://cloud.elastic.co/account/keys) and click on **Create API Key**.
   5. Choose a name for your API key.
   6. Save your API key somewhere safe.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ To generate an API key, follow these steps:
   1. Open you browser and navigate to <https://cloud.elastic.co/login>.
   2. Log in with your email and password.
   3. Click on [Elasticsearch Service](https://cloud.elastic.co/deployments).
-  4. Navigate to [Features > API Keys](https://cloud.elastic.co/deployment-features/keys) and click on **Generate API Key**.
+  4. Navigate to [Organization > API Keys](https://cloud.elastic.co/account/keys) and click on **Create API Key**.
   5. Choose a name for your API key.
   6. Save your API key somewhere.
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -42,7 +42,7 @@ To generate an API key, follow these steps:
   1. Open you browser and navigate to <https://cloud.elastic.co/login>.
   2. Log in with your email and password.
   3. Click on [Elasticsearch Service](https://cloud.elastic.co/deployments).
-  4. Navigate to [Features > API Keys](https://cloud.elastic.co/deployment-features/keys) and click on **Generate API Key**.
+  4. Navigate to [Organization > API Keys](https://cloud.elastic.co/account/keys) and click on **Create API Key**.
   5. Choose a name for your API key.
   6. Save your API key somewhere.
 


### PR DESCRIPTION


## Description
Minor change of updating a single outdated step for generating an API key. The original code provides a dead link. The fix in this PR includes updating the link and the navigation path to the link.

## Related Issues
This is such a minor change (small and only affects documentation on steps outside the tool) that I did not feel the need to create an issue as it could create extra unnecessary work. However, I'm to create an issue if so.

## Motivation and Context
The current documentation is incorrect and references a dead link.

## How Has This Been Tested?
I got the new URL and steps from navigating on `cloud.elastic.co`.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
