### PR TITLE
test(acc): pin Kibana to 2g in datasource basic test to avoid OOMs

### DIFF
--- a/ec/acc/testdata/datasource_deployment_basic.tf
+++ b/ec/acc/testdata/datasource_deployment_basic.tf
@@ -34,7 +34,9 @@ resource "ec_deployment" "basic_datasource" {
     }
   }
 
-  kibana = {}
+  kibana = {
+    size = "2g"
+  }
 
   apm = {}
 


### PR DESCRIPTION
### Description

`ec/acc/testdata/datasource_deployment_basic.tf` declared `kibana = {}` for `ec_deployment.basic_datasource`, so Kibana fell through to the deployment-template default of **1 GB**. That default proved insufficient: Kibana instances fail to start, which fails `TestAccDatasourceDeployment_basic` during create.

This sets an explicit `size = "2g"` on that Kibana block.

### Failing builds this addresses

`TestAccDatasourceDeployment_basic` is the only test failing consistently in the acceptance pipeline, on `ec_deployment.basic_datasource`:

```
found deployment plan errors: 2 errors occurred:
    * [apm]...: "Plan change failed: Cluster not reachable: [kibana]... Please validate the cluster is in a healthy state and retry."
    * [kibana]...: "Plan change failed: Some instances were not running"
```

Reproduced on two unrelated branches ~17h apart (systematic, not transient):
- https://buildkite.com/elastic/terraform-provider-ec-acceptance/builds/2372 (`renovate/github.comhashicorp-dependencies`)
- https://buildkite.com/elastic/terraform-provider-ec-acceptance/builds/2452 (`renovate/github.comoapi-codegen-dependencies`)

### Notes

- The test's Kibana size assertions are attribute pairs (datasource vs. resource, `TestCheckResourceAttrPair`), so no assertion change is required.
- This test uses the `cpu-optimized` template. 2 GB is a standard Kibana tier and is already exercised in the acc suite (`deployment_basic_defaults_2.tf`, on the `storage-optimized` template); Kibana instance configs are generally shared across deployment templates in a region, so 2g is expected to be valid here too. The acceptance run on this PR is the real confirmation.
- Test-only change (single acceptance fixture); no user-facing behavior changes, so no changelog entry.
- `terraform fmt` is clean.
- Out of scope: other tests that share the same 1g-Kibana default pattern (`deployment_basic`, `deployment_basic_defaults`, `deployment_cpu_optimized`, `deployment_migrate_to_latest_hw`, `deployment_template_migration`) are left untouched here and can be addressed in a follow-up if the same OOMs surface there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)