### PR TITLE
Add monitor false tag to failed deployment test to be excluded from alerting

### DIFF
--- a/ec/acc/deployment_failed_upgrade_retry_test.go
+++ b/ec/acc/deployment_failed_upgrade_retry_test.go
@@ -39,6 +39,8 @@ func TestAccDeployment_failed_upgrade_retry(t *testing.T) {
 			{
 				Config: fixtureDeploymentDefaults(t, "testdata/deployment_upgrade_retry_1.tf"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resName, "tags.monitor", "false"),
 					readEsCredentials(t, &esCreds),
 					checkMajorMinorVersion(t, resName, 7, 10),
 				),
@@ -49,6 +51,8 @@ func TestAccDeployment_failed_upgrade_retry(t *testing.T) {
 				Config:      fixtureDeploymentDefaults(t, "testdata/deployment_upgrade_retry_2.tf"),
 				ExpectError: regexp.MustCompile(`\[kibana\].*Plan[ |\t|\n]+change[ |\t|\n]+failed.*`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resName, "tags.monitor", "false"),
 					checkMajorMinorVersion(t, resName, 7, 10),
 				),
 			},
@@ -57,6 +61,8 @@ func TestAccDeployment_failed_upgrade_retry(t *testing.T) {
 				PreConfig: deleteIndex(t, &esCreds, ".kibana_2"),
 				Config:    fixtureDeploymentDefaults(t, "testdata/deployment_upgrade_retry_2.tf"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resName, "tags.monitor", "false"),
 					checkMajorMinorVersion(t, resName, 7, 11),
 				),
 			},

--- a/ec/acc/testdata/deployment_upgrade_retry_1.tf
+++ b/ec/acc/testdata/deployment_upgrade_retry_1.tf
@@ -14,6 +14,10 @@ resource "ec_deployment" "upgrade_retry" {
   version                = data.ec_stack.latest.version
   deployment_template_id = local.deployment_template
 
+  tags = {
+    monitor = "false"
+  }
+
   elasticsearch = {
     hot = {
       size        = "1g"

--- a/ec/acc/testdata/deployment_upgrade_retry_2.tf
+++ b/ec/acc/testdata/deployment_upgrade_retry_2.tf
@@ -14,6 +14,10 @@ resource "ec_deployment" "upgrade_retry" {
   version                = data.ec_stack.latest.version
   deployment_template_id = local.deployment_template
 
+  tags = {
+    monitor = "false"
+  }
+
   elasticsearch = {
     hot = {
       size        = "1g"


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above. -->

Add monitor false tag to failed deployment test to be excluded from alerting

## Description
<!--- Describe your changes in detail. -->

Adds a tag `monitor:false` to deployments that are purposely failing upgrades so they can be excluded from alerting

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
