### PR TITLE
feat(hosted): add BYOK argument for `ec_deployment` resource

### DIFF
--- a/ec/ecresource/deploymentresource/deployment/v2/deployment_create_payload.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/deployment_create_payload.go
@@ -19,6 +19,7 @@ package v2
 
 import (
 	"context"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/deptemplateapi"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/esremoteclustersapi"
@@ -43,6 +44,7 @@ type DeploymentTF struct {
 	Version                    types.String `tfsdk:"version"`
 	Region                     types.String `tfsdk:"region"`
 	DeploymentTemplateId       types.String `tfsdk:"deployment_template_id"`
+	ByokArn                    types.String `tfsdk:"byok_arn"`
 	Name                       types.String `tfsdk:"name"`
 	RequestId                  types.String `tfsdk:"request_id"`
 	ElasticsearchUsername      types.String `tfsdk:"elasticsearch_username"`
@@ -172,6 +174,14 @@ func (dep DeploymentTF) CreateRequest(ctx context.Context, client *api.API) (*mo
 	}
 
 	result.Settings.Observability = observabilityPayload
+
+	if !dep.ByokArn.IsNull() && !dep.ByokArn.IsUnknown() {
+		if result.Settings.Byok == nil {
+			result.Settings.Byok = &models.ByokSettings{KeyResourcePath: ec.String(dep.ByokArn.ValueString())}
+		} else {
+			result.Settings.Byok.KeyResourcePath = ec.String(dep.ByokArn.ValueString())
+		}
+	}
 
 	result.Metadata.Tags, diags = converters.TypesMapToModelsTags(ctx, dep.Tags)
 

--- a/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/deployment_read.go
@@ -55,6 +55,7 @@ type Deployment struct {
 	DeploymentTemplateId       string                                   `tfsdk:"deployment_template_id"`
 	Name                       string                                   `tfsdk:"name"`
 	RequestId                  string                                   `tfsdk:"request_id"`
+	ByokArn                    *string                                  `tfsdk:"byok_arn"`
 	ElasticsearchUsername      string                                   `tfsdk:"elasticsearch_username"`
 	ElasticsearchPassword      string                                   `tfsdk:"elasticsearch_password"`
 	ApmSecretToken             *string                                  `tfsdk:"apm_secret_token"`
@@ -202,6 +203,10 @@ func ReadDeployment(res *models.DeploymentGetResponse, remotes *models.RemoteRes
 
 	if res.Metadata != nil {
 		dep.Tags = converters.ModelsTagsToMap(res.Metadata.Tags)
+	}
+
+	if res.Metadata != nil && *res.Metadata.ByokEnabled {
+		dep.ByokArn = res.Settings.Byok.KeyResourcePath
 	}
 
 	if res.Resources == nil {

--- a/ec/ecresource/deploymentresource/deployment/v2/schema.go
+++ b/ec/ecresource/deploymentresource/deployment/v2/schema.go
@@ -73,6 +73,13 @@ func DeploymentSchema() schema.Schema {
 				Description: "Deployment template identifier to create the deployment from. See the [full list](https://www.elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html) of regions and deployment templates available in ESS.",
 				Required:    true,
 			},
+			"byok_arn": schema.StringAttribute{
+				Description: "Reference to a customer-managed key for data-at-rest encryption",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"name": schema.StringAttribute{
 				Description: "Name for the deployment",
 				Optional:    true,


### PR DESCRIPTION
## Description
This change depends on https://github.com/elastic/cloud-sdk-go/pull/502

Adding `byok_arn` argument for `ec_deployment` resource to enable deployment creation encrypted with CMK.

## Related Issues
https://github.com/elastic/terraform-provider-ec/issues/827

## Motivation and Context
Need to create an elasticsearch deployment with help of Terraform, and have this deployment encrypted with a customer key (e.g. AWS KMS).

## How Has This Been Tested?
With custom build of `terraform-provider-ec` able to create hosted elasticsearch deployment encrypted with our own AWS KMS key.
```
resource "ec_deployment" "this" {
  name = var.name

  region                     = var.region
  version                    = local.version
  deployment_template_id     = var.deployment_template_id
  migrate_to_latest_hardware = true
  byok_arn                   = var.byok_arn
...
```

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
