### PR TITLE
Run go mod tidy in NOTICE regeneration workflow

### DIFF
--- a/.github/workflows/renovate-notice.yml
+++ b/.github/workflows/renovate-notice.yml
@@ -25,7 +25,9 @@ jobs:
           cache: true
 
       - name: Download Go modules
-        run: go mod download
+        run: |
+          go mod download
+          go mod tidy
 
       - name: Regenerate NOTICE
         run: make notice


### PR DESCRIPTION
## Summary

Follow-up to #1000. The new auto-update workflow ran successfully on Renovate PR #998 but produced a NOTICE with ~150 fewer dependencies than master (e.g. dropped `cloud.google.com/go/logging`, `cloud.google.com/go/trace`, `filippo.io/edwards25519`, and many indirect deps).

Root cause: a bare `go mod download` only fetches modules needed to build for the current GOOS/GOARCH, so many indirect dependencies are absent from `$GOMODCACHE` on a fresh CI runner. `go-licence-detector` then silently skips those entries.

`make vendor` (which the main CI uses) avoids this because it follows `go mod download` with `go mod tidy`, which walks the full module graph and fetches whatever is missing. This PR mirrors that behavior in the workflow.

Reproduced locally with `go clean -modcache && go mod download && make notice` — produced the same 422-dep NOTICE as the workflow. Adding `go mod tidy` brings it back to the 571-dep NOTICE that matches master byte-for-byte.

## Test plan

- [ ] Merge
- [ ] Next Renovate PR: the auto-update commit should only show real dep changes, not bulk deletions