### PR TITLE
test(acc): pin Kibana to 2g in self-observability test to avoid OOMs

### DIFF
--- a/ec/acc/testdata/deployment_observability_self.tf
+++ b/ec/acc/testdata/deployment_observability_self.tf
@@ -24,7 +24,7 @@ resource "ec_deployment" "observability" {
   }
 
   kibana = {
-    size       = "1g"
+    size       = "2g"
     zone_count = 1
   }
 }


### PR DESCRIPTION
## Problem

`TestAccDeployment_observability_createWithSelfObservability` flaked in CI ([Buildkite build 2482](https://buildkite.com/elastic/terraform-provider-ec-acceptance/builds/2482#019f6b07-550e-420b-9e4b-8e6ce96438da)) with:

```
found deployment plan errors: 1 error occurred:
	* deployment [ded996b2ea45b7b5e10b392d04f01346] -
	[kibana][74eeec85f2a54b8da2ef7c9830430d10]: caught error: "Plan change
	failed: Some instances were not running"
```

Prod constructor logs for that deployment show the Kibana instance was **OOM-killed on startup** (`exit code [137]`) after 4 retry attempts, producing `PlanRaisedStepFailureException: Some instances were not running`. The fixture allocated only `1g` to Kibana, which is insufficient to start on the latest stack version. The same test failed identically in builds 2462 and 2416.

## Fix

Bump Kibana to `2g` in `deployment_observability_self.tf`. Elasticsearch `hot` is left at `1g` — only Kibana OOM'd. This mirrors the same fix applied to the datasource basic test in #1024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)