### PR TITLE
ci: auto-approve Renovate PRs after required checks

### DIFF
--- a/.buildkite/acceptance.sh
+++ b/.buildkite/acceptance.sh
@@ -18,6 +18,8 @@ docs_only_pr() {
 
 if docs_only_pr; then
   echo "--- Skip acceptance tests (docs/dev-docs only)"
+  # pre-exit still runs; skip sweep so a leftover cleanup failure cannot fail the required check.
+  touch .buildkite/.skip-acceptance-sweep
   exit 0
 fi
 

--- a/.buildkite/acceptance.sh
+++ b/.buildkite/acceptance.sh
@@ -1,6 +1,26 @@
 #!/bin/bash
 set -euo pipefail
 
+# Docs-only PRs still need a green Buildkite status: master requires
+# buildkite/terraform-provider-ec-acceptance, and skip_ci_on_only_changed would
+# leave that context missing (blocking merge). Exit 0 here instead of running
+# the paid suite.
+docs_only_pr() {
+  [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]] && return 1
+  local base="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
+  # Fail-safe: if we cannot see the base, run the suite rather than skip.
+  git fetch --depth=50 origin "$base" || return 1
+  local files
+  files=$(git diff --name-only "origin/${base}...HEAD") || return 1
+  [[ -n "$files" ]] || return 1
+  ! echo "$files" | grep -qvE '^(docs/|dev-docs/)'
+}
+
+if docs_only_pr; then
+  echo "--- Skip acceptance tests (docs/dev-docs only)"
+  exit 0
+fi
+
 echo "--- Download dependencies"
 make vendor
 

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -3,6 +3,10 @@
 set -euo pipefail
 
 if  [[ "$BUILDKITE_STEP_KEY" == "acceptance-tests" ]]; then
+  if [[ -f .buildkite/.skip-acceptance-sweep ]]; then
+    echo "--- Skip sweep (docs/dev-docs only)"
+    exit 0
+  fi
   echo "--- Sweeps any deployments and serverless projects older than 3h."
   EC_API_KEY=$TERRAFORM_PROVIDER_API_KEY_SECRET SWEEPARGS='-sweep-run=ec_deployments,ec_serverless_projects' make sweep
   rm -rf reports bin

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,10 +13,7 @@
         "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
         "skip_ci_labels": [ ],
         "skip_target_branches": [ ],
-        "skip_ci_on_only_changed": [
-          "^docs/",
-          "^dev-docs/"
-        ],
+        "skip_ci_on_only_changed": [ ],
         "always_require_ci_on_changed": [ ]
       }
     ]

--- a/.github/workflows/approve-renovate.yml
+++ b/.github/workflows/approve-renovate.yml
@@ -1,0 +1,43 @@
+name: Auto-approve Renovate
+
+# github-actions[bot] approves Renovate PRs that already have auto-merge on
+# (Renovate cannot approve its own PRs). Majors never enable auto-merge.
+# synchronize re-approves after the NOTICE follow-up commit.
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [auto_merge_enabled, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  approve:
+    name: Approve
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.pull_request.user.login == 'elastic-renovate-prod[bot]' ||
+       github.event.pull_request.user.login == 'elastic-renovate-dev[bot]') &&
+      github.event.pull_request.auto_merge != null
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            try {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                event: 'APPROVE',
+              })
+            } catch (error) {
+              // Duplicate approve on the same commit.
+              if (error.status === 422) {
+                core.info(`Skipping approve: ${error.message}`)
+                return
+              }
+              throw error
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 .terraform.lock.hcl
 node_modules/
 
+# CI sentinel: docs-only acc jobs write this so pre-exit skips make sweep
+.buildkite/.skip-acceptance-sweep
+
 # agent local overrides (not committed)
 .agents/settings.local.json
 .agents/worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ and related resources through the Elastic Cloud API.
 - Acceptance tests (`make testacc`, and anything gated by `TF_ACC=1`) create and destroy **real
   deployments** against the live Elastic Cloud API (`EC_API_KEY`) and cost real money. **Never run
   acceptance tests from an agentic workflow** — no live-cloud credentials are exposed to agents. The
-  full suite runs on Buildkite per PR (a human reviews the result); a human working on a change
+  full suite runs on Buildkite per PR and is a **required** status check on `master`
+  (`buildkite/terraform-provider-ec-acceptance`); a human working on a change
   should run the targeted `TestAcc…` case(s) locally first. See [`testing.md`](./dev-docs/high-level/testing.md).
 - There is **no local Docker stack** for this provider (unlike the Elastic Stack provider). Unit
   tests (`make unit`) need no credentials and are always safe to run.

--- a/dev-docs/high-level/development-workflow.md
+++ b/dev-docs/high-level/development-workflow.md
@@ -15,8 +15,8 @@ fragments are the source of truth for exact behavior.
 > **Before opening a PR, run the _targeted_ test(s) covering your change locally** —
 > `make testacc TEST_NAME='TestAccMyThing'` — for fast feedback, then `make sweep` any leftovers.
 > Don't run the **full** suite locally for routine iteration (~2 hours); the Buildkite acceptance
-> pipeline runs the full suite for every PR and a human reviews the result. **Agents never run
-> acceptance tests** — no live-cloud credentials are exposed to agentic workflows. See
+> pipeline runs the full suite for every PR and is a required status check on `master`. **Agents
+> never run acceptance tests** — no live-cloud credentials are exposed to agentic workflows. See
 > [`testing.md`](./testing.md). `make unit` needs no credentials and is always safe. There is **no
 > local Docker stack** for this provider.
 
@@ -64,5 +64,5 @@ full manual runbook see [`../RELEASE.md`](../RELEASE.md).
 7. Add a changelog entry at `.changelog/{PR}.txt` for any user-facing change (one file per PR; see
    [`contributing.md`](./contributing.md)).
 
-The **full** acceptance suite runs on Buildkite for every PR; run only the targeted cases locally,
-and note that **agents never run acceptance tests** at all.
+The **full** acceptance suite runs on Buildkite for every PR and must pass before merge; run only
+the targeted cases locally, and note that **agents never run acceptance tests** at all.

--- a/dev-docs/high-level/repo-structure.md
+++ b/dev-docs/high-level/repo-structure.md
@@ -25,7 +25,7 @@ the [terraform-plugin-framework](https://developer.hashicorp.com/terraform/plugi
 | `examples/` | Example Terraform configs, also pulled into the generated docs. |
 | `.changelog/` | Per-PR changelog fragments (`{PR}.txt`); consolidated into `CHANGELOG.md` at release. See [`contributing.md`](./contributing.md). |
 | `.buildkite/` | Buildkite pipelines — notably the per-PR **acceptance** pipeline. See [`testing.md`](./testing.md). |
-| `.github/` | GitHub Actions (unit/lint/docs via `go.yml`, OpenSpec via `openspec.yml`) and repo config. |
+| `.github/` | GitHub Actions (unit/lint/docs via `go.yml`, OpenSpec via `openspec.yml`, Renovate auto-approve via `approve-renovate.yml`) and repo config. |
 | `dev-docs/` | Developer docs (this set), including [`RELEASE.md`](../RELEASE.md) — the release runbook. |
 | `docs-elastic/` | AsciiDoc source (`index.asciidoc`) for the Elastic docs site. |
 | `tools/` | Tool dependencies (pinned via `go` tooling). |

--- a/dev-docs/high-level/testing.md
+++ b/dev-docs/high-level/testing.md
@@ -80,13 +80,14 @@ Acceptance runs are wired through Buildkite, not run inline by contributors:
 - [`.buildkite/pull-requests.json`](../../.buildkite/pull-requests.json) gates the
   `terraform-provider-ec-acceptance` pipeline: org users with `admin`/`write` (plus `renovate[bot]`)
   trigger it on commit or on a `build this` / `test this` comment. The pipeline always runs so the
-  required `buildkite/terraform-provider-ec-acceptance` status is posted; docs-only PRs are a
-  fast no-op inside `acceptance.sh` rather than skipped at the trigger.
+  required `buildkite/terraform-provider-ec-acceptance` status is posted. Docs-only PRs still start
+  an agent (`pre-command` still loads the API key) but skip `make testacc` and the `pre-exit` sweep.
 - [`.buildkite/acceptance_pipeline.yml`](../../.buildkite/acceptance_pipeline.yml) defines the
   single "Acceptance tests" step running [`.buildkite/acceptance.sh`](../../.buildkite/acceptance.sh)
   on a `golang` image.
-- `acceptance.sh` exits 0 without `make testacc` when the PR only touches `docs/` or `dev-docs/`;
-  otherwise it runs `make vendor` then `EC_API_KEY=$TERRAFORM_PROVIDER_API_KEY_SECRET make testacc`.
+- `acceptance.sh` exits 0 without `make testacc` when the PR only touches `docs/` or `dev-docs/`
+  (and writes `.buildkite/.skip-acceptance-sweep` so `pre-exit` does not sweep); otherwise it
+  runs `make vendor` then `EC_API_KEY=$TERRAFORM_PROVIDER_API_KEY_SECRET make testacc`.
 - Branch protection on `master` requires **CLA**, **Unit**, and
   `buildkite/terraform-provider-ec-acceptance`. GitHub auto-merge (used by Renovate) waits on those
   checks. Non-major Renovate PRs are auto-approved as `github-actions[bot]` by
@@ -94,7 +95,8 @@ Acceptance runs are wired through Buildkite, not run inline by contributors:
   Renovate enables auto-merge.
 - The [`pre-command`](../../.buildkite/hooks/pre-command) hook loads the API key from Vault and
   exports `BUILD_ID` (which makes `make sweep` skip its interactive confirmation).
-- The [`pre-exit`](../../.buildkite/hooks/pre-exit) hook always sweeps afterward (see below).
+- The [`pre-exit`](../../.buildkite/hooks/pre-exit) hook sweeps afterward unless the docs-only
+  skip file is present (see below).
 
 The Buildkite result is a required check; merge is blocked until it is green.
 
@@ -120,8 +122,9 @@ sweep:
   matching filters.
 - **CI cleans up automatically:** Buildkite's `pre-exit` hook (on the `acceptance-tests` step) runs
   `SWEEPARGS='-sweep-run=ec_deployments,ec_serverless_projects' make sweep` after every acceptance
-  build — so stale deployments **and** projects are reaped on exit regardless of pass/fail. (The
-  `acceptance.sh` step itself only runs `make vendor` + `make testacc`.)
+  build except docs-only skips (`.buildkite/.skip-acceptance-sweep`) — so stale deployments
+  **and** projects are reaped on exit regardless of pass/fail. (The `acceptance.sh` step itself
+  only runs `make vendor` + `make testacc`, or exits early on docs-only PRs.)
 - **When to run manually:** after a *local* acceptance failure that may have left dangling
   infrastructure, or to reclaim serverless quota (see below).
 

--- a/dev-docs/high-level/testing.md
+++ b/dev-docs/high-level/testing.md
@@ -34,8 +34,9 @@ and destroying real deployments and serverless projects. All test wiring lives i
 > 🚫 **Don't run the _full_ suite locally for routine iteration, and agents never run acceptance
 > tests at all** — no `TF_ACC` in agentic workflows and no live-cloud credentials are exposed to
 > agents. The full suite runs automatically for every PR on the dedicated **Buildkite acceptance
-> pipeline** (the GitHub Actions `go.yml` CI runs unit/lint/docs only), and a human reviews the
-> result.
+> pipeline** (the GitHub Actions `go.yml` CI runs unit/lint/docs only). That Buildkite status is a
+> **required** check on `master`, so a PR cannot merge — including Renovate automerge — until it is
+> green.
 
 Gating and recipe (from `build/Makefile.test`):
 
@@ -78,17 +79,24 @@ Acceptance runs are wired through Buildkite, not run inline by contributors:
 
 - [`.buildkite/pull-requests.json`](../../.buildkite/pull-requests.json) gates the
   `terraform-provider-ec-acceptance` pipeline: org users with `admin`/`write` (plus `renovate[bot]`)
-  trigger it on commit or on a `build this` / `test this` comment; changes touching only `^docs/`
-  or `^dev-docs/` are skipped.
+  trigger it on commit or on a `build this` / `test this` comment. The pipeline always runs so the
+  required `buildkite/terraform-provider-ec-acceptance` status is posted; docs-only PRs are a
+  fast no-op inside `acceptance.sh` rather than skipped at the trigger.
 - [`.buildkite/acceptance_pipeline.yml`](../../.buildkite/acceptance_pipeline.yml) defines the
   single "Acceptance tests" step running [`.buildkite/acceptance.sh`](../../.buildkite/acceptance.sh)
   on a `golang` image.
-- `acceptance.sh` runs `make vendor` then `EC_API_KEY=$TERRAFORM_PROVIDER_API_KEY_SECRET make testacc`.
+- `acceptance.sh` exits 0 without `make testacc` when the PR only touches `docs/` or `dev-docs/`;
+  otherwise it runs `make vendor` then `EC_API_KEY=$TERRAFORM_PROVIDER_API_KEY_SECRET make testacc`.
+- Branch protection on `master` requires **CLA**, **Unit**, and
+  `buildkite/terraform-provider-ec-acceptance`. GitHub auto-merge (used by Renovate) waits on those
+  checks. Non-major Renovate PRs are auto-approved as `github-actions[bot]` by
+  [`.github/workflows/approve-renovate.yml`](../../.github/workflows/approve-renovate.yml) once
+  Renovate enables auto-merge.
 - The [`pre-command`](../../.buildkite/hooks/pre-command) hook loads the API key from Vault and
   exports `BUILD_ID` (which makes `make sweep` skip its interactive confirmation).
 - The [`pre-exit`](../../.buildkite/hooks/pre-exit) hook always sweeps afterward (see below).
 
-A human reviews the Buildkite result as part of PR review.
+The Buildkite result is a required check; merge is blocked until it is green.
 
 ## Sweepers
 


### PR DESCRIPTION
## Summary
- Auto-approve non-major Renovate PRs as `github-actions[bot]` once Renovate has enabled auto-merge (same pattern as elastic/cloud). `synchronize` re-approves after the NOTICE follow-up commit from the vault bot.
- Always run the Buildkite acceptance pipeline so a status is posted; docs-only PRs exit 0 in `acceptance.sh` instead of being skipped at trigger time. That keeps merge unblocked with `buildkite/terraform-provider-ec-acceptance` as a required check (already set on `master`).

## Test plan
- [ ] Confirm the new workflow is skipped on this PR (not opened by Renovate)
- [ ] Confirm Buildkite acceptance still runs on this PR (not docs-only)
- [x] `buildkite/terraform-provider-ec-acceptance` is a required check on `master`
- [ ] On the next non-major Renovate PR, confirm `github-actions[bot]` approves on auto-merge and again after a NOTICE commit if present
- [ ] Confirm a docs-only PR gets a green Buildkite status without running `make testacc`

Made with [Cursor](https://cursor.com)