### PR TITLE
[1.3] OpenSpec authoring conventions + exemplar specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ and related resources through the Elastic Cloud API.
 - Testing (unit + acceptance) and required env: [`testing.md`](./dev-docs/high-level/testing.md)
 - Generated clients (serverless OpenAPI) and regeneration: [`generated-clients.md`](./dev-docs/high-level/generated-clients.md)
 - Documentation generation (`tfplugindocs`): [`documentation.md`](./dev-docs/high-level/documentation.md)
+- OpenSpec authoring (Purpose / SHALL-MUST / Scenarios): [`openspec-requirements.md`](./dev-docs/high-level/openspec-requirements.md)
 
 ## Testing note — acceptance tests hit the real, paid Elastic Cloud API
 
@@ -40,5 +41,6 @@ and related resources through the Elastic Cloud API.
 - Add a `.changelog/{PR}.txt` entry for user-facing changes (see [`contributing.md`](./dev-docs/high-level/contributing.md)).
 
 > The OpenSpec CLI is installed via `make setup-openspec` (Node.js 24, `npm ci`) and validated by
-> `make check-openspec` / `.github/workflows/openspec.yml`. Spec authoring conventions, lifecycle
-> skills, and GitHub Agentic Workflows land in later Phase 1–4 issues of the LLM-driven SDLC epic.
+> `make check-openspec` / `.github/workflows/openspec.yml`. Author specs per
+> [`openspec-requirements.md`](./dev-docs/high-level/openspec-requirements.md). Lifecycle skills and
+> GitHub Agentic Workflows land in later Phase 1–4 issues of the LLM-driven SDLC epic.

--- a/dev-docs/high-level/README.md
+++ b/dev-docs/high-level/README.md
@@ -10,7 +10,8 @@ They intentionally stay high-level and link to deeper, canonical docs elsewhere 
 - Generated clients: [`generated-clients.md`](./generated-clients.md)
 - Documentation: [`documentation.md`](./documentation.md)
 - Contributing: [`contributing.md`](./contributing.md)
+- OpenSpec authoring (Purpose / SHALL / Scenarios): [`openspec-requirements.md`](./openspec-requirements.md)
 
-> Docs for the OpenSpec requirements layer and the GitHub Agentic Workflows (overview, factory
-> workflows, continuous-quality scanners, OpenSpec loop, and the `verify-openspec` gate) will be
-> added here as those phases of the LLM-driven SDLC epic land.
+> Docs for GitHub Agentic Workflows (overview, factory workflows, continuous-quality scanners,
+> the OpenSpec implementation loop, and the `verify-openspec` gate) will be added here as those
+> phases of the LLM-driven SDLC epic land.

--- a/dev-docs/high-level/coding-standards.md
+++ b/dev-docs/high-level/coding-standards.md
@@ -91,7 +91,10 @@ Run `make format` before committing and `make lint` to gate. Both are thin wrapp
 - **`terraform fmt -check`** — formatting of `.tf` example/test files.
 
 OpenSpec structural validation is **`make check-openspec`**, not part of `make lint`. CI runs it in
-`.github/workflows/openspec.yml`.
+`.github/workflows/openspec.yml`. Author specs per [`openspec-requirements.md`](./openspec-requirements.md)
+(Purpose / SHALL-MUST requirements / Given-When-Then scenarios). Canonical specs live in
+`openspec/specs/`; new or changed behavior is proposed under `openspec/changes/` and archived into
+`openspec/specs/` after the implementation lands.
 
 ## Error handling
 

--- a/dev-docs/high-level/contributing.md
+++ b/dev-docs/high-level/contributing.md
@@ -6,5 +6,6 @@ the PR flow, dev-environment setup, the pre-submit checklist, commit conventions
 `.changelog/{PR}.txt` changelog convention.
 
 For the how-to detail behind it, see [`development-workflow.md`](./development-workflow.md) (make
-targets and the change loop), [`testing.md`](./testing.md) (unit + acceptance, required env), and
-[`coding-standards.md`](./coding-standards.md).
+targets and the change loop), [`testing.md`](./testing.md) (unit + acceptance, required env),
+[`coding-standards.md`](./coding-standards.md), and [`openspec-requirements.md`](./openspec-requirements.md)
+(OpenSpec Purpose / SHALL-MUST / Scenarios).

--- a/dev-docs/high-level/development-workflow.md
+++ b/dev-docs/high-level/development-workflow.md
@@ -32,7 +32,8 @@ fragments are the source of truth for exact behavior.
   `make lint` before opening a PR.
 - **`make check-openspec`** structurally validates `openspec/` (`openspec validate --all`). It is
   not part of `make lint`; CI runs it in `.github/workflows/openspec.yml`. Run it locally when you
-  change specs. It installs the CLI via `setup-openspec` if needed.
+  change specs. It installs the CLI via `setup-openspec` if needed. Authoring conventions:
+  [`openspec-requirements.md`](./openspec-requirements.md).
 - **`make gen`** (alias `make generate`) regenerates the serverless client *and* `ec/version.go`. To
   refresh the vendored serverless OpenAPI spec, use `scripts/update-serverless-spec.sh` — see
   [`generated-clients.md`](./generated-clients.md).

--- a/dev-docs/high-level/openspec-requirements.md
+++ b/dev-docs/high-level/openspec-requirements.md
@@ -103,6 +103,9 @@ combinatorics.
 Optional `## Schema` sketches use HCL with `<required|optional|computed, type>` annotations. They
 orient the reader; the Requirements section is normative.
 
+When a current-behavior spec captures a known limitation, keep the `SHALL` as the observable rule
+and add a non-normative **Known gaps** note. A later bug fix is a change that updates the `SHALL`.
+
 ## Cloud-provider constraints
 
 These apply to every spec in this repo and to any later change that implements one:

--- a/dev-docs/high-level/openspec-requirements.md
+++ b/dev-docs/high-level/openspec-requirements.md
@@ -1,0 +1,135 @@
+# OpenSpec requirements
+
+This repository uses [OpenSpec](https://openspec.dev/) for **living functional requirements**.
+Canonical specs live under [`openspec/specs/`](../../openspec/specs/) and describe behavior that is
+already in the provider. Proposed new or changed behavior lives under `openspec/changes/` until the
+implementation is archived into `openspec/specs/`.
+
+This page is the authoring contract: file layout, requirement phrasing, and when to write a spec.
+Operational skills that create / apply / archive a change land in later Phase 1 issues; GitHub
+Agentic Workflows (`change-factory`, `verify-openspec`) land in later phases. Until those exist,
+follow the layout here by hand.
+
+## Layout
+
+- **`openspec/specs/<capability>/spec.md`** — One capability per directory. Each file includes:
+  - **`## Purpose`** — Scope in plain language (what is in, what is out).
+  - **`## Schema`** (optional) — HCL sketch of the Terraform resource or data source; appendix-style,
+    not a substitute for the Go schema.
+  - **`## Requirements`** — `### Requirement: …` blocks using **SHALL** / **MUST** (RFC 2119).
+  - **`#### Scenario: …`** — Given / When / Then checks reviewers and agents can trace to code or tests.
+- **`openspec/changes/<name>/`** — An in-progress **change**: proposal, design, tasks, and **delta
+  specs**. This is the default path for any work that adds or updates requirements. After the code
+  matches the change, `openspec archive` folds the deltas into `openspec/specs/` and moves the change
+  under `openspec/changes/archive/`.
+- **`openspec/config.yaml`** — Project OpenSpec configuration.
+
+Copy from the seed exemplars rather than inventing a new shape:
+
+- [`openspec/specs/deployment-traffic-filter/spec.md`](../../openspec/specs/deployment-traffic-filter/spec.md)
+  — small **resource** (`ec_deployment_traffic_filter`).
+- [`openspec/specs/stack/spec.md`](../../openspec/specs/stack/spec.md) — small **data source**
+  (`ec_stack`).
+
+## Capability ids
+
+Pick a stable kebab-case id **without** the `ec_` Terraform type prefix. It names both the canonical
+directory `openspec/specs/<id>/` and any delta spec under a change.
+
+| Terraform type | Capability id |
+| --- | --- |
+| `ec_deployment_traffic_filter` | `deployment-traffic-filter` |
+| `ec_stack` | `stack` |
+
+For a slice of a large resource, name the slice, not the monolith — e.g. a future
+`deployment-integrations-server` spec for Integrations Server endpoints, **not** a single
+`deployment` spec covering all of `ec_deployment`.
+
+Automation that we author later uses a `ci-*` prefix (for example `ci-aw-openspec-verification`).
+Do not retro-spec existing CI; only new or changed automation needs a spec.
+
+## When to write a spec
+
+**Going forward, only new or changed behavior needs a spec.** Do not backfill the rest of the
+provider. The two seed specs above exist so authors have something to copy; they are not a mandate
+to spec every existing resource.
+
+Write a spec (via a change) when any of these is true:
+
+- New Terraform resource or data source.
+- New or changed user-visible attributes, validation, or CRUD behavior.
+- A bug fix that changes observable behavior (the spec states the intended behavior).
+- New CI / automation behavior that we choose to pin (`ci-*`).
+
+Skip a spec for mechanical work with no spec impact (lint, dependency bumps, typo, generated-docs
+refresh, changelog-only).
+
+## Where to put it
+
+| Situation | Location |
+| --- | --- |
+| New or changed behavior (the default) | `openspec/changes/<id>/` — delta specs plus proposal / design / tasks. After implement + verify, archive into `openspec/specs/`. |
+| Behavior already in the product, captured as a copyable example (this seed) | `openspec/specs/<capability>/spec.md` directly. |
+| Tiny follow-up on an existing canonical spec (typo, link, wording) | Edit `openspec/specs/` directly. |
+
+Do **not** put unimplemented behavior into `openspec/specs/`. If the code does not do it yet, it
+belongs in a change. Example: exposing an Integrations Server `ingest` endpoint is a change, not a
+canonical requirement, until that code lands.
+
+A change that extends an existing capability adds a delta against `openspec/specs/<capability>/`. A
+change that introduces a brand-new capability ships its first `spec.md` as a delta; archive creates
+the canonical directory.
+
+## Authoring requirements
+
+Each `### Requirement:` block states one observable rule with **SHALL** or **MUST**. Keep the
+requirement at the Terraform / API-contract level (schema, validation, CRUD, error diagnostics),
+not a line-by-line transcription of Go.
+
+Each requirement has one or more `#### Scenario:` blocks:
+
+```
+#### Scenario: <short name>
+
+- GIVEN <precondition>
+- WHEN <action>
+- THEN the provider SHALL <observable result>
+```
+
+Scenarios are the reviewable unit: a reader should be able to point at a test or a code path that
+would fail if the requirement were violated. Prefer a few precise scenarios over exhaustive
+combinatorics.
+
+Optional `## Schema` sketches use HCL with `<required|optional|computed, type>` annotations. They
+orient the reader; the Requirements section is normative.
+
+## Cloud-provider constraints
+
+These apply to every spec in this repo and to any later change that implements one:
+
+- The provider is 100% [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) (no SDKv2).
+- There is **no local Docker stack**. Hosted ESS calls go through `cloud-sdk-go`; serverless calls
+  go through the generated client under `ec/internal/gen/serverless/`.
+- **Agents never run acceptance tests** (`TF_ACC`). Acc hits the real, paid Elastic Cloud API and
+  runs out-of-band on Buildkite. Specs may mention acc coverage as a *human* verification step; they
+  MUST NOT require an agent to execute `make testacc`.
+- User-facing implementation PRs add `.changelog/{PR}.txt` (not a PR-body changelog block). Spec /
+  docs-only PRs skip it. See [`contributing.md`](./contributing.md).
+- `make check-openspec` is **not** part of `make lint`. CI runs it in
+  [`.github/workflows/openspec.yml`](../../.github/workflows/openspec.yml).
+
+## Validation
+
+`make check-openspec` installs the pinned OpenSpec CLI (`make setup-openspec`, Node.js 24) and runs
+`openspec validate --all`. That checks structure and normative keywords. It does **not** prove the
+Go implementation matches every requirement — that is code review (and, later, the
+`openspec-verify-change` skill / `verify-openspec` label).
+
+Run it locally whenever you touch `openspec/`.
+
+## References
+
+- OpenSpec: [GitHub — OpenSpec](https://github.com/Fission-AI/OpenSpec)
+- Contributor setup (Node 24, `make setup-openspec`): [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+- Day-to-day make targets: [`development-workflow.md`](./development-workflow.md)
+- Coding conventions: [`coding-standards.md`](./coding-standards.md)

--- a/dev-docs/high-level/repo-structure.md
+++ b/dev-docs/high-level/repo-structure.md
@@ -18,7 +18,7 @@ the [terraform-plugin-framework](https://developer.hashicorp.com/terraform/plugi
 | `ec/` | All provider code — resources, data sources, and internals (see below). |
 | `gen/` | `gen.go`, a small `go:generate` program that writes `ec/version.go` from the `Makefile` `VERSION`. |
 | `Makefile` + `build/` | The root `Makefile` `include`s the split fragments under `build/` (`Makefile.build`, `.test`, `.dev`, `.openspec`, `.deps`, `.lint`, `.format`, `.release`, `.version`) plus `scripts/Makefile.help`. |
-| `openspec/` | OpenSpec requirements tree (`specs/`, `changes/`, `config.yaml`). Structural validation via `make check-openspec`. |
+| `openspec/` | OpenSpec requirements tree (`specs/`, `changes/`, `config.yaml`). Structural validation via `make check-openspec`. Authoring conventions: [`openspec-requirements.md`](./openspec-requirements.md). |
 | `package.json` | Pins the OpenSpec CLI (`@fission-ai/openspec`); install with `make setup-openspec`. |
 | `scripts/` | Helper scripts (changelog, version bump, `Makefile.help`, etc.). |
 | `templates/` + `docs/` | Doc **sources** (`templates/`) and the **generated** registry docs (`docs/`). See [`documentation.md`](./documentation.md). |

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -3,4 +3,4 @@ schema: spec-driven
 context: |
   Tech stack: Go, Terraform Plugin Framework
   Domain: Terraform provider for Elastic Cloud (hosted deployments, serverless projects, traffic filters, extensions)
-  Requirements: Canonical specs live in openspec/specs/ (OpenSpec). Authoring conventions will land in dev-docs/high-level/openspec-requirements.md.
+  Requirements: Canonical specs live in openspec/specs/ (OpenSpec). Authoring conventions: dev-docs/high-level/openspec-requirements.md.

--- a/openspec/specs/deployment-traffic-filter/spec.md
+++ b/openspec/specs/deployment-traffic-filter/spec.md
@@ -1,0 +1,367 @@
+# `ec_deployment_traffic_filter`
+
+Resource implementation: `ec/ecresource/trafficfilterresource`
+
+## Purpose
+
+Define schema and behavior for the Elastic Cloud traffic filter **resource** `ec_deployment_traffic_filter` (capability id `deployment-traffic-filter`): ruleset identity and import, type-gated rule validation, CRUD against the hosted Elastic Cloud traffic-filter API (`cloud-sdk-go` `trafficfilterapi`), create/update-then-read, unconfigured-client guard, and mapping between Terraform state and a traffic filter ruleset.
+
+**In scope:** this resource only — attributes, `rule` blocks, validation, lifecycle, and import-by-id.
+
+**Out of scope:**
+
+- Data source `ec_traffic_filter` (different Terraform type name)
+- Resource `ec_deployment_traffic_filter_association`
+- The `traffic_filter` argument on `ec_deployment`
+- Attaching or detaching a ruleset from a deployment except for the association teardown this resource performs on destroy
+
+## Schema
+
+```hcl
+resource "ec_deployment_traffic_filter" "example" {
+  id                 = <computed, string>  # Elastic Cloud ruleset id; UseStateForUnknown
+  name               = <required, string>
+  type               = <required, string>  # ip | vpce | azure_private_endpoint | gcp_private_service_connect_endpoint | remote_cluster
+  region             = <required, string>
+  include_by_default = <optional+computed, bool>  # default false
+  description        = <optional, string>
+
+  rule {  # set nested block; at least one required
+    source                = <optional, string>  # IP, CIDR, VPC endpoint id, or GCP PSC id; documented as required except when type is azure_private_endpoint
+    description           = <optional, string>
+    azure_endpoint_name   = <optional, string>  # only when type is azure_private_endpoint
+    azure_endpoint_guid   = <optional, string>  # only when type is azure_private_endpoint
+    remote_cluster_id     = <optional, string>  # required when type is remote_cluster
+    remote_cluster_org_id = <optional, string>  # required when type is remote_cluster
+    id                    = <computed, string>  # API rule id; unknown when rules change; do not UseStateForUnknown
+  }
+}
+```
+
+## Requirements
+
+### Requirement: Resource type and API client
+
+The resource type name SHALL be `<provider>_deployment_traffic_filter` (with the default provider name, `ec_deployment_traffic_filter`).
+
+The resource SHALL use the configured stateful Elastic Cloud API client (`cloud-sdk-go`) for all CRUD calls. It SHALL NOT use the serverless generated client.
+
+#### Scenario: Type name
+
+- GIVEN the provider type name `ec`
+- WHEN the resource metadata is registered
+- THEN the provider SHALL expose the resource as `ec_deployment_traffic_filter`
+
+### Requirement: Unconfigured API client
+
+Every Create, Read, Update, and Delete call SHALL require a non-nil API client. When the client is missing, the resource SHALL add an error diagnostic with summary `Unconfigured API Client` and SHALL NOT call the traffic-filter API.
+
+#### Scenario: CRUD with no client
+
+- GIVEN the resource has not been configured with an API client
+- WHEN Create, Read, Update, or Delete is invoked
+- THEN the provider SHALL surface an `Unconfigured API Client` error
+- AND SHALL NOT send a traffic-filter API request
+
+### Requirement: Ruleset identity
+
+The Terraform `id` SHALL be the Elastic Cloud traffic filter ruleset identifier returned by the create API. The attribute SHALL be computed and SHALL use `UseStateForUnknown` so the ruleset id is not shown as unknown on later plans.
+
+#### Scenario: Id after create
+
+- GIVEN a successful create whose API response includes ruleset id `abc123`
+- WHEN state is persisted
+- THEN the provider SHALL set `id` to `abc123`
+
+### Requirement: Required ruleset attributes
+
+`name`, `type`, and `region` SHALL be required. `description` SHALL be optional. Documented `type` values are `ip`, `vpce`, `azure_private_endpoint`, `gcp_private_service_connect_endpoint`, and `remote_cluster`.
+
+`include_by_default` SHALL be optional and computed. When omitted, the plan SHALL default it to `false`.
+
+#### Scenario: Omit include_by_default
+
+- GIVEN a configuration that does not set `include_by_default`
+- WHEN the configuration is planned
+- THEN the provider SHALL plan `include_by_default` as `false`
+
+#### Scenario: Set include_by_default true
+
+- GIVEN a configuration with `include_by_default = true`
+- WHEN Create is called
+- THEN the provider SHALL send `include_by_default` as true in the create request
+
+### Requirement: At least one rule
+
+The `rule` block SHALL be a set of nested objects. The resource SHALL require at least one rule (`setvalidator.SizeAtLeast(1)`).
+
+#### Scenario: No rule blocks
+
+- GIVEN a configuration with `name`, `type`, and `region` but no `rule` blocks
+- WHEN the configuration is validated
+- THEN the provider SHALL reject the configuration because the rule set size is below 1
+
+#### Scenario: One rule accepted
+
+- GIVEN a configuration with a single valid `rule` block
+- WHEN the configuration is validated
+- THEN the provider SHALL accept the rule set
+
+### Requirement: Computed rule id
+
+Each rule's `id` SHALL be computed from the API (the Elastic Cloud rule identifier). The attribute SHALL NOT use `UseStateForUnknown`. When the planned set of rules differs from state, each rule `id` SHALL be unknown in the plan (`StringIsUnknownIfRulesChange`).
+
+Because unknown rule ids are omitted from the update payload, an apply that changes rules MAY receive new rule ids from the API.
+
+#### Scenario: Rule ids after create
+
+- GIVEN a newly created ruleset whose GET response includes rule ids
+- WHEN Create finishes
+- THEN the provider SHALL store those rule `id` values in state
+
+#### Scenario: Rules change marks rule ids unknown
+
+- GIVEN an existing ruleset in state with computed rule ids
+- AND the configuration adds, removes, or replaces a `rule` block
+- WHEN a plan is computed
+- THEN the provider SHALL set each rule `id` to unknown in the plan
+
+### Requirement: Type-gated rule validation
+
+`ValidateConfig` SHALL type-gate rule attributes. It SHALL skip that gating when `type` or `rule` is unknown (for example when those values come from variables that are not yet known).
+
+When `type` is not `remote_cluster`, a rule SHALL NOT set `remote_cluster_id` or `remote_cluster_org_id`. When `type` is `remote_cluster` and both values are known, both `remote_cluster_id` and `remote_cluster_org_id` SHALL be set; otherwise the resource SHALL add a `Missing Required Attributes` error.
+
+When `type` is not `azure_private_endpoint`, a rule SHALL NOT set `azure_endpoint_name` or `azure_endpoint_guid`.
+
+The resource SHALL NOT Terraform-validate that `source` is present or absent for a given `type`; `source` is optional in the schema and is documented as required except when `type` is `azure_private_endpoint`. Azure endpoint fields are optional in the schema even when `type` is `azure_private_endpoint`.
+
+#### Scenario: Skip gating while type is unknown
+
+- GIVEN `type` is unknown at validate time
+- WHEN `ValidateConfig` runs
+- THEN the provider SHALL NOT emit type-gating diagnostics for rule attributes
+
+#### Scenario: Remote cluster fields on an IP ruleset
+
+- GIVEN `type = "ip"`
+- AND a `rule` sets `remote_cluster_id` and/or `remote_cluster_org_id`
+- WHEN the configuration is validated
+- THEN the provider SHALL add an `Invalid Rule Configuration` error stating those attributes can only be specified when `type` is `remote_cluster`
+
+#### Scenario: Remote cluster type missing a field
+
+- GIVEN `type = "remote_cluster"`
+- AND a `rule` sets `remote_cluster_id` but omits `remote_cluster_org_id`
+- WHEN the configuration is validated
+- THEN the provider SHALL add a `Missing Required Attributes` error stating both `remote_cluster_id` and `remote_cluster_org_id` are required
+
+#### Scenario: Azure fields on an IP ruleset
+
+- GIVEN `type = "ip"`
+- AND a `rule` sets `azure_endpoint_name` and/or `azure_endpoint_guid`
+- WHEN the configuration is validated
+- THEN the provider SHALL add an `Invalid Rule Configuration` error stating those attributes can only be specified when `type` is `azure_private_endpoint`
+
+#### Scenario: Azure private endpoint rule
+
+- GIVEN `type = "azure_private_endpoint"`
+- AND a `rule` sets `azure_endpoint_name` and `azure_endpoint_guid`
+- WHEN the configuration is validated
+- THEN the provider SHALL accept the configuration
+
+#### Scenario: Remote cluster rule
+
+- GIVEN `type = "remote_cluster"`
+- AND a `rule` sets both `remote_cluster_id` and `remote_cluster_org_id`
+- WHEN the configuration is validated
+- THEN the provider SHALL accept the configuration
+
+### Requirement: Create then read
+
+Create SHALL expand the plan into a `TrafficFilterRulesetRequest` and call `trafficfilterapi.Create`. On API error, the resource SHALL surface the error and SHALL NOT persist state.
+
+On success, the resource SHALL set `id` from the create response, then SHALL read the ruleset back (`trafficfilterapi.Get` with `include_associations=false`) and persist state from that read. If the ruleset is not found after create, the resource SHALL add the error `Failed to read deployment traffic filter ruleset after create.`, SHALL remove the resource from state, and SHALL NOT leave a partial resource.
+
+#### Scenario: Create IP ruleset
+
+- GIVEN a plan with `type = "ip"`, a name, a region, and one or more `rule` blocks with `source` set
+- WHEN Create is called
+- THEN the provider SHALL call `trafficfilterapi.Create` with that name, type, region, and rules
+- AND SHALL GET the ruleset by the returned id
+- AND SHALL persist attributes from the GET response
+
+#### Scenario: Create remote cluster ruleset
+
+- GIVEN a plan with `type = "remote_cluster"` and a rule with `remote_cluster_id` and `remote_cluster_org_id`
+- WHEN Create is called
+- THEN the provider SHALL include `remote_cluster_id` and `remote_cluster_org_id` on the rule in the create request
+
+#### Scenario: Create Azure private endpoint ruleset
+
+- GIVEN a plan with `type = "azure_private_endpoint"` and a rule with `azure_endpoint_name` and `azure_endpoint_guid`
+- WHEN Create is called
+- THEN the provider SHALL include those Azure fields on the rule in the create request
+
+#### Scenario: Create API error
+
+- GIVEN the create API returns an error
+- WHEN Create is called
+- THEN the provider SHALL surface the error
+- AND SHALL NOT persist state
+
+#### Scenario: Missing after create
+
+- GIVEN create succeeds
+- AND the subsequent GET reports the ruleset as not found
+- WHEN Create finishes
+- THEN the provider SHALL surface `Failed to read deployment traffic filter ruleset after create.`
+- AND SHALL remove the resource from state
+
+### Requirement: Read
+
+Read SHALL call `trafficfilterapi.Get` with the state `id` and `include_associations=false`.
+
+When the API reports the ruleset as not found, the resource SHALL be removed from state with no error. Any other API error SHALL be surfaced and state SHALL be left unchanged.
+
+#### Scenario: Read existing ruleset
+
+- GIVEN a ruleset exists in Elastic Cloud
+- WHEN Read is called
+- THEN the provider SHALL map name, type, region, description, `include_by_default`, and rules into state
+
+#### Scenario: Read missing ruleset
+
+- GIVEN the ruleset was deleted out of band
+- WHEN Read is called
+- THEN the provider SHALL remove the resource from state with no error
+
+#### Scenario: Read API error
+
+- GIVEN GET returns a non-not-found error
+- WHEN Read is called
+- THEN the provider SHALL surface the error
+- AND SHALL NOT remove the resource from state as not found
+
+### Requirement: Update then read
+
+Update SHALL expand the plan into a `TrafficFilterRulesetRequest` and call `trafficfilterapi.Update` with the existing ruleset `id`. Known (non-null, non-unknown) rule `id` values SHALL be included on the corresponding rules in the request.
+
+On API error, the resource SHALL surface the error. On success, the resource SHALL read the ruleset back and persist state from that read. If the ruleset is not found after update, the resource SHALL add the error `Failed to read deployment traffic filter ruleset after update.` and SHALL remove the resource from state.
+
+#### Scenario: Update include_by_default
+
+- GIVEN a ruleset exists
+- AND the plan changes `include_by_default`
+- WHEN Update is called
+- THEN the provider SHALL call `trafficfilterapi.Update` with the planned ruleset
+- AND SHALL GET the ruleset
+- AND SHALL persist attributes from the GET response
+
+#### Scenario: Update sends known rule ids
+
+- GIVEN state has rule ids assigned by the API
+- AND the planned rules are unchanged enough that those ids remain known
+- WHEN Update is called
+- THEN the provider SHALL include those rule ids in the update request
+
+#### Scenario: Missing after update
+
+- GIVEN update succeeds
+- AND the subsequent GET reports the ruleset as not found
+- WHEN Update finishes
+- THEN the provider SHALL surface `Failed to read deployment traffic filter ruleset after update.`
+- AND SHALL remove the resource from state
+
+### Requirement: Delete disassociates then deletes
+
+Delete SHALL GET the ruleset with `include_associations=true`. If that GET reports not found, delete SHALL succeed without further API calls.
+
+For each association on the ruleset, Delete SHALL call `trafficfilterapi.DeleteAssociation`. A not-found error on an association SHALL be ignored; any other association-delete error SHALL be surfaced and SHALL stop deletion.
+
+After associations are cleared, Delete SHALL call `trafficfilterapi.Delete`. A not-found error on the ruleset delete SHALL be treated as success. Any other delete error SHALL be surfaced.
+
+#### Scenario: Delete ruleset with no associations
+
+- GIVEN a ruleset exists with no associations
+- WHEN Destroy is called
+- THEN the provider SHALL GET the ruleset with associations
+- AND SHALL call `trafficfilterapi.Delete`
+- AND SHALL remove the resource from state
+
+#### Scenario: Delete ruleset with associations
+
+- GIVEN a ruleset is associated with one or more deployments
+- WHEN Destroy is called
+- THEN the provider SHALL delete each association
+- AND SHALL then delete the ruleset
+
+#### Scenario: Association already gone
+
+- GIVEN an association delete returns not found
+- WHEN Destroy is running
+- THEN the provider SHALL ignore that error and continue deleting remaining associations and the ruleset
+
+#### Scenario: Ruleset already gone on GET
+
+- GIVEN GET-with-associations reports the ruleset as not found
+- WHEN Destroy is called
+- THEN the provider SHALL treat delete as success with no error
+
+#### Scenario: Ruleset already gone on DELETE
+
+- GIVEN GET succeeds
+- AND `trafficfilterapi.Delete` reports not found
+- WHEN Destroy is called
+- THEN the provider SHALL treat delete as success with no error
+
+#### Scenario: Association delete fails
+
+- GIVEN an association delete returns a non-not-found error
+- WHEN Destroy is called
+- THEN the provider SHALL surface the error
+- AND SHALL NOT proceed to delete the ruleset
+
+### Requirement: Import by id
+
+Import SHALL accept the Elastic Cloud ruleset id as the import ID and SHALL set Terraform `id` to that value. A subsequent Read SHALL populate the remaining attributes from the API.
+
+#### Scenario: Import existing ruleset
+
+- GIVEN a ruleset exists with id `320b7b540dfc967a7a649c18e2fce4ed`
+- WHEN `terraform import ec_deployment_traffic_filter.name 320b7b540dfc967a7a649c18e2fce4ed` is run
+- THEN the provider SHALL set `id` to `320b7b540dfc967a7a649c18e2fce4ed`
+- AND SHALL read the ruleset and populate name, type, region, description, `include_by_default`, and rules
+
+### Requirement: State mapping
+
+Expand SHALL send `name`, `type`, `region`, `include_by_default`, and every planned rule. A rule `source`, `description`, Azure endpoint fields, and remote-cluster fields SHALL be sent when they are known and non-null. A known non-null rule `id` SHALL be sent; unknown or null rule ids SHALL be omitted.
+
+Flatten SHALL map empty API strings for ruleset `description` and for each rule's `source`, `description`, Azure endpoint fields, and remote-cluster fields to null in Terraform state (not empty strings). Non-empty API values SHALL be stored as strings. Rule `id` SHALL be stored from the API rule id.
+
+#### Scenario: Empty ruleset description
+
+- GIVEN the API returns an empty ruleset description
+- WHEN Read maps the response
+- THEN `description` in state SHALL be null
+
+#### Scenario: Flatten remote cluster rule
+
+- GIVEN the API returns a rule with `remote_cluster_id` and `remote_cluster_org_id` and no `source`
+- WHEN Read maps the response
+- THEN the rule in state SHALL have those remote-cluster attributes set
+- AND `source` SHALL be null
+
+#### Scenario: Flatten Azure private endpoint rule
+
+- GIVEN the API returns a rule with `azure_endpoint_name` and `azure_endpoint_guid` and no `source`
+- WHEN Read maps the response
+- THEN the rule in state SHALL have those Azure attributes set
+- AND `source` SHALL be null
+
+#### Scenario: Flatten IP rule
+
+- GIVEN the API returns a rule with `source` `1.1.1.1` and a rule id
+- WHEN Read maps the response
+- THEN the rule in state SHALL have `source` `1.1.1.1` and that `id`
+- AND Azure and remote-cluster attributes SHALL be null

--- a/openspec/specs/deployment-traffic-filter/spec.md
+++ b/openspec/specs/deployment-traffic-filter/spec.md
@@ -4,7 +4,7 @@ Resource implementation: `ec/ecresource/trafficfilterresource`
 
 ## Purpose
 
-Define schema and behavior for the Elastic Cloud traffic filter **resource** `ec_deployment_traffic_filter` (capability id `deployment-traffic-filter`): ruleset identity and import, type-gated rule validation, CRUD against the hosted Elastic Cloud traffic-filter API (`cloud-sdk-go` `trafficfilterapi`), create/update-then-read, unconfigured-client guard, and mapping between Terraform state and a traffic filter ruleset.
+Define schema and behavior for the Elastic Cloud traffic filter **resource** `ec_deployment_traffic_filter` (capability id `deployment-traffic-filter`): ruleset identity and import, type-gated rule validation, CRUD against the hosted Elastic Cloud traffic-filter API, create/update-then-read, unconfigured-client guard, and mapping between Terraform state and a traffic filter ruleset.
 
 **In scope:** this resource only — attributes, `rule` blocks, validation, lifecycle, and import-by-id.
 
@@ -19,7 +19,7 @@ Define schema and behavior for the Elastic Cloud traffic filter **resource** `ec
 
 ```hcl
 resource "ec_deployment_traffic_filter" "example" {
-  id                 = <computed, string>  # Elastic Cloud ruleset id; UseStateForUnknown
+  id                 = <computed, string>  # Elastic Cloud ruleset id; kept from state on later plans
   name               = <required, string>
   type               = <required, string>  # ip | vpce | azure_private_endpoint | gcp_private_service_connect_endpoint | remote_cluster
   region             = <required, string>
@@ -33,7 +33,7 @@ resource "ec_deployment_traffic_filter" "example" {
     azure_endpoint_guid   = <optional, string>  # only when type is azure_private_endpoint
     remote_cluster_id     = <optional, string>  # required when type is remote_cluster
     remote_cluster_org_id = <optional, string>  # required when type is remote_cluster
-    id                    = <computed, string>  # API rule id; unknown when rules change; do not UseStateForUnknown
+    id                    = <computed, string>  # API rule id; unknown in the plan when rules change
   }
 }
 ```
@@ -65,7 +65,7 @@ Every Create, Read, Update, and Delete call SHALL require a non-nil API client. 
 
 ### Requirement: Ruleset identity
 
-The Terraform `id` SHALL be the Elastic Cloud traffic filter ruleset identifier returned by the create API. The attribute SHALL be computed and SHALL use `UseStateForUnknown` so the ruleset id is not shown as unknown on later plans.
+The Terraform `id` SHALL be the Elastic Cloud traffic filter ruleset identifier returned by the create API. The attribute SHALL be computed. After create, later plans SHALL keep the existing ruleset `id` rather than showing it as unknown.
 
 #### Scenario: Id after create
 
@@ -93,7 +93,7 @@ The Terraform `id` SHALL be the Elastic Cloud traffic filter ruleset identifier 
 
 ### Requirement: At least one rule
 
-The `rule` block SHALL be a set of nested objects. The resource SHALL require at least one rule (`setvalidator.SizeAtLeast(1)`).
+The `rule` block SHALL be a set of nested objects. The resource SHALL require at least one rule.
 
 #### Scenario: No rule blocks
 
@@ -109,7 +109,7 @@ The `rule` block SHALL be a set of nested objects. The resource SHALL require at
 
 ### Requirement: Computed rule id
 
-Each rule's `id` SHALL be computed from the API (the Elastic Cloud rule identifier). The attribute SHALL NOT use `UseStateForUnknown`. When the planned set of rules differs from state, each rule `id` SHALL be unknown in the plan (`StringIsUnknownIfRulesChange`).
+Each rule's `id` SHALL be computed from the API (the Elastic Cloud rule identifier). When the planned set of rules differs from state, each rule `id` SHALL be unknown in the plan (the ruleset `id` is not treated this way).
 
 Because unknown rule ids are omitted from the update payload, an apply that changes rules MAY receive new rule ids from the API.
 
@@ -128,7 +128,7 @@ Because unknown rule ids are omitted from the update payload, an apply that chan
 
 ### Requirement: Type-gated rule validation
 
-`ValidateConfig` SHALL type-gate rule attributes. It SHALL skip that gating when `type` or `rule` is unknown (for example when those values come from variables that are not yet known).
+Config validation SHALL type-gate rule attributes. It SHALL skip that gating when `type` or `rule` is unknown (for example when those values come from variables that are not yet known).
 
 When `type` is not `remote_cluster`, a rule SHALL NOT set `remote_cluster_id` or `remote_cluster_org_id`. When `type` is `remote_cluster` and both values are known, both `remote_cluster_id` and `remote_cluster_org_id` SHALL be set; otherwise the resource SHALL add a `Missing Required Attributes` error.
 
@@ -139,7 +139,7 @@ The resource SHALL NOT Terraform-validate that `source` is present or absent for
 #### Scenario: Skip gating while type is unknown
 
 - GIVEN `type` is unknown at validate time
-- WHEN `ValidateConfig` runs
+- WHEN config is validated
 - THEN the provider SHALL NOT emit type-gating diagnostics for rule attributes
 
 #### Scenario: Remote cluster fields on an IP ruleset
@@ -179,15 +179,15 @@ The resource SHALL NOT Terraform-validate that `source` is present or absent for
 
 ### Requirement: Create then read
 
-Create SHALL expand the plan into a `TrafficFilterRulesetRequest` and call `trafficfilterapi.Create`. On API error, the resource SHALL surface the error and SHALL NOT persist state.
+Create SHALL send the planned ruleset to the Elastic Cloud traffic-filter create API. On API error, the resource SHALL surface the error and SHALL NOT persist state.
 
-On success, the resource SHALL set `id` from the create response, then SHALL read the ruleset back (`trafficfilterapi.Get` with `include_associations=false`) and persist state from that read. If the ruleset is not found after create, the resource SHALL add the error `Failed to read deployment traffic filter ruleset after create.`, SHALL remove the resource from state, and SHALL NOT leave a partial resource.
+On success, the resource SHALL set `id` from the create response, then SHALL GET the ruleset (without associations) and persist state from that read. If the ruleset is not found after create, the resource SHALL add the error `Failed to read deployment traffic filter ruleset after create.`, SHALL remove the resource from state, and SHALL NOT leave a partial resource.
 
 #### Scenario: Create IP ruleset
 
 - GIVEN a plan with `type = "ip"`, a name, a region, and one or more `rule` blocks with `source` set
 - WHEN Create is called
-- THEN the provider SHALL call `trafficfilterapi.Create` with that name, type, region, and rules
+- THEN the provider SHALL create the ruleset with that name, type, region, and rules
 - AND SHALL GET the ruleset by the returned id
 - AND SHALL persist attributes from the GET response
 
@@ -220,7 +220,7 @@ On success, the resource SHALL set `id` from the create response, then SHALL rea
 
 ### Requirement: Read
 
-Read SHALL call `trafficfilterapi.Get` with the state `id` and `include_associations=false`.
+Read SHALL GET the ruleset by the state `id` without requesting associations.
 
 When the API reports the ruleset as not found, the resource SHALL be removed from state with no error. Any other API error SHALL be surfaced and state SHALL be left unchanged.
 
@@ -245,16 +245,16 @@ When the API reports the ruleset as not found, the resource SHALL be removed fro
 
 ### Requirement: Update then read
 
-Update SHALL expand the plan into a `TrafficFilterRulesetRequest` and call `trafficfilterapi.Update` with the existing ruleset `id`. Known (non-null, non-unknown) rule `id` values SHALL be included on the corresponding rules in the request.
+Update SHALL send the planned ruleset to the Elastic Cloud traffic-filter update API using the existing ruleset `id`. Known (non-null, non-unknown) rule `id` values SHALL be included on the corresponding rules in the request.
 
-On API error, the resource SHALL surface the error. On success, the resource SHALL read the ruleset back and persist state from that read. If the ruleset is not found after update, the resource SHALL add the error `Failed to read deployment traffic filter ruleset after update.` and SHALL remove the resource from state.
+On API error, the resource SHALL surface the error. On success, the resource SHALL GET the ruleset and persist state from that read. If the ruleset is not found after update, the resource SHALL add the error `Failed to read deployment traffic filter ruleset after update.` and SHALL remove the resource from state.
 
 #### Scenario: Update include_by_default
 
 - GIVEN a ruleset exists
 - AND the plan changes `include_by_default`
 - WHEN Update is called
-- THEN the provider SHALL call `trafficfilterapi.Update` with the planned ruleset
+- THEN the provider SHALL update the ruleset with the planned attributes
 - AND SHALL GET the ruleset
 - AND SHALL persist attributes from the GET response
 
@@ -275,18 +275,18 @@ On API error, the resource SHALL surface the error. On success, the resource SHA
 
 ### Requirement: Delete disassociates then deletes
 
-Delete SHALL GET the ruleset with `include_associations=true`. If that GET reports not found, delete SHALL succeed without further API calls.
+Delete SHALL GET the ruleset including associations. If that GET reports not found, delete SHALL succeed without further API calls.
 
-For each association on the ruleset, Delete SHALL call `trafficfilterapi.DeleteAssociation`. A not-found error on an association SHALL be ignored; any other association-delete error SHALL be surfaced and SHALL stop deletion.
+For each association on the ruleset, Delete SHALL delete the association. A not-found error on an association SHALL be ignored; any other association-delete error SHALL be surfaced and SHALL stop deletion.
 
-After associations are cleared, Delete SHALL call `trafficfilterapi.Delete`. A not-found error on the ruleset delete SHALL be treated as success. Any other delete error SHALL be surfaced.
+After associations are cleared, Delete SHALL delete the ruleset. A not-found error on the ruleset delete SHALL be treated as success. Any other delete error SHALL be surfaced.
 
 #### Scenario: Delete ruleset with no associations
 
 - GIVEN a ruleset exists with no associations
 - WHEN Destroy is called
 - THEN the provider SHALL GET the ruleset with associations
-- AND SHALL call `trafficfilterapi.Delete`
+- AND SHALL delete the ruleset
 - AND SHALL remove the resource from state
 
 #### Scenario: Delete ruleset with associations
@@ -311,7 +311,7 @@ After associations are cleared, Delete SHALL call `trafficfilterapi.Delete`. A n
 #### Scenario: Ruleset already gone on DELETE
 
 - GIVEN GET succeeds
-- AND `trafficfilterapi.Delete` reports not found
+- AND the ruleset delete reports not found
 - WHEN Destroy is called
 - THEN the provider SHALL treat delete as success with no error
 

--- a/openspec/specs/stack/spec.md
+++ b/openspec/specs/stack/spec.md
@@ -1,0 +1,210 @@
+# `ec_stack` data source
+
+Capability id: `stack`. Implementation: `ec/ecdatasource/stackdatasource`.
+
+## Purpose
+
+Capture the **current** behavior of the Terraform data source `ec_stack`, which looks up one Elastic Cloud stack pack (version plus per-kind metadata) for a region. This is a copyable canonical exemplar of behavior already in the provider, not a change proposal.
+
+**In scope**
+
+- Data source `ec_stack` only (Plugin Framework; stateful Elastic Cloud API).
+- Lookup of a single stack from the region list: literal `latest`, optional `lock` pin, or a Go `version_regex`.
+- Flatten of computed stack metadata and per-kind config (denylist, capacity constraints, docker image, Elasticsearch plugins).
+- Unconfigured-client guard and error diagnostics for list failure, no match, and invalid regex.
+
+**Out of scope**
+
+- `ec_deployment` (or any other resource) version arguments.
+- Changing the lookup algorithm (including any special-case for patch lines such as 7.17).
+- Resources, serverless projects, or unimplemented fields (for example `node_types` on kind configs).
+
+## Schema
+
+```hcl
+data "ec_stack" "example" {
+  version_regex = <required, string>  # Go regexp, or the literal "latest"
+  region        = <required, string>  # ESS region; ECE installations use "ece-region"
+  lock          = <optional, bool>    # when true, pin "latest" to an already-selected version
+
+  # Computed
+  id                  = <computed, string>         # same as version
+  version             = <computed, string>
+  accessible          = <computed, bool>           # ESS; not meaningful on ECE
+  min_upgradable_from = <computed, string>
+  upgradable_to       = <computed, list(string)>
+  allowlisted         = <computed, bool>           # ESS; not meaningful on ECE
+
+  # Computed lists, size at most 1
+  apm = <computed, list(object)> [{
+    denylist                 = <computed, list(string)>
+    capacity_constraints_max = <computed, int64>
+    capacity_constraints_min = <computed, int64>
+    compatible_node_types    = <computed, list(string)>
+    docker_image             = <computed, string>
+  }]
+  kibana            = <computed, list(object)>  # same object shape as apm
+  enterprise_search = <computed, list(object)>  # same object shape as apm
+  elasticsearch     = <computed, list(object)> [{
+    denylist                 = <computed, list(string)>
+    capacity_constraints_max = <computed, int64>
+    capacity_constraints_min = <computed, int64>
+    compatible_node_types    = <computed, list(string)>
+    docker_image             = <computed, string>
+    plugins                  = <computed, list(string)>
+    default_plugins          = <computed, list(string)>
+  }]
+}
+```
+
+## Requirements
+
+### Requirement: Data source schema
+
+The provider SHALL register a data source of type `ec_stack`. `version_regex` and `region` SHALL be required strings. `lock` SHALL be an optional bool (unset is treated as false). The data source SHALL expose computed `id`, `version`, `accessible`, `min_upgradable_from`, `upgradable_to` (list of strings), `allowlisted`, and the nested lists `apm`, `kibana`, `enterprise_search`, and `elasticsearch`. Each nested list SHALL allow at most one object. Elasticsearch objects SHALL also include computed `plugins` and `default_plugins`; the other kinds SHALL NOT.
+
+#### Scenario: Required version_regex enforced
+
+- GIVEN a data source configuration that omits `version_regex`
+- WHEN Terraform validates the configuration
+- THEN Terraform SHALL reject the configuration with a validation error
+
+#### Scenario: Required region enforced
+
+- GIVEN a data source configuration that omits `region`
+- WHEN Terraform validates the configuration
+- THEN Terraform SHALL reject the configuration with a validation error
+
+### Requirement: Unconfigured API client
+
+On read, if the stateful Elastic Cloud API client has not been configured, the data source SHALL return an error diagnostic and SHALL NOT call the stack list API.
+
+#### Scenario: Read with no client
+
+- GIVEN the provider has not configured an API client on the data source
+- WHEN the data source is read
+- THEN the provider SHALL return an error diagnostic with summary `Unconfigured API Client`
+
+### Requirement: List stacks for the configured region
+
+The data source SHALL list stack packs for the configured `region` through the Elastic Cloud stack list API (`stackapi.List`). The provider SHALL pass `region` through unchanged (Elastic Cloud Enterprise installations use `ece-region`) and SHALL NOT re-sort the returned list (the API returns latest-first). When the list call fails, the data source SHALL return an error diagnostic and SHALL NOT apply version filters.
+
+#### Scenario: Successful list
+
+- GIVEN a configured API client and `region = "us-east-1"`
+- WHEN the data source is read
+- THEN the provider SHALL list stacks for `us-east-1`
+
+#### Scenario: ECE region passed through
+
+- GIVEN a configured API client and `region = "ece-region"`
+- WHEN the data source is read
+- THEN the provider SHALL list stacks for `ece-region`
+
+#### Scenario: List API failure
+
+- GIVEN the stack list API returns an error
+- WHEN the data source is read
+- THEN the provider SHALL return an error diagnostic indicating it failed to retrieve the specified stack version
+
+### Requirement: `latest` selects the first listed stack
+
+When `version_regex` is the literal string `latest` and the lookup is not pinned by `lock` (see below), the data source SHALL return the first stack in the list (`stacks[0]`).
+
+#### Scenario: Unlocked latest
+
+- GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]` (latest-first)
+- AND `version_regex = "latest"`
+- AND `lock` is false or unset
+- WHEN the data source resolves a stack
+- THEN the provider SHALL select version `7.9.1`
+
+### Requirement: `lock` pins `latest` to an already-selected version
+
+When `version_regex` is `latest`, `lock` is true, and a stack `version` is already set on the data source, the provider SHALL treat the lookup expression as that version (pin) instead of taking the first listed stack. `lock` SHALL have no effect when `version_regex` is not `latest`, or when `lock` is true but no version has been selected yet (first read SHALL behave as unlocked `latest`).
+
+#### Scenario: latest plus lock pins existing version
+
+- GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]`
+- AND `version_regex = "latest"`
+- AND `lock` is true
+- AND `version` is already `7.8.1`
+- WHEN the data source resolves a stack
+- THEN the provider SHALL select version `7.8.1`
+
+#### Scenario: First locked latest has no version yet
+
+- GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]`
+- AND `version_regex = "latest"`
+- AND `lock` is true
+- AND `version` is not set
+- WHEN the data source resolves a stack
+- THEN the provider SHALL select version `7.9.1`
+
+#### Scenario: lock ignored for a non-latest regex
+
+- GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]`
+- AND `version_regex = "7.8.?"`
+- AND `lock` is true
+- AND `version` is `7.9.1`
+- WHEN the data source resolves a stack
+- THEN the provider SHALL select version `7.8.1`
+
+### Requirement: `version_regex` selects the first matching stack
+
+When `version_regex` is not the literal `latest` (including after a lock pin rewrites `latest` to a version string), the provider SHALL compile `version_regex` as a Go regular expression and return the **first** stack whose `version` matches, in list order. Because the list is latest-first, the first match is the newest matching stack.
+
+#### Scenario: Exact version string
+
+- GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]`
+- AND `version_regex = "7.9.0"`
+- WHEN the data source resolves a stack
+- THEN the provider SHALL select version `7.9.0`
+
+#### Scenario: Patch regex
+
+- GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]`
+- AND `version_regex = "7.8.?"`
+- WHEN the data source resolves a stack
+- THEN the provider SHALL select version `7.8.1`
+
+### Requirement: Lookup diagnostics
+
+If `version_regex` is not valid Go regexp syntax, the data source SHALL return an error diagnostic that it failed to compile `version_regex`. If no listed stack matches, the data source SHALL return an error diagnostic asking for a valid `version_regex`. Data sources SHALL error on a missing match rather than producing empty state.
+
+#### Scenario: Invalid regex
+
+- GIVEN `version_regex = "(?!"`
+- WHEN the data source resolves a stack
+- THEN the provider SHALL return an error diagnostic that it failed to compile `version_regex`
+
+#### Scenario: No matching stack
+
+- GIVEN the list `[{version: "7.8.0"}]`
+- AND `version_regex = "7.9.1"`
+- WHEN the data source resolves a stack
+- THEN the provider SHALL return an error diagnostic matching `failed to obtain a stack version matching "7.9.1": please specify a valid version_regex`
+
+### Requirement: Flatten selected stack into state
+
+On a successful lookup, the data source SHALL write the selected stack into state: `id` and `version` SHALL equal the stack version string; `accessible`, `min_upgradable_from`, `upgradable_to`, and `allowlisted` SHALL be populated from the corresponding stack fields when present. Each of `apm`, `kibana`, `enterprise_search`, and `elasticsearch` SHALL be a list of one object when that kind has config (denylist from the API denylist/blacklist, capacity min/max, compatible node types, docker image; Elasticsearch also plugins and default plugins), and SHALL be empty/null when that kind is absent or empty.
+
+#### Scenario: Metadata after a successful read
+
+- GIVEN a selected stack with version `7.9.1`, accessible and allowlisted true, and `min_upgradable_from = "6.8.0"`
+- WHEN the data source writes state
+- THEN `id` and `version` SHALL equal `7.9.1`
+- AND `accessible` and `allowlisted` SHALL be true
+- AND `min_upgradable_from` SHALL equal `6.8.0`
+
+#### Scenario: Elasticsearch kind config
+
+- GIVEN the selected stack includes Elasticsearch denylist, capacity constraints, docker image, plugins, and default plugins
+- WHEN the data source writes state
+- THEN `elasticsearch` SHALL contain one object with those fields populated (`denylist`, `capacity_constraints_max`, `capacity_constraints_min`, `docker_image`, `plugins`, `default_plugins`)
+
+#### Scenario: Empty kind omitted
+
+- GIVEN the selected stack has no APM config (nil or empty)
+- WHEN the data source writes state
+- THEN `apm` SHALL be empty/null rather than a list of one empty object

--- a/openspec/specs/stack/spec.md
+++ b/openspec/specs/stack/spec.md
@@ -110,7 +110,7 @@ The data source SHALL list stack packs for the configured `region` through the E
 
 ### Requirement: `latest` selects the first listed stack
 
-When `version_regex` is the literal string `latest`, the data source SHALL return the first stack in the list. This path SHALL NOT use the no-match diagnostic used for regex lookup. An empty list is unhandled: the data source does not check length before selecting the first stack.
+When `version_regex` is the literal string `latest`, the data source SHALL return the first stack in the list.
 
 #### Scenario: latest
 
@@ -119,18 +119,9 @@ When `version_regex` is the literal string `latest`, the data source SHALL retur
 - WHEN the data source resolves a stack
 - THEN the provider SHALL select version `7.9.1`
 
-#### Scenario: latest with an empty list
-
-- GIVEN the stack list is empty
-- AND `version_regex = "latest"`
-- WHEN the data source resolves a stack
-- THEN the provider SHALL NOT return the no-match diagnostic used for regex lookup
-
 ### Requirement: `lock` does not change lookup on Read
 
 `lock` SHALL be an optional configuration attribute. Read SHALL load **configuration only** (`version` is computed and is not in config), so a previously selected version is not available on a later Read. Therefore `lock = true` with `version_regex = "latest"` SHALL still select the first listed stack, the same as unlocked `latest`. `lock` SHALL NOT change lookup when `version_regex` is not `latest`.
-
-Schema copy describes `lock` as pinning `latest` so a new stack release does not cascade. That advertised pin is **not** Terraform-observable on Read.
 
 #### Scenario: locked latest still takes the first stack
 
@@ -207,3 +198,24 @@ On a successful lookup, the data source SHALL write the selected stack into stat
 - GIVEN the selected stack has no APM config (nil or empty)
 - WHEN the data source writes state
 - THEN `apm` SHALL be empty/null rather than a list of one empty object
+
+## Known gaps (non-normative)
+
+These record limitations of the current implementation. A later fix is a change that
+updates the `SHALL`s above; do not treat this section as the desired contract.
+
+### `lock` does not pin
+
+Schema and registry docs describe `lock` as pinning the `latest` result so a new
+stack release does not cascade. `stackFromFilters` still implements that pin when
+`version` is non-empty, and the unit test `"returns the latest stackpack with a
+locked version"` expects it. Read loads configuration only, so `version` is empty
+and the pin is not Terraform-observable. A change that makes `lock` work should
+replace the Read requirement above.
+
+### `latest` with an empty list
+
+The `latest` path indexes the first list element with no length check. An empty
+list panics; it does not use the regex no-match diagnostic. A change should add
+an explicit error (or documented empty handling) and a scenario with a positive
+THEN.

--- a/openspec/specs/stack/spec.md
+++ b/openspec/specs/stack/spec.md
@@ -9,9 +9,10 @@ Capture the **current** behavior of the Terraform data source `ec_stack`, which 
 **In scope**
 
 - Data source `ec_stack` only (Plugin Framework; stateful Elastic Cloud API).
-- Lookup of a single stack from the region list: literal `latest`, optional `lock` pin, or a Go `version_regex`.
+- Lookup of a single stack from the region list: literal `latest` or a Go `version_regex`.
+- The optional `lock` attribute as it actually behaves on Read (it does not pin a previously selected version).
 - Flatten of computed stack metadata and per-kind config (denylist, capacity constraints, docker image, Elasticsearch plugins).
-- Unconfigured-client guard and error diagnostics for list failure, no match, and invalid regex.
+- Unconfigured-client guard and error diagnostics for list failure, no-match (regex path), and invalid regex.
 
 **Out of scope**
 
@@ -25,7 +26,7 @@ Capture the **current** behavior of the Terraform data source `ec_stack`, which 
 data "ec_stack" "example" {
   version_regex = <required, string>  # Go regexp, or the literal "latest"
   region        = <required, string>  # ESS region; ECE installations use "ece-region"
-  lock          = <optional, bool>    # when true, pin "latest" to an already-selected version
+  lock          = <optional, bool>    # accepted in config; does not change lookup (see Requirements)
 
   # Computed
   id                  = <computed, string>         # same as version
@@ -87,7 +88,7 @@ On read, if the stateful Elastic Cloud API client has not been configured, the d
 
 ### Requirement: List stacks for the configured region
 
-The data source SHALL list stack packs for the configured `region` through the Elastic Cloud stack list API (`stackapi.List`). The provider SHALL pass `region` through unchanged (Elastic Cloud Enterprise installations use `ece-region`) and SHALL NOT re-sort the returned list (the API returns latest-first). When the list call fails, the data source SHALL return an error diagnostic and SHALL NOT apply version filters.
+The data source SHALL list stack packs for the configured `region` through the Elastic Cloud stack list API. The provider SHALL pass `region` through unchanged (Elastic Cloud Enterprise installations use `ece-region`) and SHALL NOT re-sort the returned list (the API returns latest-first). When the list call fails, the data source SHALL return an error diagnostic and SHALL NOT apply version filters.
 
 #### Scenario: Successful list
 
@@ -109,36 +110,35 @@ The data source SHALL list stack packs for the configured `region` through the E
 
 ### Requirement: `latest` selects the first listed stack
 
-When `version_regex` is the literal string `latest` and the lookup is not pinned by `lock` (see below), the data source SHALL return the first stack in the list (`stacks[0]`).
+When `version_regex` is the literal string `latest`, the data source SHALL return the first stack in the list. This path SHALL NOT use the no-match diagnostic used for regex lookup. An empty list is unhandled: the data source does not check length before selecting the first stack.
 
-#### Scenario: Unlocked latest
+#### Scenario: latest
 
 - GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]` (latest-first)
 - AND `version_regex = "latest"`
-- AND `lock` is false or unset
 - WHEN the data source resolves a stack
 - THEN the provider SHALL select version `7.9.1`
 
-### Requirement: `lock` pins `latest` to an already-selected version
+#### Scenario: latest with an empty list
 
-When `version_regex` is `latest`, `lock` is true, and a stack `version` is already set on the data source, the provider SHALL treat the lookup expression as that version (pin) instead of taking the first listed stack. `lock` SHALL have no effect when `version_regex` is not `latest`, or when `lock` is true but no version has been selected yet (first read SHALL behave as unlocked `latest`).
+- GIVEN the stack list is empty
+- AND `version_regex = "latest"`
+- WHEN the data source resolves a stack
+- THEN the provider SHALL NOT return the no-match diagnostic used for regex lookup
 
-#### Scenario: latest plus lock pins existing version
+### Requirement: `lock` does not change lookup on Read
+
+`lock` SHALL be an optional configuration attribute. Read SHALL load **configuration only** (`version` is computed and is not in config), so a previously selected version is not available on a later Read. Therefore `lock = true` with `version_regex = "latest"` SHALL still select the first listed stack, the same as unlocked `latest`. `lock` SHALL NOT change lookup when `version_regex` is not `latest`.
+
+Schema copy describes `lock` as pinning `latest` so a new stack release does not cascade. That advertised pin is **not** Terraform-observable on Read.
+
+#### Scenario: locked latest still takes the first stack
 
 - GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]`
 - AND `version_regex = "latest"`
 - AND `lock` is true
-- AND `version` is already `7.8.1`
-- WHEN the data source resolves a stack
-- THEN the provider SHALL select version `7.8.1`
-
-#### Scenario: First locked latest has no version yet
-
-- GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]`
-- AND `version_regex = "latest"`
-- AND `lock` is true
-- AND `version` is not set
-- WHEN the data source resolves a stack
+- AND a previous Read stored `version` `7.8.1` in state
+- WHEN the data source is read again
 - THEN the provider SHALL select version `7.9.1`
 
 #### Scenario: lock ignored for a non-latest regex
@@ -146,13 +146,12 @@ When `version_regex` is `latest`, `lock` is true, and a stack `version` is alrea
 - GIVEN the list `[7.9.1, 7.9.0, 7.8.1, 7.8.0]`
 - AND `version_regex = "7.8.?"`
 - AND `lock` is true
-- AND `version` is `7.9.1`
 - WHEN the data source resolves a stack
 - THEN the provider SHALL select version `7.8.1`
 
 ### Requirement: `version_regex` selects the first matching stack
 
-When `version_regex` is not the literal `latest` (including after a lock pin rewrites `latest` to a version string), the provider SHALL compile `version_regex` as a Go regular expression and return the **first** stack whose `version` matches, in list order. Because the list is latest-first, the first match is the newest matching stack.
+When `version_regex` is not the literal `latest`, the provider SHALL compile `version_regex` as a Go regular expression and return the **first** stack whose `version` matches, in list order. Because the list is latest-first, the first match is the newest matching stack.
 
 #### Scenario: Exact version string
 
@@ -170,7 +169,7 @@ When `version_regex` is not the literal `latest` (including after a lock pin rew
 
 ### Requirement: Lookup diagnostics
 
-If `version_regex` is not valid Go regexp syntax, the data source SHALL return an error diagnostic that it failed to compile `version_regex`. If no listed stack matches, the data source SHALL return an error diagnostic asking for a valid `version_regex`. Data sources SHALL error on a missing match rather than producing empty state.
+If `version_regex` is not valid Go regexp syntax, the data source SHALL return an error diagnostic that it failed to compile `version_regex`. If `version_regex` is not `latest` and no listed stack matches, the data source SHALL return an error diagnostic asking for a valid `version_regex` rather than producing empty state. These diagnostics do not apply to the `latest` path (see above).
 
 #### Scenario: Invalid regex
 


### PR DESCRIPTION
## Summary
- Add `dev-docs/high-level/openspec-requirements.md`: Purpose / SHALL-MUST requirements / Given-When-Then scenarios, `openspec/specs/` vs `openspec/changes/`, and the cloud-provider rules (no Docker stack; agents never run `TF_ACC`; changelog is `.changelog/{PR}.txt`; going forward only new/changed behavior needs a spec).
- Seed two **current-behavior** canonical specs as copy examples: `openspec/specs/deployment-traffic-filter/` (`ec_deployment_traffic_filter` resource) and `openspec/specs/stack/` (`ec_stack` data source).
- Point `openspec/config.yaml`, `AGENTS.md`, and the high-level dev docs at the conventions.

Relates to elastic/cp-hosted-team#4365 (epic elastic/cp-hosted-team#4362).

## Divergences from the ticket
- **No spec for issue terraform-provider-ec#966.** `remote_cluster` already shipped in #965; the traffic-filter spec documents that as current behavior, not as work to implement.
- **No integrations-server / terraform-provider-ec#947 exemplar.** `#947` is unimplemented (`ingest`); that contract belongs in `openspec/changes/` when 1.4/1.5 implement it, not in `openspec/specs/`.
- **Direct to `openspec/specs/`.** These exemplars capture existing code. New/changed behavior still goes through `openspec/changes/` then `openspec archive`.

## Test plan
- [x] `make check-openspec` locally (2 specs passed)
- [ ] Confirm `OpenSpec CI / Validate OpenSpecs` is green on this PR
- [ ] Human review of the conventions doc (Purpose / SHALL-MUST / Scenarios)

Made with [Cursor](https://cursor.com)