### PR TITLE
Retry GET after traffic-filter create/update when the ruleset is not yet visible

### DIFF
--- a/.changelog/1052.txt
+++ b/.changelog/1052.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/ec_deployment_traffic_filter: Retry GET after create/update when the ruleset is not immediately visible.
+```

--- a/ec/ecresource/trafficfilterresource/create.go
+++ b/ec/ecresource/trafficfilterresource/create.go
@@ -20,6 +20,7 @@ package trafficfilterresource
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -56,17 +57,20 @@ func (r Resource) Create(ctx context.Context, request resource.CreateRequest, re
 
 	newState.ID = types.StringValue(*res.ID)
 
-	found, diags := r.read(ctx, newState.ID.ValueString(), &newState)
+	found, diags := r.readAfterMutate.UntilFound(ctx, func(ctx context.Context) (bool, diag.Diagnostics) {
+		return r.readRetryable(ctx, newState.ID.ValueString(), &newState)
+	})
+	found, diags = missingIfForbidden(found, diags)
 	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 	if !found {
 		response.Diagnostics.AddError(
 			"Failed to read deployment traffic filter ruleset after create.",
 			"Failed to read deployment traffic filter ruleset after create.",
 		)
 		response.State.RemoveResource(ctx)
-		return
-	}
-	if response.Diagnostics.HasError() {
 		return
 	}
 

--- a/ec/ecresource/trafficfilterresource/read.go
+++ b/ec/ecresource/trafficfilterresource/read.go
@@ -19,6 +19,7 @@ package trafficfilterresource
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -29,6 +30,8 @@ import (
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
+
+var errForbidden = errors.New("forbidden")
 
 // Read queries the remote deployment traffic filter ruleset state and updates
 // the local state.
@@ -76,11 +79,11 @@ func (r Resource) readIfMissing(ctx context.Context, id string, state *modelV0, 
 			return false, diags
 		}
 		if apierror.IsRuntimeStatusCode(err, http.StatusForbidden) {
-			diags.AddError("forbidden", "forbidden")
+			diags.AddError(errForbidden.Error(), errForbidden.Error())
 			return false, diags
 		}
 		diags.AddError(err.Error(), err.Error())
-		return true, diags
+		return false, diags
 	}
 
 	diags.Append(modelToState(ctx, res, state)...)
@@ -88,13 +91,10 @@ func (r Resource) readIfMissing(ctx context.Context, id string, state *modelV0, 
 }
 
 func missingIfForbidden(found bool, diags diag.Diagnostics) (bool, diag.Diagnostics) {
-	if found || !diags.HasError() {
-		return found, diags
-	}
 	for _, d := range diags {
-		if d.Summary() == context.Canceled.Error() {
-			return found, diags
+		if d.Summary() == errForbidden.Error() {
+			return false, nil
 		}
 	}
-	return false, nil
+	return found, diags
 }

--- a/ec/ecresource/trafficfilterresource/read.go
+++ b/ec/ecresource/trafficfilterresource/read.go
@@ -19,10 +19,12 @@ package trafficfilterresource
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
 
 	"github.com/elastic/terraform-provider-ec/ec/internal/util"
@@ -58,11 +60,23 @@ func (r Resource) Read(ctx context.Context, request resource.ReadRequest, respon
 }
 
 func (r Resource) read(ctx context.Context, id string, state *modelV0) (found bool, diags diag.Diagnostics) {
+	return r.readIfMissing(ctx, id, state, util.TrafficFilterNotFound)
+}
+
+func (r Resource) readRetryable(ctx context.Context, id string, state *modelV0) (found bool, diags diag.Diagnostics) {
+	return r.readIfMissing(ctx, id, state, util.TrafficFilterRetryableMiss)
+}
+
+func (r Resource) readIfMissing(ctx context.Context, id string, state *modelV0, missing func(error) bool) (found bool, diags diag.Diagnostics) {
 	res, err := trafficfilterapi.Get(trafficfilterapi.GetParams{
 		API: r.client, ID: id, IncludeAssociations: false,
 	})
 	if err != nil {
-		if util.TrafficFilterNotFound(err) {
+		if missing(err) {
+			return false, diags
+		}
+		if apierror.IsRuntimeStatusCode(err, http.StatusForbidden) {
+			diags.AddError("forbidden", "forbidden")
 			return false, diags
 		}
 		diags.AddError(err.Error(), err.Error())
@@ -71,4 +85,16 @@ func (r Resource) read(ctx context.Context, id string, state *modelV0) (found bo
 
 	diags.Append(modelToState(ctx, res, state)...)
 	return true, diags
+}
+
+func missingIfForbidden(found bool, diags diag.Diagnostics) (bool, diag.Diagnostics) {
+	if found || !diags.HasError() {
+		return found, diags
+	}
+	for _, d := range diags {
+		if d.Summary() == context.Canceled.Error() {
+			return found, diags
+		}
+	}
+	return false, nil
 }

--- a/ec/ecresource/trafficfilterresource/resource_test.go
+++ b/ec/ecresource/trafficfilterresource/resource_test.go
@@ -125,6 +125,24 @@ func TestResourceTrafficFilter_failedRead1(t *testing.T) {
 	})
 }
 
+func TestResourceTrafficFilter_serverErrorAfterCreate(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactoriesWithMockClientRetry(
+			api.NewMock(
+				createResponse("true"),
+				failedReadResponse("false"),
+			),
+			util.ImmediateRetry(time.Second),
+		),
+		Steps: []r.TestStep{
+			{
+				Config:      trafficFilter,
+				ExpectError: regexp.MustCompile(`internal.server.error: There was an internal server error`),
+			},
+		},
+	})
+}
+
 func TestResourceTrafficFilter_forbiddenAfterCreateIsNotRetried(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		ProtoV6ProviderFactories: protoV6ProviderFactoriesWithMockClientRetry(

--- a/ec/ecresource/trafficfilterresource/resource_test.go
+++ b/ec/ecresource/trafficfilterresource/resource_test.go
@@ -18,9 +18,11 @@
 package trafficfilterresource_test
 
 import (
+	"net/http"
 	"net/url"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -31,6 +33,7 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	provider "github.com/elastic/terraform-provider-ec/ec"
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 func TestResourceTrafficFilter(t *testing.T) {
@@ -122,9 +125,124 @@ func TestResourceTrafficFilter_failedRead1(t *testing.T) {
 	})
 }
 
+func TestResourceTrafficFilter_forbiddenAfterCreateIsNotRetried(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactoriesWithMockClientRetry(
+			api.NewMock(
+				createResponse("true"),
+				forbiddenReadResponse("false"),
+			),
+			util.ImmediateRetry(time.Second),
+		),
+		Steps: []r.TestStep{
+			{
+				Config:      trafficFilter,
+				ExpectError: regexp.MustCompile(`Failed to read deployment traffic filter ruleset after create.`),
+			},
+		},
+	})
+}
+
+func TestResourceTrafficFilter_retryReadAfterCreate(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactoriesWithMockClientRetry(
+			api.NewMock(
+				createResponse("true"),
+				notFoundReadResponse("false"),
+				readResponse("false", "true"),
+				readResponse("false", "true"),
+				readResponse("true", "true"),
+				deleteResponse(),
+			),
+			util.ImmediateRetry(time.Second),
+		),
+		Steps: []r.TestStep{
+			{
+				Config: trafficFilter,
+				Check:  checkResource("true"),
+			},
+		},
+	})
+}
+
+func TestResourceTrafficFilter_notFoundAfterCreate(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactoriesWithMockClientRetry(
+			api.NewMock(
+				createResponse("true"),
+				notFoundReadResponse("false"),
+			),
+			util.NoRetry(),
+		),
+		Steps: []r.TestStep{
+			{
+				Config:      trafficFilter,
+				ExpectError: regexp.MustCompile(`Failed to read deployment traffic filter ruleset after create.`),
+			},
+		},
+	})
+}
+
+func TestResourceTrafficFilter_retryReadAfterUpdate(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactoriesWithMockClientRetry(
+			api.NewMock(
+				createResponse("true"),
+				readResponse("false", "true"),
+				readResponse("false", "true"),
+				readResponse("false", "true"),
+				updateResponse("false"),
+				notFoundReadResponse("false"),
+				readResponse("false", "false"),
+				readResponse("false", "false"),
+				readResponse("true", "false"),
+				deleteResponse(),
+			),
+			util.ImmediateRetry(time.Second),
+		),
+		Steps: []r.TestStep{
+			{
+				Config: trafficFilter,
+				Check:  checkResource("true"),
+			},
+			{
+				Config: trafficFilterWithoutIncludeByDefault,
+				Check:  checkResource("false"),
+			},
+		},
+	})
+}
+
+func TestResourceTrafficFilter_forbiddenAfterUpdateIsNotRetried(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactoriesWithMockClientRetry(
+			api.NewMock(
+				createResponse("true"),
+				readResponse("false", "true"),
+				readResponse("false", "true"),
+				readResponse("false", "true"),
+				updateResponse("false"),
+				forbiddenReadResponse("false"),
+				notFoundReadResponse("true"), // required for cleanup
+			),
+			util.ImmediateRetry(time.Second),
+		),
+		Steps: []r.TestStep{
+			{ // Create resource
+				Config: trafficFilter,
+				Check:  checkResource("true"),
+			},
+			{ // Update resource
+				Config:      trafficFilterWithoutIncludeByDefault,
+				ExpectError: regexp.MustCompile(`Failed to read deployment traffic filter ruleset after update.`),
+			},
+		},
+	})
+}
+
 func TestResourceTrafficFilter_notFoundAfterUpdate(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
-		ProtoV6ProviderFactories: protoV6ProviderFactoriesWithMockClient(
+		ProtoV6ProviderFactories: protoV6ProviderFactoriesWithMockClientRetry(
 			api.NewMock(
 				createResponse("true"),
 				readResponse("false", "true"),
@@ -134,6 +252,7 @@ func TestResourceTrafficFilter_notFoundAfterUpdate(t *testing.T) {
 				notFoundReadResponse("false"),
 				notFoundReadResponse("true"),
 			),
+			util.NoRetry(),
 		),
 		Steps: []r.TestStep{
 			{ // Create resource
@@ -638,6 +757,24 @@ func notFoundReadResponse(includeAssociations string) mock.Response {
 		mock.NewStringBody(`{	}`),
 	)
 }
+
+func forbiddenReadResponse(includeAssociations string) mock.Response {
+	return mock.Response{
+		Assert: &mock.RequestAssertion{
+			Host:   api.DefaultMockHost,
+			Header: api.DefaultReadMockHeaders,
+			Method: "GET",
+			Path:   "/api/v1/deployments/traffic-filter/rulesets/some-random-id",
+			Query: url.Values{
+				"include_associations": []string{includeAssociations},
+			},
+		},
+		Response: http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       mock.NewStringBody(`{"errors":[{"code":"root.permission_denied","message":"To access the resource, the user must have the required authorization."}]}`),
+		},
+	}
+}
 func failedReadResponse(includeAssociations string) mock.Response {
 	return mock.New500ResponseAssertion(
 		&mock.RequestAssertion{
@@ -700,9 +837,13 @@ func failedDeletionResponse() mock.Response {
 }
 
 func protoV6ProviderFactoriesWithMockClient(client *api.API) map[string]func() (tfprotov6.ProviderServer, error) {
+	return protoV6ProviderFactoriesWithMockClientRetry(client, util.ReadAfterMutate{})
+}
+
+func protoV6ProviderFactoriesWithMockClientRetry(client *api.API, ram util.ReadAfterMutate) map[string]func() (tfprotov6.ProviderServer, error) {
 	return map[string]func() (tfprotov6.ProviderServer, error){
 		"ec": func() (tfprotov6.ProviderServer, error) {
-			return providerserver.NewProtocol6(provider.ProviderWithClient(client, "unit-tests"))(), nil
+			return providerserver.NewProtocol6(provider.ProviderWithClientRetry(client, "unit-tests", ram))(), nil
 		},
 	}
 }

--- a/ec/ecresource/trafficfilterresource/schema.go
+++ b/ec/ecresource/trafficfilterresource/schema.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/elastic/terraform-provider-ec/ec/internal"
 	"github.com/elastic/terraform-provider-ec/ec/internal/planmodifiers"
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces
@@ -150,7 +151,8 @@ Timeouts: &schema.ResourceTimeout{
 */
 
 type Resource struct {
-	client *api.API
+	client          *api.API
+	readAfterMutate util.ReadAfterMutate
 }
 
 func resourceReady(r Resource, dg *diag.Diagnostics) bool {
@@ -234,6 +236,7 @@ func (r *Resource) Configure(ctx context.Context, request resource.ConfigureRequ
 	clients, diags := internal.ConvertProviderData(request.ProviderData)
 	response.Diagnostics.Append(diags...)
 	r.client = clients.Stateful
+	r.readAfterMutate = clients.ReadAfterMutate
 }
 
 func (r *Resource) Metadata(ctx context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {

--- a/ec/ecresource/trafficfilterresource/update.go
+++ b/ec/ecresource/trafficfilterresource/update.go
@@ -20,6 +20,7 @@ package trafficfilterresource
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/trafficfilterapi"
@@ -50,7 +51,10 @@ func (r Resource) Update(ctx context.Context, request resource.UpdateRequest, re
 		return
 	}
 
-	found, diags := r.read(ctx, newState.ID.ValueString(), &newState)
+	found, diags := r.readAfterMutate.UntilFound(ctx, func(ctx context.Context) (bool, diag.Diagnostics) {
+		return r.readRetryable(ctx, newState.ID.ValueString(), &newState)
+	})
+	found, diags = missingIfForbidden(found, diags)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return

--- a/ec/internal/provider.go
+++ b/ec/internal/provider.go
@@ -24,11 +24,13 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/terraform-provider-ec/ec/internal/gen/serverless"
+	"github.com/elastic/terraform-provider-ec/ec/internal/util"
 )
 
 type ProviderClients struct {
-	Stateful   *api.API
-	Serverless serverless.ClientWithResponsesInterface
+	Stateful        *api.API
+	Serverless      serverless.ClientWithResponsesInterface
+	ReadAfterMutate util.ReadAfterMutate
 }
 
 // ConvertProviderData is a helper function for DataSource.Configure and Resource.Configure implementations

--- a/ec/internal/util/traffic_filter_err.go
+++ b/ec/internal/util/traffic_filter_err.go
@@ -25,6 +25,15 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
 )
 
+// TrafficFilterRetryableMiss is HTTP 404 only (not 403).
+func TrafficFilterRetryableMiss(err error) bool {
+	var notFound *deployments_traffic_filter.GetTrafficFilterRulesetNotFound
+	if errors.As(err, &notFound) {
+		return true
+	}
+	return apierror.IsRuntimeStatusCode(err, http.StatusNotFound)
+}
+
 // TrafficFilterNotFound returns true when the error is a 404 or 403.
 func TrafficFilterNotFound(err error) bool {
 	// We're using the As() call since we do not care about the error value

--- a/ec/internal/util/traffic_filter_err_test.go
+++ b/ec/internal/util/traffic_filter_err_test.go
@@ -73,3 +73,38 @@ func TestTrafficFilterNotFound(t *testing.T) {
 		})
 	}
 }
+
+func TestTrafficFilterRetryableMiss(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "empty"},
+		{
+			name: "403 is not retryable",
+			err:  &apierror.Error{Err: &runtime.APIError{Code: 403}},
+		},
+		{
+			name: "500 is not retryable",
+			err:  &apierror.Error{Err: &runtime.APIError{Code: 500}},
+		},
+		{
+			name: "typed 404 is retryable",
+			err:  &apierror.Error{Err: &deployments_traffic_filter.GetTrafficFilterRulesetNotFound{}},
+			want: true,
+		},
+		{
+			name: "runtime 404 is retryable",
+			err:  &apierror.Error{Err: &runtime.APIError{Code: 404}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TrafficFilterRetryableMiss(tt.err); got != tt.want {
+				t.Errorf("TrafficFilterRetryableMiss() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ec/internal/util/until_found.go
+++ b/ec/internal/util/until_found.go
@@ -1,0 +1,139 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package util
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+const (
+	DefaultReadAfterMutateTimeout  = 30 * time.Second
+	DefaultReadAfterMutateInterval = 5 * time.Second
+)
+
+// ReadAfterMutate configures GET retries after create/update.
+// A nil Timeout is the 30s default; Timeout 0 disables retry.
+type ReadAfterMutate struct {
+	Wait     func(context.Context, time.Duration)
+	Timeout  *time.Duration
+	Interval time.Duration
+}
+
+func NoRetry() ReadAfterMutate {
+	z := time.Duration(0)
+	return ReadAfterMutate{Timeout: &z}
+}
+
+func ImmediateRetry(timeout time.Duration) ReadAfterMutate {
+	t := timeout
+	return ReadAfterMutate{
+		Wait:    func(context.Context, time.Duration) {},
+		Timeout: &t,
+	}
+}
+
+func (c ReadAfterMutate) wait() func(context.Context, time.Duration) {
+	if c.Wait != nil {
+		return c.Wait
+	}
+	return ContextualSleep
+}
+
+func (c ReadAfterMutate) timeout() time.Duration {
+	if c.Timeout != nil {
+		return *c.Timeout
+	}
+	return DefaultReadAfterMutateTimeout
+}
+
+func (c ReadAfterMutate) interval() time.Duration {
+	if c.Interval > 0 {
+		return c.Interval
+	}
+	return DefaultReadAfterMutateInterval
+}
+
+func (c ReadAfterMutate) UntilFound(
+	ctx context.Context,
+	get func(context.Context) (found bool, diags diag.Diagnostics),
+) (found bool, diags diag.Diagnostics) {
+	return UntilFound(ctx, c.wait(), c.timeout(), c.interval(), get)
+}
+
+func ContextualSleep(ctx context.Context, d time.Duration) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(d):
+	}
+}
+
+// UntilFound retries get while found is false and diags are empty.
+// timeout 0 is a single GET. DeadlineExceeded is not-found; Canceled is an
+// error. Callers must check HasError before treating !found as missing.
+func UntilFound(
+	ctx context.Context,
+	wait func(context.Context, time.Duration),
+	timeout, interval time.Duration,
+	get func(context.Context) (found bool, diags diag.Diagnostics),
+) (found bool, diags diag.Diagnostics) {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	for {
+		if found, diags, stop := stoppedByContext(ctx); stop {
+			return found, diags
+		}
+		found, diags = get(ctx)
+		if diags.HasError() {
+			return found, diags
+		}
+		if found {
+			if found, diags, stop := stoppedByContext(ctx); stop {
+				return found, diags
+			}
+			return true, diags
+		}
+		if timeout == 0 {
+			return false, diags
+		}
+		wait(ctx, interval)
+		if found, diags, stop := stoppedByContext(ctx); stop {
+			return found, diags
+		}
+	}
+}
+
+func stoppedByContext(ctx context.Context) (found bool, diags diag.Diagnostics, stop bool) {
+	err := ctx.Err()
+	if err == nil {
+		return false, nil, false
+	}
+	if errors.Is(err, context.Canceled) {
+		var d diag.Diagnostics
+		d.AddError(err.Error(), err.Error())
+		return false, d, true
+	}
+	return false, nil, true
+}

--- a/ec/internal/util/until_found.go
+++ b/ec/internal/util/until_found.go
@@ -119,9 +119,6 @@ func UntilFound(
 			return false, diags
 		}
 		wait(ctx, interval)
-		if found, diags, stop := stoppedByContext(ctx); stop {
-			return found, diags
-		}
 	}
 }
 

--- a/ec/internal/util/until_found.go
+++ b/ec/internal/util/until_found.go
@@ -102,16 +102,16 @@ func UntilFound(
 	}
 
 	for {
-		if found, diags, stop := stoppedByContext(ctx); stop {
-			return found, diags
+		if diags, stop := stoppedByContext(ctx); stop {
+			return false, diags
 		}
 		found, diags = get(ctx)
 		if diags.HasError() {
 			return found, diags
 		}
 		if found {
-			if found, diags, stop := stoppedByContext(ctx); stop {
-				return found, diags
+			if diags, stop := stoppedByContext(ctx); stop {
+				return false, diags
 			}
 			return true, diags
 		}
@@ -122,15 +122,15 @@ func UntilFound(
 	}
 }
 
-func stoppedByContext(ctx context.Context) (found bool, diags diag.Diagnostics, stop bool) {
+func stoppedByContext(ctx context.Context) (diags diag.Diagnostics, stop bool) {
 	err := ctx.Err()
 	if err == nil {
-		return false, nil, false
+		return nil, false
 	}
 	if errors.Is(err, context.Canceled) {
 		var d diag.Diagnostics
 		d.AddError(err.Error(), err.Error())
-		return false, d, true
+		return d, true
 	}
-	return false, nil, true
+	return nil, true
 }

--- a/ec/internal/util/until_found_test.go
+++ b/ec/internal/util/until_found_test.go
@@ -1,0 +1,198 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package util
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUntilFound_FoundOnFirstTry(t *testing.T) {
+	calls := 0
+	waits := 0
+	wait := func(context.Context, time.Duration) { waits++ }
+	get := func(context.Context) (bool, diag.Diagnostics) {
+		calls++
+		return true, nil
+	}
+
+	found, diags := UntilFound(context.Background(), wait, time.Second, time.Millisecond, get)
+	require.True(t, found)
+	require.False(t, diags.HasError())
+	require.Equal(t, 1, calls)
+	require.Equal(t, 0, waits)
+}
+
+func TestUntilFound_NotFoundThenFound(t *testing.T) {
+	calls := 0
+	get := func(context.Context) (bool, diag.Diagnostics) {
+		calls++
+		return calls >= 2, nil
+	}
+
+	found, diags := UntilFound(context.Background(), func(context.Context, time.Duration) {}, time.Second, time.Millisecond, get)
+	require.True(t, found)
+	require.False(t, diags.HasError())
+	require.Equal(t, 2, calls)
+}
+
+func TestUntilFound_ErrorDiagsStopImmediately(t *testing.T) {
+	calls := 0
+	waits := 0
+	wait := func(context.Context, time.Duration) { waits++ }
+	get := func(context.Context) (bool, diag.Diagnostics) {
+		calls++
+		var d diag.Diagnostics
+		d.AddError("boom", "boom")
+		return false, d
+	}
+
+	found, diags := UntilFound(context.Background(), wait, time.Second, time.Millisecond, get)
+	require.False(t, found)
+	require.True(t, diags.HasError())
+	require.Equal(t, 1, calls)
+	require.Equal(t, 0, waits)
+}
+
+func TestUntilFound_ErrorAfterMissStops(t *testing.T) {
+	calls := 0
+	waits := 0
+	wait := func(context.Context, time.Duration) { waits++ }
+	get := func(context.Context) (bool, diag.Diagnostics) {
+		calls++
+		if calls == 1 {
+			return false, nil
+		}
+		var d diag.Diagnostics
+		d.AddError("boom", "boom")
+		return true, d
+	}
+
+	found, diags := UntilFound(context.Background(), wait, time.Second, time.Millisecond, get)
+	require.True(t, found)
+	require.True(t, diags.HasError())
+	require.Equal(t, 2, calls)
+	require.Equal(t, 1, waits)
+}
+
+func TestUntilFound_TimeoutZeroNotFound(t *testing.T) {
+	calls := 0
+	waits := 0
+	wait := func(context.Context, time.Duration) { waits++ }
+	get := func(context.Context) (bool, diag.Diagnostics) {
+		calls++
+		return false, nil
+	}
+
+	found, diags := UntilFound(context.Background(), wait, 0, time.Second, get)
+	require.False(t, found)
+	require.False(t, diags.HasError())
+	require.Equal(t, 1, calls)
+	require.Equal(t, 0, waits)
+}
+
+func TestUntilFound_TimeoutElapsedStillMissing(t *testing.T) {
+	calls := 0
+	get := func(context.Context) (bool, diag.Diagnostics) {
+		calls++
+		return false, nil
+	}
+
+	done := make(chan struct{})
+	var found bool
+	var diags diag.Diagnostics
+	go func() {
+		found, diags = UntilFound(context.Background(), func(context.Context, time.Duration) {}, 50*time.Millisecond, time.Millisecond, get)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry loop did not stop")
+	}
+	require.False(t, found)
+	require.Empty(t, diags)
+	require.Greater(t, calls, 1)
+}
+
+func TestUntilFound_CanceledIsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	wait := func(context.Context, time.Duration) { cancel() }
+	get := func(context.Context) (bool, diag.Diagnostics) {
+		return false, nil
+	}
+
+	found, diags := UntilFound(ctx, wait, time.Second, time.Millisecond, get)
+	require.False(t, found)
+	require.True(t, diags.HasError())
+	require.Contains(t, diags[0].Summary(), "canceled")
+}
+
+func TestUntilFound_AlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+
+	found, diags := UntilFound(ctx, func(context.Context, time.Duration) {}, time.Second, time.Millisecond, func(context.Context) (bool, diag.Diagnostics) {
+		calls++
+		return false, nil
+	})
+	require.False(t, found)
+	require.True(t, diags.HasError())
+	require.Contains(t, diags[0].Summary(), "canceled")
+	require.Equal(t, 0, calls)
+}
+
+func TestUntilFound_CanceledAfterFound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	get := func(context.Context) (bool, diag.Diagnostics) {
+		cancel()
+		return true, nil
+	}
+
+	found, diags := UntilFound(ctx, func(context.Context, time.Duration) {}, time.Second, time.Millisecond, get)
+	require.False(t, found)
+	require.True(t, diags.HasError())
+	require.Contains(t, diags[0].Summary(), "canceled")
+}
+
+func TestReadAfterMutate_ZeroValueUsesDefaults(t *testing.T) {
+	var c ReadAfterMutate
+	require.Equal(t, DefaultReadAfterMutateTimeout, c.timeout())
+	require.Equal(t, DefaultReadAfterMutateInterval, c.interval())
+	require.NotNil(t, c.wait())
+}
+
+func TestReadAfterMutate_NoRetryDisablesRetry(t *testing.T) {
+	require.Equal(t, time.Duration(0), NoRetry().timeout())
+}
+
+func TestReadAfterMutate_UntilFoundUsesConfig(t *testing.T) {
+	calls := 0
+	found, diags := ImmediateRetry(time.Second).UntilFound(context.Background(), func(context.Context) (bool, diag.Diagnostics) {
+		calls++
+		return calls >= 2, nil
+	})
+	require.True(t, found)
+	require.False(t, diags.HasError())
+	require.Equal(t, 2, calls)
+}

--- a/ec/provider.go
+++ b/ec/provider.go
@@ -86,15 +86,20 @@ func New(version string) provider.Provider {
 }
 
 func ProviderWithClient(client *api.API, version string) provider.Provider {
-	return &Provider{client: client, version: version}
+	return ProviderWithClientRetry(client, version, util.ReadAfterMutate{})
+}
+
+func ProviderWithClientRetry(client *api.API, version string, ram util.ReadAfterMutate) provider.Provider {
+	return &Provider{client: client, version: version, readAfterMutate: ram}
 }
 
 var _ provider.Provider = (*Provider)(nil)
 
 type Provider struct {
-	version   string
-	client    *api.API
-	slsClient serverless.ClientWithResponsesInterface
+	version         string
+	client          *api.API
+	slsClient       serverless.ClientWithResponsesInterface
+	readAfterMutate util.ReadAfterMutate
 }
 
 func (p *Provider) Metadata(ctx context.Context, request provider.MetadataRequest, response *provider.MetadataResponse) {
@@ -194,8 +199,9 @@ type providerConfig struct {
 func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	if p.client != nil {
 		data := internal.ProviderClients{
-			Stateful:   p.client,
-			Serverless: p.slsClient,
+			Stateful:        p.client,
+			Serverless:      p.slsClient,
+			ReadAfterMutate: p.readAfterMutate,
 		}
 		// Required for unit tests, because a mock client is pre-created there.
 		resp.DataSourceData = data
@@ -355,8 +361,9 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	p.client = client
 	p.slsClient = serverlessClient
 	data := internal.ProviderClients{
-		Stateful:   client,
-		Serverless: serverlessClient,
+		Stateful:        client,
+		Serverless:      serverlessClient,
+		ReadAfterMutate: p.readAfterMutate,
 	}
 	resp.DataSourceData = data
 	resp.ResourceData = data


### PR DESCRIPTION
## Summary

Acceptance tests sometimes failed with `Failed to read deployment traffic filter ruleset after create.` after Create returned an id: the follow-up GET was a 404, so Terraform never stored state ([#2940](https://buildkite.com/elastic/terraform-provider-ec-acceptance/builds/2940), [#2944](https://buildkite.com/elastic/terraform-provider-ec-acceptance/builds/2944)). Same user-facing string as [#857](https://github.com/elastic/terraform-provider-ec/issues/857).

**Change:** retry GET after `ec_deployment_traffic_filter` create/update while the ruleset is not yet visible (HTTP 404 only). Default bound 30s, poll 5s; timeout 0 is a single GET. Happy path is still one GET.

**Decisions**
- Retry **404 only**. 403 is not retried and stays a miss with the same generic failed-to-read message as today.
- Traffic filter create/update only. Read, delete, associations, and other resources are unchanged.
- Deadline → not-found. Other cancels → error (do not `RemoveResource`).
- No new HCL timeouts.

## Test plan
- [x] Unit tests for `ec/internal/util` and `ec/ecresource/trafficfilterresource`
- [ ] Human: targeted acc (`TestAccDatasourceDeployment_basic`, `TestAccDatasource_trafficfilter_remoteCluster`) if Buildkite flakes again