### PR TITLE
ci: cancel intermediate acceptance builds on PR branches

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -21,6 +21,8 @@ spec:
     spec:
       repository: elastic/terraform-provider-ec
       pipeline_file: ".buildkite/acceptance_pipeline.yml"
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: "!master"
       provider_settings:
         build_pull_request_forks: false
         build_pull_requests: true


### PR DESCRIPTION
## Summary

Enable `cancel_intermediate_builds` on the `terraform-provider-ec-acceptance` pipeline (via its `catalog-info.yaml` definition), so a newer commit on a branch cancels the older still-running acceptance build.

```yaml
cancel_intermediate_builds: true
cancel_intermediate_builds_branch_filter: "!master"
```

## Why

Acceptance runs hit the **real, paid Elastic Cloud API** and take **~2 hours**. The pipeline currently has no cancellation configured, so every push on a branch — Renovate rebases, plus the `renovate-notice` workflow's NOTICE fix-up commit — stacks another full run without cancelling the previous. Observed on the goreleaser Renovate branch: **six acceptance builds `running` simultaneously** on one branch.

`master` is excluded so merged commits always get a complete, uncancelled acceptance result; cancellation only applies to PR/feature branches, where the pileup happens. The release pipeline (tag-triggered) is untouched.
