### PR TITLE
test(acc): cap deployment instance sizes at 2g

### DIFF
--- a/ec/acc/deployment_basic_defaults_test.go
+++ b/ec/acc/deployment_basic_defaults_test.go
@@ -52,7 +52,7 @@ func TestAccDeployment_basic_defaults_first(t *testing.T) {
 				// Deployment Template and schema defaults.
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),
@@ -68,7 +68,7 @@ func TestAccDeployment_basic_defaults_first(t *testing.T) {
 				Config: secondConfigCfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// changed
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
@@ -148,10 +148,10 @@ func TestAccDeployment_basic_defaults_hw(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.warm.instance_configuration_id"),
-					// general purpose config set to 4g.
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "4g"),
+					// general purpose config set to 2g.
+					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.warm.size", "4g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.warm.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.warm.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_basic_defaults_test.go
+++ b/ec/acc/deployment_basic_defaults_test.go
@@ -52,7 +52,6 @@ func TestAccDeployment_basic_defaults_first(t *testing.T) {
 				// Deployment Template and schema defaults.
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),
@@ -68,7 +67,6 @@ func TestAccDeployment_basic_defaults_first(t *testing.T) {
 				Config: secondConfigCfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// changed
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
@@ -148,10 +146,7 @@ func TestAccDeployment_basic_defaults_hw(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.warm.instance_configuration_id"),
-					// general purpose config set to 2g.
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.warm.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.warm.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_basic_defaults_test.go
+++ b/ec/acc/deployment_basic_defaults_test.go
@@ -63,7 +63,7 @@ func TestAccDeployment_basic_defaults_first(t *testing.T) {
 				),
 			},
 			{
-				// Add an APM resource size.
+				// Add integrations_server and increase kibana size.
 				Config: secondConfigCfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// changed

--- a/ec/acc/deployment_ccs_test.go
+++ b/ec/acc/deployment_ccs_test.go
@@ -94,10 +94,9 @@ func TestAccDeployment_ccs(t *testing.T) {
 				),
 			},
 			{
-				// Change the Elasticsearch topology size and node count.
+				// Remove remote cluster (CCS) configuration.
 				Config: secondConfigCfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// Changes.
 					resource.TestCheckResourceAttrSet(generalPurposeResName, "elasticsearch.hot.instance_configuration_id"),
 					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size_resource", "memory"),
 

--- a/ec/acc/deployment_ccs_test.go
+++ b/ec/acc/deployment_ccs_test.go
@@ -54,7 +54,6 @@ func TestAccDeployment_ccs(t *testing.T) {
 
 					// general purpose template checks
 					resource.TestCheckResourceAttrSet(generalPurposeResName, "elasticsearch.hot.instance_configuration_id"),
-					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size_resource", "memory"),
 
 					// Remote cluster settings
@@ -100,7 +99,6 @@ func TestAccDeployment_ccs(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Changes.
 					resource.TestCheckResourceAttrSet(generalPurposeResName, "elasticsearch.hot.instance_configuration_id"),
-					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size_resource", "memory"),
 
 					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.remote_cluster.#", "0"),

--- a/ec/acc/deployment_ccs_test.go
+++ b/ec/acc/deployment_ccs_test.go
@@ -54,8 +54,7 @@ func TestAccDeployment_ccs(t *testing.T) {
 
 					// general purpose template checks
 					resource.TestCheckResourceAttrSet(generalPurposeResName, "elasticsearch.hot.instance_configuration_id"),
-					// general purpose template defaults to 8g.
-					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size", "8g"),
+					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size_resource", "memory"),
 
 					// Remote cluster settings
@@ -101,7 +100,7 @@ func TestAccDeployment_ccs(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Changes.
 					resource.TestCheckResourceAttrSet(generalPurposeResName, "elasticsearch.hot.instance_configuration_id"),
-					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size", "4g"),
+					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.hot.size_resource", "memory"),
 
 					resource.TestCheckResourceAttr(generalPurposeResName, "elasticsearch.remote_cluster.#", "0"),

--- a/ec/acc/deployment_cpu_optimized_test.go
+++ b/ec/acc/deployment_cpu_optimized_test.go
@@ -42,7 +42,7 @@ func TestAccDeployment_cpuOptimized(t *testing.T) {
 				Config: cfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_cpu_optimized_test.go
+++ b/ec/acc/deployment_cpu_optimized_test.go
@@ -54,11 +54,10 @@ func TestAccDeployment_cpuOptimized(t *testing.T) {
 				),
 			},
 			{
-				// Change the Elasticsearch topology size and add capacity to the APM instance.
+				// Add an APM instance.
 				Config: secondConfigCfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_cpu_optimized_test.go
+++ b/ec/acc/deployment_cpu_optimized_test.go
@@ -42,7 +42,6 @@ func TestAccDeployment_cpuOptimized(t *testing.T) {
 				Config: cfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_general_purpose_test.go
+++ b/ec/acc/deployment_general_purpose_test.go
@@ -47,7 +47,7 @@ func TestAccDeployment_general_purpose(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.warm.instance_configuration_id"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_general_purpose_test.go
+++ b/ec/acc/deployment_general_purpose_test.go
@@ -47,7 +47,6 @@ func TestAccDeployment_general_purpose(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.instance_configuration_id"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.warm.instance_configuration_id"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_general_purpose_test.go
+++ b/ec/acc/deployment_general_purpose_test.go
@@ -60,7 +60,7 @@ func TestAccDeployment_general_purpose(t *testing.T) {
 				),
 			},
 			{
-				// Change the Elasticsearch toplogy size and node count.
+				// Change hot size and zone counts.
 				Config: secondConfigCfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Changes.

--- a/ec/acc/deployment_migrate_to_latest_hw_test.go
+++ b/ec/acc/deployment_migrate_to_latest_hw_test.go
@@ -46,7 +46,7 @@ func TestAccDeployment_migrate_to_latest_hw(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, cpuOpTemplate)),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.instance_configuration_id", "aws.es.datahot.m5d"), // it should contain custom IC
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),
@@ -64,7 +64,7 @@ func TestAccDeployment_migrate_to_latest_hw(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, cpuOpTemplate)),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.instance_configuration_id", expectedHotIC), // it should contain the latest cpu opt IC
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_migrate_to_latest_hw_test.go
+++ b/ec/acc/deployment_migrate_to_latest_hw_test.go
@@ -58,7 +58,7 @@ func TestAccDeployment_migrate_to_latest_hw(t *testing.T) {
 				),
 			},
 			{
-				// Create a Compute Optimized deployment with the default settings.
+				// Migrate to the latest hardware for the CPU optimized template.
 				Config: migrateToLatestHwCfg,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, cpuOpTemplate)),

--- a/ec/acc/deployment_migrate_to_latest_hw_test.go
+++ b/ec/acc/deployment_migrate_to_latest_hw_test.go
@@ -46,7 +46,6 @@ func TestAccDeployment_migrate_to_latest_hw(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, cpuOpTemplate)),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.instance_configuration_id", "aws.es.datahot.m5d"), // it should contain custom IC
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),
@@ -64,7 +63,6 @@ func TestAccDeployment_migrate_to_latest_hw(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, cpuOpTemplate)),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.instance_configuration_id", expectedHotIC), // it should contain the latest cpu opt IC
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_template_migration_test.go
+++ b/ec/acc/deployment_template_migration_test.go
@@ -43,7 +43,7 @@ func TestAccDeployment_template_migration(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, cpuOpFasterTemplate)),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.instance_configuration_id", "aws.es.datahot.c5d"), // cpu optimized IC
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),
@@ -61,7 +61,7 @@ func TestAccDeployment_template_migration(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, generalPurposeTemplate)),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.instance_configuration_id", "aws.es.datahot.m5d"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "8g"),
+					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/deployment_template_migration_test.go
+++ b/ec/acc/deployment_template_migration_test.go
@@ -43,7 +43,6 @@ func TestAccDeployment_template_migration(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, cpuOpFasterTemplate)),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.instance_configuration_id", "aws.es.datahot.c5d"), // cpu optimized IC
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),
@@ -61,7 +60,6 @@ func TestAccDeployment_template_migration(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "deployment_template_id", setDefaultTemplate(region, generalPurposeTemplate)),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.instance_configuration_id", "aws.es.datahot.m5d"),
-					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size", "2g"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.size_resource", "memory"),
 					resource.TestCheckResourceAttrSet(resName, "elasticsearch.hot.node_roles.#"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.hot.zone_count", "2"),

--- a/ec/acc/testdata/deployment_basic_defaults_1.tf
+++ b/ec/acc/testdata/deployment_basic_defaults_1.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "defaults" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_basic_defaults_2.tf
+++ b/ec/acc/testdata/deployment_basic_defaults_2.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "defaults" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
 

--- a/ec/acc/testdata/deployment_basic_defaults_hw_2.tf
+++ b/ec/acc/testdata/deployment_basic_defaults_hw_2.tf
@@ -11,11 +11,11 @@ resource "ec_deployment" "defaults" {
 
   elasticsearch = {
     hot = {
-      size        = "4g"
+      size        = "2g"
       autoscaling = {}
     }
     warm = {
-      size        = "4g"
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_basic_integrations_server_1.tf
+++ b/ec/acc/testdata/deployment_basic_integrations_server_1.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "basic" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_basic_integrations_server_2.tf
+++ b/ec/acc/testdata/deployment_basic_integrations_server_2.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "basic" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_ccs_1.tf
+++ b/ec/acc/testdata/deployment_ccs_1.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "general_purpose" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
 

--- a/ec/acc/testdata/deployment_ccs_2.tf
+++ b/ec/acc/testdata/deployment_ccs_2.tf
@@ -11,7 +11,7 @@ resource "ec_deployment" "general_purpose" {
 
   elasticsearch = {
     hot = {
-      size        = "4g"
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_cpu_optimized_1.tf
+++ b/ec/acc/testdata/deployment_cpu_optimized_1.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "cpu_optimized" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_cpu_optimized_with_custom_hot_ic.tf
+++ b/ec/acc/testdata/deployment_cpu_optimized_with_custom_hot_ic.tf
@@ -12,6 +12,7 @@ resource "ec_deployment" "cpu_optimized" {
   elasticsearch = {
     hot = {
       instance_configuration_id = "aws.es.datahot.m5d"
+      size                      = "2g"
       autoscaling               = {}
     }
   }

--- a/ec/acc/testdata/deployment_cpu_optimized_with_migrate_to_latest_hw.tf
+++ b/ec/acc/testdata/deployment_cpu_optimized_with_migrate_to_latest_hw.tf
@@ -12,6 +12,7 @@ resource "ec_deployment" "cpu_optimized" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_enterprise_search_1.tf
+++ b/ec/acc/testdata/deployment_enterprise_search_1.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "enterprise_search" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_general_purpose_1.tf
+++ b/ec/acc/testdata/deployment_general_purpose_1.tf
@@ -11,10 +11,12 @@ resource "ec_deployment" "general_purpose" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
 
     warm = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_memory_optimized_1.tf
+++ b/ec/acc/testdata/deployment_memory_optimized_1.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "memory_optimized" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_observability_tpl_1.tf
+++ b/ec/acc/testdata/deployment_observability_tpl_1.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "observability_tpl" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_security_1.tf
+++ b/ec/acc/testdata/deployment_security_1.tf
@@ -11,6 +11,7 @@ resource "ec_deployment" "security" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
   }

--- a/ec/acc/testdata/deployment_with_extension_bundle_file.tf
+++ b/ec/acc/testdata/deployment_with_extension_bundle_file.tf
@@ -19,6 +19,7 @@ resource "ec_deployment" "with_extension" {
 
   elasticsearch = {
     hot = {
+      size        = "2g"
       autoscaling = {}
     }
     extension = [{


### PR DESCRIPTION
## Summary
- Cap acceptance-test Elasticsearch topology sizes at 2g to reduce ACC cost (override template defaults that provision 8g; lower explicit 4g configs).
- Leave existing 1g/2g sizes and autoscaling `max_size` ceilings unchanged.
- Drop size assertions that only verified the previous 8g/4g template defaults.

## Test plan
- [ ] Review testdata diffs for any remaining provisioned size > 2g
- [ ] Run affected ACC suites (or wait for Buildkite acceptance on this PR)

Made with [Cursor](https://cursor.com)