### PR TITLE
Prepare 0.12.5 release

### DIFF
--- a/.changelog/957.txt
+++ b/.changelog/957.txt
@@ -1,5 +1,0 @@
-```release-note:bug
-resource/organization: Fix a bug where adding deployments or projects to an existing user would:
-* Remove the existing resource permissions
-* Cause the provider to fail with an inconsistent state error
-```

--- a/.changelog/965.txt
+++ b/.changelog/965.txt
@@ -1,7 +1,0 @@
-```release-note:feature
-resource/traffic_filter: Add support for `remote_cluster` traffic filter type with `remote_cluster_id` and `remote_cluster_org_id` attributes
-```
-
-```release-note:note
-data-source/traffic_filter: The `source` and `description` fields in traffic filter rules now return `null` instead of an empty string when not set. Users who check for empty strings (e.g., `source == ""`) should update their configurations to check for `null` instead (e.g., `source == null`).
-```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.12.5 (April 7, 2025)
+
+FEATURES:
+
+* resource/project: Add support for importing Serverless projects with `terraform import` ([#961](https://github.com/elastic/terraform-provider-ec/issues/961))
+* resource/project: Add support for managing Serverless project tags ([#983](https://github.com/elastic/terraform-provider-ec/issues/983))
+* resource/serverless_traffic_filter: Add serverless traffic filter resource and API endpoints for managing IP filters ([#978](https://github.com/elastic/terraform-provider-ec/issues/978))
+* resource/traffic_filter: Add support for `remote_cluster` traffic filter type with `remote_cluster_id` and `remote_cluster_org_id` attributes ([#965](https://github.com/elastic/terraform-provider-ec/issues/965))
+
+NOTES:
+
+* data-source/traffic_filter: The `source` and `description` fields in traffic filter rules now return `null` instead of an empty string when not set. Users who check for empty strings (e.g., `source == ""`) should update their configurations to check for `null` instead (e.g., `source == null`). ([#965](https://github.com/elastic/terraform-provider-ec/issues/965))
+
 # 0.12.4 (December 19, 2024)
 
 BUG FIXES:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 export GO111MODULE ?= on
-export VERSION := 0.12.4-dev
+export VERSION := 0.12.5-dev
 export BINARY := terraform-provider-ec
 export GOBIN = $(shell pwd)/bin
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.12.4"
+      version = "0.12.5"
     }
   }
 }

--- a/ec/version.go
+++ b/ec/version.go
@@ -18,4 +18,4 @@
 package ec
 
 // Version contains the current terraform provider version.
-const Version = "0.12.4-dev"
+const Version = "0.12.5-dev"

--- a/examples/deployment_ccs/deployment.tf
+++ b/examples/deployment_ccs/deployment.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.12.4"
+      version = "0.12.5"
     }
   }
 }

--- a/examples/deployment_ec2_instance/provider.tf
+++ b/examples/deployment_ec2_instance/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.12.4"
+      version = "0.12.5"
     }
 
     aws = {

--- a/examples/deployment_with_init/provider.tf
+++ b/examples/deployment_with_init/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.12.4"
+      version = "0.12.5"
     }
   }
 }

--- a/examples/extension_bundle/extension.tf
+++ b/examples/extension_bundle/extension.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = "0.12.4"
+      version = "0.12.5"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bump version to 0.12.5-dev
- Update provider version references in examples and README
- Consolidate changelog entries for 0.12.5 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)